### PR TITLE
XML-escape HTML elements in <documentation> nodes

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -89,8 +89,8 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <extension cppname="TimecodeScale"/>
   </element>
   <!-- <element name="TimestampScaleDenominator" parent="/Segment/Info" level="2" id="0x2AD7B2" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" default="1000000000">
-    <documentation lang="en">Timestamp scale numerator; see <a href="https://www.matroska.org/technical/elements.html#TimestampScale">TimestampScale</a>.</documentation>
-TimestampScale When combined with <a href="https://www.matroska.org/technical/elements.html#TimestampScaleDenominator">TimestampScaleDenominator</a> the Timestamp scale is given by the fraction TimestampScale/TimestampScaleDenominator in seconds.-->
+    <documentation lang="en">Timestamp scale numerator, see &lt;a href="https://www.matroska.org/technical/elements.html#TimestampScale"&gt;TimestampScale&lt;/a&gt;.</documentation>
+    TimestampScale When combined with &lt;a href="https://www.matroska.org/technical/elements.html#TimestampScaleDenominator"&gt;TimestampScaleDenominator&lt;/a&gt; the Timestamp scale is given by the fraction TimestampScale/TimestampScaleDenominator in seconds.-->
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds based on TimestampScale.</documentation>
   </element>


### PR DESCRIPTION
The documentation uses HTML tags such as `<a>` for links, `<br/>` for line
breaks or `<strong>` for emphasis. Unfortunately those were not
XML-escaped. That meant that XML parsers determined `<a href=…>` to be a
whole new child node of the `<description>` instead of being part of the
text of the `<description>`.

In order to reproduce the HTML-equivalent of such child ones,
transformations or programs would have to iterate recursively over all
child nodes of `<documentation>`, iterate over all existing attributes
etc. Very tedious and superfluous.