### PR TITLE
Deprecate CodecDecodeAll

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -385,8 +385,8 @@ see [@!I-D.ietf-cellar-codec] for more info.</documentation>
   <element name="CodecDownloadURL" path="\Segment\Tracks\TrackEntry\CodecDownloadURL" id="0x26B240" type="string" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">A URL to download about the codec used.</documentation>
   </element>
-  <element name="CodecDecodeAll" path="\Segment\Tracks\TrackEntry\CodecDecodeAll" id="0xAA" type="uinteger" minver="2" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The codec can decode potentially damaged data.</documentation>
+  <element name="CodecDecodeAll" path="\Segment\Tracks\TrackEntry\CodecDecodeAll" id="0xAA" type="uinteger" maxver="0" range="0-1" default="1" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set to 1 if the codec can decode potentially damaged data.</documentation>
   </element>
   <element name="TrackOverlay" path="\Segment\Tracks\TrackEntry\TrackOverlay" id="0x6FAB" type="uinteger">
     <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the Track specified (in the u-integer).


### PR DESCRIPTION
It's not a container feature but a feature of the decoder on the system

This is very unlikely to have been used anywhere.

Too bad it's a 1-octet ID that is wasted for such a thing...