### PR TITLE
Improve track autoselection capabilities and documentation

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -298,13 +298,13 @@ This **SHOULD** be kept the same when making a direct stream copy of the Track t
     <extension cppname="TrackFlagEnabled"/>
   </element>
   <element name="FlagDefault" path="\Segment\Tracks\TrackEntry\FlagDefault" id="0x88" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) **SHOULD** be active if no language found matches the user preference. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) **SHOULD** be eligible for automatic selection by the player. (1 bit)</documentation>
     <extension cppname="TrackFlagDefault"/>
   </element>
   <element name="FlagForced" path="\Segment\Tracks\TrackEntry\FlagForced" id="0x55AA" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track **MUST** be active during playback. There can be many forced track for a kind (audio, video or subs),
-the player **SHOULD** select the one which language matches the user preference or the default + forced track.
-Overlay **MAY** happen between a forced and non-forced track of the same kind. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Applies only to subtitles. Set if that track **SHOULD** be eligible for automatic selection by the player if it matches the user's language preference,
+even if the user's preferences would normally not enable subtitles with the selected audio track;
+this can be used for tracks containing only translations of foreign-language audio or onscreen text. (1 bit)</documentation>
     <extension cppname="TrackFlagForced"/>
   </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -307,6 +307,18 @@ even if the user's preferences would normally not enable subtitles with the sele
 this can be used for tracks containing only translations of foreign-language audio or onscreen text. (1 bit)</documentation>
     <extension cppname="TrackFlagForced"/>
   </element>
+  <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" default="0" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set if that track is suitable for users with hearing impairments. (1 bit)</documentation>
+    <extension webm="0"/>
+  </element>
+  <element name="FlagVisualImpaired" path="\Segment\Tracks\TrackEntry\FlagVisualImpaired" id="0x55AC" type="uinteger" range="0-1" default="0" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set if that track is suitable for users with visual impairments. (1 bit)</documentation>
+    <extension webm="0"/>
+  </element>
+  <element name="FlagTextDescriptions" path="\Segment\Tracks\TrackEntry\FlagTextDescriptions" id="0x55AD" type="uinteger" range="0-1" default="0" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set if that track contains textual descriptions of video content. (1 bit)</documentation>
+    <extension webm="0"/>
+  </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if the track **MAY** contain blocks using lacing. (1 bit)</documentation>
     <extension cppname="TrackFlagLacing"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -298,13 +298,14 @@ This **SHOULD** be kept the same when making a direct stream copy of the Track t
     <extension cppname="TrackFlagEnabled"/>
   </element>
   <element name="FlagDefault" path="\Segment\Tracks\TrackEntry\FlagDefault" id="0x88" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) **SHOULD** be eligible for automatic selection by the player. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) **SHOULD** be eligible for automatic selection by the player; see (#default-track-selection) for more details. (1 bit)</documentation>
     <extension cppname="TrackFlagDefault"/>
   </element>
   <element name="FlagForced" path="\Segment\Tracks\TrackEntry\FlagForced" id="0x55AA" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Applies only to subtitles. Set if that track **SHOULD** be eligible for automatic selection by the player if it matches the user's language preference,
 even if the user's preferences would normally not enable subtitles with the selected audio track;
-this can be used for tracks containing only translations of foreign-language audio or onscreen text. (1 bit)</documentation>
+this can be used for tracks containing only translations of foreign-language audio or onscreen text.
+See (#default-track-selection) for more details. (1 bit)</documentation>
     <extension cppname="TrackFlagForced"/>
   </element>
   <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" default="0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -323,6 +323,10 @@ this can be used for tracks containing only translations of foreign-language aud
     <documentation lang="en" purpose="definition">Set if that track is in the content's original language (not a translation). (1 bit)</documentation>
     <extension webm="0"/>
   </element>
+  <element name="FlagCommentary" path="\Segment\Tracks\TrackEntry\FlagCommentary" id="0x55AF" type="uinteger" range="0-1" default="0" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set if that track contains commentary. (1 bit)</documentation>
+    <extension webm="0"/>
+  </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if the track **MAY** contain blocks using lacing. (1 bit)</documentation>
     <extension cppname="TrackFlagLacing"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -319,6 +319,10 @@ this can be used for tracks containing only translations of foreign-language aud
     <documentation lang="en" purpose="definition">Set if that track contains textual descriptions of video content. (1 bit)</documentation>
     <extension webm="0"/>
   </element>
+  <element name="FlagOriginal" path="\Segment\Tracks\TrackEntry\FlagOriginal" id="0x55AE" type="uinteger" range="0-1" default="0" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set if that track is in the content's original language (not a translation). (1 bit)</documentation>
+    <extension webm="0"/>
+  </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if the track **MAY** contain blocks using lacing. (1 bit)</documentation>
     <extension cppname="TrackFlagLacing"/>

--- a/notes.md
+++ b/notes.md
@@ -257,24 +257,22 @@ so that the `Matroska Player` can quickly switch from one to the other.
 
 ## Default flag
 
-The "default track" flag is a hint for a `Matroska Player` and **SHOULD** always be changeable
-by the user. If the user wants to see or hear a track of a certain kind (audio, video, subtitles)
-and hasn't chosen a specific track, the `Matroska Player` **SHOULD** use the first track
-of that kind whose "default track" flag is set to "1". If no such track is found,
-then the first track of this kind **SHOULD** be chosen.
+The "default track" flag is a hint for a `Matroska Player` indicating that a given track
+**SHOULD** be eligible to be automatically selected as the default track for a given
+language. If no tracks in a given language have the default track flag set, then all tracks
+in that language are eligible for automatic selection. This can be used to indicate that
+a track provides "regular service" suitable for users with default settings, as opposed to
+specialized services, such as commentary, hearing-impaired captions, or descriptive audio.
 
-Only one track of a kind **MAY** have its "default track" flag set in a segment.
-If a track entry does not contain the "default track" flag element, then its
-default value "1" is to be used.
+The `Matroska Player` **MAY** override the "default track" flag for any reason, including
+user preferences to prefer tracks providing accessibility services.
 
 ## Forced flag
 
-The "forced" flag tells the `Matroska Player` that it **MUST** display/play this track
-or another track of the same kind that also has its "forced" flag set. When there are multiple
-"forced" tracks, the `Matroska Player` **SHOULD** determine the track based upon the language
-of the forced flag or use the default flag if no track matches the use languages.
-Another track of the same kind without the "forced" flag may be use simultaneously
-with the "forced" track, like DVD subtitles.
+The "forced" flag tells the `Matroska Player` that it **SHOULD** display this subtitle track,
+even if user preferences usually would not call for any subtitles to be displayed alongside
+the current selected audio track. This can be used to indicate that a track contains translations
+of onscreen text, or of dialogue spoken in a different language than the track's primary one.
 
 ## Track Operation
 

--- a/notes.md
+++ b/notes.md
@@ -298,6 +298,11 @@ The "original" flag tells the `Matroska Player` that this track is in the origin
 and that it **SHOULD** prefer it if configured to prefer original-language tracks of this
 track's type.
 
+## Commentary flag
+
+The "commentary" flag tells the `Matroska Player` that this track contains commentary on
+the content.
+
 ## Track Operation
 
 `TrackOperation` allows combining multiple tracks to make a virtual one. It uses

--- a/notes.md
+++ b/notes.md
@@ -292,6 +292,12 @@ The "descriptions" flag tells the `Matroska Player` that this track is suitable 
 a text-to-speech system for a visually-impaired user, and that it **SHOULD NOT** automatically
 select this track when selecting a default track for a non-visually-impaired user.
 
+## Original flag
+
+The "original" flag tells the `Matroska Player` that this track is in the original language,
+and that it **SHOULD** prefer it if configured to prefer original-language tracks of this
+track's type.
+
 ## Track Operation
 
 `TrackOperation` allows combining multiple tracks to make a virtual one. It uses

--- a/notes.md
+++ b/notes.md
@@ -274,6 +274,24 @@ even if user preferences usually would not call for any subtitles to be displaye
 the current selected audio track. This can be used to indicate that a track contains translations
 of onscreen text, or of dialogue spoken in a different language than the track's primary one.
 
+## Hearing-impaired flag
+
+The "hearing impaired" flag tells the `Matroska Player` that it **SHOULD** prefer this track
+when selecting a default track for a hearing-impaired user, and that it **MAY** prefer to select
+a different track when selecting a default track for a non-hearing-impaired user.
+
+## Visual-impaired flag
+
+The "visual impaired" flag tells the `Matroska Player` that it **SHOULD** prefer this track
+when selecting a default track for a visually-impaired user, and that it **MAY** prefer to select
+a different track when selecting a default track for a non-visually-impaired user.
+
+## Descriptions flag
+
+The "descriptions" flag tells the `Matroska Player` that this track is suitable to play via
+a text-to-speech system for a visually-impaired user, and that it **SHOULD NOT** automatically
+select this track when selecting a default track for a non-visually-impaired user.
+
 ## Track Operation
 
 `TrackOperation` allows combining multiple tracks to make a virtual one. It uses


### PR DESCRIPTION
This is a (long-delayed) successor to #158 and is intended to fix #374; there's a substantial amount of discussion in that issue and the previous PR.

This aims to solve a few problems:
- The lack of clarity around the meanings of the "default" and "forced" flags, redefining both to have more useful meanings:
  - The "default" flag previously had no particular value; its function was indistinguishable from simply making the "default" track the first of its type in the file (and, in fact, most files that set a single track as "default" seem to set it on the first track of a given type)
  - The "forced" flag previously was documented to have behavior that no player implemented, and that no authoring software supported. Instead, many files have used it in the way described in this PR, so there doesn't seem to be any reason not to make it official. Some players seem to have used the forced flag as a sort of a "super-default" (i.e. a forced track is preferred over a default track, and a default track over a no-flags track), which isn't especially useful either.
- The lack of any structured way to indicate tracks providing accessibility services
- The lack of a way to specify explicit associations between audio and subtitle tracks
- The lack of clear documentation on how to implement track autoselection

The algorithm described in the last commit is very similar to the ones implemented in mpv and Plex. I'd be curious to see additional feedback from other player developers.