### PR TITLE
allow TrackTimestampScale in Matroska v4

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -312,9 +312,9 @@ If set to 0, the reference pseudo-cache system is not used.</documentation>
 see (#defaultdecodedfieldduration) for more information</documentation>
     <extension type="libmatroska" cppname="TrackDefaultDecodedFieldDuration"/>
   </element>
-  <element name="TrackTimestampScale" path="\Segment\Tracks\TrackEntry\TrackTimestampScale" id="0x23314F" type="float" maxver="3" range="&gt; 0x0p+0" default="0x1p+0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">DEPRECATED, DO NOT USE. The scale to apply on this track to work at normal speed in relation with other tracks
-(mostly used to adjust video speed when the audio length differs).</documentation>
+  <element name="TrackTimestampScale" path="\Segment\Tracks\TrackEntry\TrackTimestampScale" id="0x23314F" type="float" range="&gt; 0x0p+0" default="0x1p+0" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">The scale to apply on this track to work at normal speed in relation with other tracks.
+Mostly used to adjust video speed when the audio length differs or to have more accurate timestamps on each track.</documentation>
     <extension type="libmatroska" cppname="TrackTimecodeScale"/>
   </element>
   <element name="TrackOffset" path="\Segment\Tracks\TrackEntry\TrackOffset" id="0x537F" type="integer" minver="0" maxver="0" default="0" maxOccurs="1">

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -62,6 +62,14 @@
   </front>
 </reference>
 
+<reference anchor="Vorbis" target="https://www.xiph.org/vorbis/doc/Vorbis_I_spec.html">
+  <front>
+    <title>Vorbis I specification</title>
+    <author fullname='Xiph.Org Foundation'><organization>Xiph.Org Foundation</organization></author>
+    <date day="4" month="July" year="2020" />
+  </front>
+</reference>
+
 <reference anchor="MCF" target="http://mukoli.free.fr/mcf/mcf.html">
   <front>
     <title>Media Container Format</title>


### PR DESCRIPTION
Following the investigation in #422 it seems like a good tool to achieve sample accurate timestamp in many (more) cases.

In posts starting from https://github.com/cellar-wg/matroska-specification/issues/422#issuecomment-711123080