### PR TITLE
Simplify EditionFlagOrdered table

### DIFF
--- a/chapters.md
+++ b/chapters.md
@@ -72,9 +72,9 @@ play those Chapters in their stored order from the timestamp marked in the
 If the `EditionFlagOrdered Flag` is set to `false`, `Simple Chapters` are used and
 only the `ChapterTimeStart` of a `Chapter` is used as chapter mark to jump to the
 predefined point in the timeline. With `Simple Chapters`, a `Matroska Player` **MUST**
-ignore certain `Chapter Elements`. All these elements are now informational only.
+ignore certain Chapter elements. All these elements are now informational only.
 
-The following list shows the different usage of `Chapter Elements` between an ordered
+The following list shows the different usage of Chapter elements between an ordered
 and non-ordered `Edition`.
 
 | Chapter elements / ordered Edition | False | True |

--- a/chapters.md
+++ b/chapters.md
@@ -88,9 +88,6 @@ The following list shows the different Chapter elements only found in `Ordered C
 | TrackEntry/TrackTranslate             |
 Table: elements only found in ordered chapters{#orderedOnly}
 
-These other `Elements` belong to the Matroska DVD menu system and are only used
-when the `ChapProcessCodecID Element` is set to 1.
-
 ##### Ordered-Edition and Matroska Segment-Linking
 
 - Hard Linking: `Ordered-Chapters` supersedes the `Hard Linking`.

--- a/chapters.md
+++ b/chapters.md
@@ -78,7 +78,6 @@ The following list shows the different Chapter elements only found in `Ordered C
 
 | Ordered Chapter elements              |
 |:--------------------------------------|
-| ChapterAtom/ChapterTimeEnd            |
 | ChapterAtom/ChapterSegmentUID         |
 | ChapterAtom/ChapterSegmentEditionUID  |
 | ChapterAtom/ChapterTrack              |

--- a/chapters.md
+++ b/chapters.md
@@ -79,17 +79,10 @@ and non-ordered `Edition`.
 
 | Chapter elements / ordered Edition | False | True |
 |:-----------------------------------|:-----:|:----:|
-| ChapterUID                         |   X   |  X   |
-| ChapterStringUID                   |   X   |  X   |
-| ChapterTimeStart                   |   X   |  X   |
 | ChapterTimeEnd                     |   -   |  X   |
-| ChapterFlagHidden                  |   X   |  X   |
-| ChapterFlagEnabled                 |   X   |  X   |
 | ChapterSegmentUID                  |   -   |  X   |
 | ChapterSegmentEditionUID           |   -   |  X   |
-| ChapterPhysicalEquiv               |   X   |  X   |
 | ChapterTrack                       |   -   |  X   |
-| ChapterDisplay                     |   X   |  X   |
 | ChapProcess                        |   -   |  X   |
 
 Furthermore there are other EBML `Elements` which could be used if the

--- a/chapters.md
+++ b/chapters.md
@@ -77,13 +77,14 @@ ignore certain Chapter elements. All these elements are now informational only.
 The following list shows the different usage of Chapter elements between an ordered
 and non-ordered `Edition`.
 
-| Chapter elements / ordered Edition | False | True |
+| Chapter elements                   | Simple Chapters | Ordered Chapters |
 |:-----------------------------------|:-----:|:----:|
 | ChapterTimeEnd                     |   -   |  X   |
 | ChapterSegmentUID                  |   -   |  X   |
 | ChapterSegmentEditionUID           |   -   |  X   |
 | ChapterTrack                       |   -   |  X   |
 | ChapProcess                        |   -   |  X   |
+Table: mandatory elements for simple/ordered chapters{#orderedMandatory}
 
 Furthermore there are other EBML `Elements` which could be used if the
 `EditionFlagOrdered Flag` is set to `true`.

--- a/chapters.md
+++ b/chapters.md
@@ -76,16 +76,16 @@ ignore certain Chapter elements. All these elements are now informational only.
 
 The following list shows the different Chapter elements only found in `Ordered Chapters`.
 
-| Ordered Chapter elements           |
-|:-----------------------------------|
-| ChapterTimeEnd                     |
-| ChapterSegmentUID                  |
-| ChapterSegmentEditionUID           |
-| ChapterTrack                       |
-| ChapProcess                        |
-| Info/SegmentFamily                 |
-| Info/ChapterTranslate              |
-| TrackEntry/TrackTranslate          |
+| Ordered Chapter elements              |
+|:--------------------------------------|
+| ChapterAtom/ChapterTimeEnd            |
+| ChapterAtom/ChapterSegmentUID         |
+| ChapterAtom/ChapterSegmentEditionUID  |
+| ChapterAtom/ChapterTrack              |
+| ChapterAtom/ChapProcess               |
+| Info/SegmentFamily                    |
+| Info/ChapterTranslate                 |
+| TrackEntry/TrackTranslate             |
 Table: elements only found in ordered chapters{#orderedOnly}
 
 These other `Elements` belong to the Matroska DVD menu system and are only used

--- a/chapters.md
+++ b/chapters.md
@@ -74,26 +74,19 @@ only the `ChapterTimeStart` of a `Chapter` is used as chapter mark to jump to th
 predefined point in the timeline. With `Simple Chapters`, a `Matroska Player` **MUST**
 ignore certain Chapter elements. All these elements are now informational only.
 
-The following list shows the different usage of Chapter elements between an ordered
-and non-ordered `Edition`.
+The following list shows the different Chapter elements only found in `Ordered Chapters`.
 
-| Chapter elements                   | Simple Chapters | Ordered Chapters |
-|:-----------------------------------|:-----:|:----:|
-| ChapterTimeEnd                     |   -   |  X   |
-| ChapterSegmentUID                  |   -   |  X   |
-| ChapterSegmentEditionUID           |   -   |  X   |
-| ChapterTrack                       |   -   |  X   |
-| ChapProcess                        |   -   |  X   |
-Table: mandatory elements for simple/ordered chapters{#orderedMandatory}
-
-Furthermore there are other EBML `Elements` which could be used if the
-`EditionFlagOrdered Flag` is set to `true`.
-
-| Other elements / ordered Edition   | False | True |
-|:-----------------------------------|:-----:|:----:|
-| Info/SegmentFamily                 |   -   |  X   |
-| Info/ChapterTranslate              |   -   |  X   |
-| Track/TrackTranslate               |   -   |  X   |
+| Ordered Chapter elements           |
+|:-----------------------------------|
+| ChapterTimeEnd                     |
+| ChapterSegmentUID                  |
+| ChapterSegmentEditionUID           |
+| ChapterTrack                       |
+| ChapProcess                        |
+| Info/SegmentFamily                 |
+| Info/ChapterTranslate              |
+| TrackEntry/TrackTranslate          |
+Table: elements only found in ordered chapters{#orderedOnly}
 
 These other `Elements` belong to the Matroska DVD menu system and are only used
 when the `ChapProcessCodecID Element` is set to 1.

--- a/index_tags.md
+++ b/index_tags.md
@@ -46,7 +46,7 @@ This document defines the Matroska tags, namely the tag names and their respecti
 
 Matroska aims to become THE standard of multimedia container formats. It can store timestamped multimedia data
 but also chapters and tags. The `Tag Elements` add important metadata to identify and classify the information found
-in a `Matroska Segment`. It can tag a whole `Segment`, separate `Track Elements`, individual `Chapter Elements` or `Attachment Elements`.
+in a `Matroska Segment`. It can tag a whole `Segment`, separate `Track Elements`, individual Chapter elements or `Attachment Elements`.
 
 While the Matroska tagging framework allows anyone to create their own custom tags, it's important to have a common
 set of values for interoperability. This document intends to define a set of common tag names used in Matroska.

--- a/notes.md
+++ b/notes.md
@@ -230,7 +230,7 @@ file name   | `SegmentUID`                      | `PrevUID`                     
 
 Medium Linking creates relationships between `Segments` using Ordered Chapters and the
 `ChapterSegmentUID Element`. A `Segment Edition` with Ordered Chapters **MAY** contain
-`Chapter Elements` that reference timestamp ranges from other `Segments`. The `Segment`
+Chapter elements that reference timestamp ranges from other `Segments`. The `Segment`
 referenced by the Ordered Chapter via the `ChapterSegmentUID Element` **SHOULD** be played as
 part of a Linked Segment. The timestamps of Segment content referenced by Ordered Chapters
 **MUST** be adjusted according to the cumulative duration of the the previous Ordered Chapters.

--- a/ordering.md
+++ b/ordering.md
@@ -47,7 +47,7 @@ for the first `SeekHead Element`.
 
 It is **RECOMMENDED** that the first `SeekHead Element` be followed by a `Void Element` to
 allow for the `SeekHead Element` to be expanded to cover new `Top-Level Elements`
-that could be added to the Matroska file, such as `Tags`, `Chapters`, and `Attachments Elements`.
+that could be added to the Matroska file, such as `Tags`, `Chapters`, and `Attachments` Elements.
 
 ## Cues (index)
 


### PR DESCRIPTION
We don't need to tell what is allowed in Simple Chapters nor mention elements that are allowed in both (nothing that is allowed in Simple Chapters is forbidden in Orderer Chapters).

What we need is to know which elements don't need to be handled if ordered chapters are not supported (ie most players). `ChapterTimeEnd` is not one of them (cf #322).

Plus less backticking (there is ton of cleaning to be done there).