### PR TITLE
Make the TrackEntry\Language mandatory

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -402,7 +402,7 @@ The intepretation of the binary data depends on the BlockAddIDType value and the
     <documentation lang="en" purpose="definition">A human-readable track name.</documentation>
     <extension cppname="TrackName"/>
   </element>
-  <element name="Language" path="\Segment\Tracks\TrackEntry\Language" id="0x22B59C" type="string" default="eng" maxOccurs="1">
+  <element name="Language" path="\Segment\Tracks\TrackEntry\Language" id="0x22B59C" type="string" default="eng" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specifies the language of the track in the Matroska languages form;
 see (#language-codes) on language codes.
 This Element **MUST** be ignored if the LanguageIETF Element is used in the same TrackEntry.</documentation>


### PR DESCRIPTION
Following the bug/inconsistency found in EBML [1] it might be better to make
the track language mandatory. It will give better past/present compatibility.

In light of the next Track Selection explanation it's also vital to know the
language when you have more than one audio/subtitle track.

This may be a problem for video tracks that were not mandatory and technically
didn't have a defined language. The flag does make sense though, even for video.
For example some text on the screen may appear differently between languages.

This change will turn every track of every file that doesn't have this value set
assume it's in English. That's probably what any system dealing with track selection
is already doing anyway given it was the official default value.

[1] https://github.com/ietf-wg-cellar/ebml-specification/issues/394