### PR TITLE
add a ChapterSkipType to mark chapters with a type of content to skip

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1405,7 +1405,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
 If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it MUST NOT have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
 If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
     </documentation>
-    <extension webm="0"/>
+    <extension type="webmproject.org" webm="0"/>
     <restriction>
       <enum value="0" label="No Skipping">
         <documentation lang="en" purpose="definition">Content which should not be skipped.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1400,26 +1400,27 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
-  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4" webm="0" default="0">
+  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4" default="0">
     <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.</documentation>
-      <restriction>
+    <extension webm="0"/>
+    <restriction>
       <enum value="0" label="Regular Content"/>
       <enum value="1" label="Opening Credits">
         <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
-      <enum value="2" label="End Credits"/>
+      <enum value="2" label="End Credits">
         <documentation lang="en" purpose="definition">Credits usually found at the end of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
-      <enum value="3" label="Recap"/>
+      <enum value="3" label="Recap">
         <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
-      <enum value="4" label="Next Preview"/>
+      <enum value="4" label="Next Preview">
         <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
-      <enum value="5" label="Preview"/>
+      <enum value="5" label="Preview">
         <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
-      <enum value="6" label="Advertisement"/>
+      <enum value="6" label="Advertisement">
         <documentation lang="en" purpose="definition">Advertisement within the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
     </restriction>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1414,10 +1414,13 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
         <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
       <enum value="4" label="Next Preview"/>
-        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
       <enum value="5" label="Preview"/>
-        <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
+      <enum value="6" label="Advertisement"/>
+        <documentation lang="en" purpose="definition">Advertisement within the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
     </restriction>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1402,7 +1402,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
   </element>
   <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="5">
     <documentation lang="en">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
-If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it MUST NOT have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
+If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it **MUST NOT** have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
 If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
     </documentation>
     <extension type="webmproject.org" webm="0"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1402,7 +1402,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
   </element>
   <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
     <documentation lang="en">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
-A Nested chapter MUST have no `ChapterSkipType` or use the same value as its Parent Chapter.
+If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it MUST NOT have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
 If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
     </documentation>
     <extension webm="0"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1400,6 +1400,14 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
+  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4" webm="0" default="0">
+    <documentation lang="en">Indicate what type of content the chapter contains. It can be used to automatically skip content based on the type.</documentation>
+      <restriction>
+      <enum value="0" label="Regular Content"/>
+      <enum value="1" label="Opening Credits"/>
+      <enum value="2" label="End Credits"/>
+    </restriction>
+  </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The EditionUID to play from the Segment linked in ChapterSegmentUID.
 If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment is used; see (#medium-linking) on medium-linking Segments.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1426,7 +1426,7 @@ If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `Chapt
         <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.</documentation>
       </enum>
       <enum value="6" label="Advertisement">
-        <documentation lang="en" purpose="definition">Advertisement within the content, usually found around the beginning.</documentation>
+        <documentation lang="en" purpose="definition">Advertisement within the content.</documentation>
       </enum>
     </restriction>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1404,7 +1404,9 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.</documentation>
     <extension webm="0"/>
     <restriction>
-      <enum value="0" label="Regular Content"/>
+      <enum value="0" label="Regular Content">
+        <documentation lang="en" purpose="definition">Content to play normally.</documentation>
+      </enum>
       <enum value="1" label="Opening Credits">
         <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1400,8 +1400,10 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
-  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4" default="0">
-    <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.</documentation>
+  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
+    <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.
+A Nested chapter MUST have no `ChapterContentType` or use the same value as its Parent Chapter.
+    </documentation>
     <extension webm="0"/>
     <restriction>
       <enum value="0" label="Regular Content">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1401,11 +1401,15 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
   <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4" webm="0" default="0">
-    <documentation lang="en">Indicate what type of content the chapter contains. It can be used to automatically skip content based on the type.</documentation>
+    <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.</documentation>
       <restriction>
       <enum value="0" label="Regular Content"/>
-      <enum value="1" label="Opening Credits"/>
+      <enum value="1" label="Opening Credits">
+        <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
       <enum value="2" label="End Credits"/>
+        <documentation lang="en" purpose="definition">Credits usually found at the end of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
     </restriction>
   </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1400,15 +1400,15 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
-  <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
-    <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.
-A Nested chapter MUST have no `ChapterContentType` or use the same value as its Parent Chapter.
-If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterContentType` is only valid until the next `ChapterAtom` with a `ChapterContentType` value or the end of the file.
+  <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
+    <documentation lang="en">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
+A Nested chapter MUST have no `ChapterSkipType` or use the same value as its Parent Chapter.
+If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
     </documentation>
     <extension webm="0"/>
     <restriction>
-      <enum value="0" label="Regular Content">
-        <documentation lang="en" purpose="definition">Content to play normally.</documentation>
+      <enum value="0" label="No Skipping">
+        <documentation lang="en" purpose="definition">Content which should not be skipped.</documentation>
       </enum>
       <enum value="1" label="Opening Credits">
         <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1403,6 +1403,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
   <element name="ChapterContentType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterContentType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
     <documentation lang="en">Indicate what type of content the ChapterAtom contains. It can be used to automatically skip content based on the type.
 A Nested chapter MUST have no `ChapterContentType` or use the same value as its Parent Chapter.
+If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterContentType` is only valid until the next `ChapterAtom` with a `ChapterContentType` value or the end of the file.
     </documentation>
     <extension webm="0"/>
     <restriction>
@@ -1410,22 +1411,22 @@ A Nested chapter MUST have no `ChapterContentType` or use the same value as its 
         <documentation lang="en" purpose="definition">Content to play normally.</documentation>
       </enum>
       <enum value="1" label="Opening Credits">
-        <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Credits usually found at the beginning of the content.</documentation>
       </enum>
       <enum value="2" label="End Credits">
-        <documentation lang="en" purpose="definition">Credits usually found at the end of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Credits usually found at the end of the content.</documentation>
       </enum>
       <enum value="3" label="Recap">
-        <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning.</documentation>
       </enum>
       <enum value="4" label="Next Preview">
-        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.</documentation>
       </enum>
       <enum value="5" label="Preview">
-        <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.</documentation>
       </enum>
       <enum value="6" label="Advertisement">
-        <documentation lang="en" purpose="definition">Advertisement within the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+        <documentation lang="en" purpose="definition">Advertisement within the content, usually found around the beginning.</documentation>
       </enum>
     </restriction>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1420,7 +1420,7 @@ If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `Chapt
         <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning.</documentation>
       </enum>
       <enum value="4" label="Next Preview">
-        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.</documentation>
+        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the end. It may contain spoilers the user wants to avoid.</documentation>
       </enum>
       <enum value="5" label="Preview">
         <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. It may contain spoilers the user want to avoid.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1410,6 +1410,15 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
       <enum value="2" label="End Credits"/>
         <documentation lang="en" purpose="definition">Credits usually found at the end of the content. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
       </enum>
+      <enum value="3" label="Recap"/>
+        <documentation lang="en" purpose="definition">Recap of previous episodes of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
+      <enum value="4" label="Next Preview"/>
+        <documentation lang="en" purpose="definition">Preview of the next episode of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
+      <enum value="5" label="Preview"/>
+        <documentation lang="en" purpose="definition">Preview of the current episode of the content, usually found around the beginning. The ChapterAtom MUST contain a value ChapterTimeEnd.</documentation>
+      </enum>
     </restriction>
   </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1400,7 +1400,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
     <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
-  <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="4">
+  <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="5">
     <documentation lang="en">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
 If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it MUST NOT have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
 If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.


### PR DESCRIPTION
It can be used to skip the content (credits) based on user preferences or show
a button to skip them during playback. It can also be used to start the next
content while the end credits are showing.

This could be done with tags but since it's a playback feature it's better if it's tied to the chapters. Just like `ChapterFlagEnabled`.