### PR TITLE
Clarify semantics of newly added flags elements

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -308,27 +308,27 @@ this can be used for tracks containing only translations of foreign-language aud
 See (#default-track-selection) for more details. (1 bit)</documentation>
     <extension cppname="TrackFlagForced"/>
   </element>
-  <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" default="0" maxOccurs="1">
+  <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if that track is suitable for users with hearing impairments. (1 bit)</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
-  <element name="FlagVisualImpaired" path="\Segment\Tracks\TrackEntry\FlagVisualImpaired" id="0x55AC" type="uinteger" range="0-1" default="0" maxOccurs="1">
+  <element name="FlagVisualImpaired" path="\Segment\Tracks\TrackEntry\FlagVisualImpaired" id="0x55AC" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if that track is suitable for users with visual impairments. (1 bit)</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
-  <element name="FlagTextDescriptions" path="\Segment\Tracks\TrackEntry\FlagTextDescriptions" id="0x55AD" type="uinteger" range="0-1" default="0" maxOccurs="1">
+  <element name="FlagTextDescriptions" path="\Segment\Tracks\TrackEntry\FlagTextDescriptions" id="0x55AD" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if that track contains textual descriptions of video content. (1 bit)</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
-  <element name="FlagOriginal" path="\Segment\Tracks\TrackEntry\FlagOriginal" id="0x55AE" type="uinteger" range="0-1" default="0" maxOccurs="1">
+  <element name="FlagOriginal" path="\Segment\Tracks\TrackEntry\FlagOriginal" id="0x55AE" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if that track is in the content's original language (not a translation). (1 bit)</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
-  <element name="FlagCommentary" path="\Segment\Tracks\TrackEntry\FlagCommentary" id="0x55AF" type="uinteger" range="0-1" default="0" maxOccurs="1">
+  <element name="FlagCommentary" path="\Segment\Tracks\TrackEntry\FlagCommentary" id="0x55AF" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set if that track contains commentary. (1 bit)</documentation>
     <extension webm="0"/>
     <extension divx="0"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -309,27 +309,27 @@ See (#default-track-selection) for more details. (1 bit)</documentation>
     <extension cppname="TrackFlagForced"/>
   </element>
   <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track is suitable for users with hearing impairments. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if that track is suitable for users with hearing impairments, set to 0 if it is unsuitable for users with hearing impairments.</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
   <element name="FlagVisualImpaired" path="\Segment\Tracks\TrackEntry\FlagVisualImpaired" id="0x55AC" type="uinteger" range="0-1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track is suitable for users with visual impairments. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if that track is suitable for users with visual impairments, set to 0 if it is unsuitable for users with visual impairments.</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
   <element name="FlagTextDescriptions" path="\Segment\Tracks\TrackEntry\FlagTextDescriptions" id="0x55AD" type="uinteger" range="0-1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track contains textual descriptions of video content. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if that track contains textual descriptions of video content, set to 0 if that track does not contain textual descriptions of video content.</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
   <element name="FlagOriginal" path="\Segment\Tracks\TrackEntry\FlagOriginal" id="0x55AE" type="uinteger" range="0-1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track is in the content's original language (not a translation). (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if that track is in the content's original language, set to 0 if it is a translation.</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>
   <element name="FlagCommentary" path="\Segment\Tracks\TrackEntry\FlagCommentary" id="0x55AF" type="uinteger" range="0-1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track contains commentary. (1 bit)</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if that track contains commentary, set to 0 if it does not contain commentary.</documentation>
     <extension webm="0"/>
     <extension divx="0"/>
   </element>


### PR DESCRIPTION
Fixes issue #453.

I opted not to add a "In the absence of the element nothing can be inferred about ..." to every flag given that it is self-evident; but I can change this if desired.