### PR TITLE
Move control track related content in a separate document

### DIFF
--- a/.github/workflows/generate-rfcs.yaml
+++ b/.github/workflows/generate-rfcs.yaml
@@ -45,6 +45,7 @@ jobs:
           mv draft-ietf-cellar-codec-??.xml artifacts
           mv draft-ietf-cellar-tags-??.xml artifacts
           mv draft-ietf-cellar-chapter-codecs-??.xml artifacts
+          mv draft-ietf-cellar-control-??.xml artifacts
 
       - name: XML Artifact
         uses: actions/upload-artifact@master

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ _site
 bootstrap.mak
 ebml_matroska_elements.md
 ebml_matroska_elements4rfc.md
+control_elements4rfc.md
 matroska_tagging_registry.md
+control_xsd.xml
 matroska_xsd.xml
 metadata.min.js
 mmark

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _site
 *ietf-cellar-codec*
 *ietf-cellar-tags-*
 *ietf-cellar-chapter-codecs-*
+*ietf-cellar-control-*
 bootstrap.mak
 ebml_matroska_elements.md
 ebml_matroska_elements4rfc.md

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_
 control_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml > $@
 
-$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md chapters.md attachments.md cues.md streaming.md menu.md notes.md rfc_backmatter_matroska.md
+$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md chapters.md attachments.md cues.md streaming.md notes.md rfc_backmatter_matroska.md
 	cat $^ | sed -e '/^---/,/^---/d' \
 	             -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_MATROSKA)/" > $@
@@ -65,7 +65,7 @@ $(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md rfc_backm
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CHAPTER_CODECS)/" > $@
 
 
-$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md rfc_backmatter_control.md
+$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.md rfc_backmatter_control.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
 

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,17 @@ VERSION_MATROSKA := 06
 VERSION_CODEC := 05
 VERSION_TAGS := 05
 VERSION_CHAPTER_CODECS := 01
+VERSION_CONTROL := 01
 STATUS_MATROSKA := draft-
 STATUS_CODEC := draft-
 STATUS_TAGS := draft-
 STATUS_CHAPTER_CODECS := draft-
+STATUS_CONTROL := draft-
 OUTPUT_MATROSKA := $(STATUS_MATROSKA)ietf-cellar-matroska-$(VERSION_MATROSKA)
 OUTPUT_CODEC := $(STATUS_CODEC)ietf-cellar-codec-$(VERSION_CODEC)
 OUTPUT_TAGS := $(STATUS_TAGS)ietf-cellar-tags-$(VERSION_TAGS)
 OUTPUT_CHAPTER_CODECS := $(STATUS_CHAPTER_CODECS)ietf-cellar-chapter-codecs-$(VERSION_CHAPTER_CODECS)
+OUTPUT_CONTROL := $(STATUS_CONTROL)ietf-cellar-control-$(VERSION_CONTROL)
 
 XML2RFC_CALL := xml2rfc
 MMARK_CALL := mmark
@@ -20,13 +23,14 @@ EBML_SCHEMA_XSD := ../ebml-specification/EBMLSchema.xsd
 XML2RFC := $(XML2RFC_CALL) --v3
 MMARK := $(MMARK_CALL)
 
-all: matroska codecs tags chapter_codecs
+all: matroska codecs tags chapter_codecs control
 	$(info RFC rendering has been tested with mmark version 2.2.8 and xml2rfc 2.46.0, please ensure these are installed and recent enough.)
 
 matroska: $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).xml
 codecs: $(OUTPUT_CODEC).html $(OUTPUT_CODEC).txt $(OUTPUT_CODEC).xml
 tags: $(OUTPUT_TAGS).html $(OUTPUT_TAGS).txt $(OUTPUT_TAGS).xml
 chapter_codecs: $(OUTPUT_CHAPTER_CODECS).html $(OUTPUT_CHAPTER_CODECS).txt $(OUTPUT_CHAPTER_CODECS).xml
+control: $(OUTPUT_CONTROL).html $(OUTPUT_CONTROL).txt $(OUTPUT_CONTROL).xml
 
 matroska_xsd.xml: transforms/schema_clean.xsl ebml_matroska.xml
 	xsltproc transforms/schema_clean.xsl ebml_matroska.xml > $@
@@ -54,6 +58,10 @@ $(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md rfc_backm
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CHAPTER_CODECS)/" > $@
 
 
+$(OUTPUT_CONTROL).md: index_control.md control.md rfc_backmatter_control.md
+	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
+	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
+
 %.xml: %.md
 	$(MMARK) $< | awk '/<?rfc toc=/ && !modif { printf("<?rfc tocdepth=\"6\"?>\n"); modif=1 } {print}' | \
 		sed -e "s/submissionType=/sortRefs=\"true\" submissionType=/" \
@@ -76,6 +84,7 @@ clean:
 	$(RM) -f $(OUTPUT_CODEC).txt $(OUTPUT_CODEC).html $(OUTPUT_CODEC).md $(OUTPUT_CODEC).xml
 	$(RM) -f $(OUTPUT_TAGS).txt $(OUTPUT_TAGS).html $(OUTPUT_TAGS).md $(OUTPUT_TAGS).xml
 	$(RM) -f $(OUTPUT_CHAPTER_CODECS).txt $(OUTPUT_CHAPTER_CODECS).html $(OUTPUT_CHAPTER_CODECS).md $(OUTPUT_CHAPTER_CODECS).xml
+	$(RM) -f $(OUTPUT_CONTROL).txt $(OUTPUT_CONTROL).html $(OUTPUT_CONTROL).md $(OUTPUT_CONTROL).xml
 	$(RM) -rf _site
 
 .PHONY: clean check website matroska codecs tags all

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,18 @@ control: $(OUTPUT_CONTROL).html $(OUTPUT_CONTROL).txt $(OUTPUT_CONTROL).xml
 matroska_xsd.xml: transforms/schema_clean.xsl ebml_matroska.xml
 	xsltproc transforms/schema_clean.xsl ebml_matroska.xml > $@
 
-check: matroska_xsd.xml $(EBML_SCHEMA_XSD)
+control_xsd.xml: transforms/schema_clean.xsl control_elements.xml
+	xsltproc transforms/schema_clean.xsl control_elements.xml > $@
+
+check: matroska_xsd.xml control_xsd.xml $(EBML_SCHEMA_XSD)
 	xmllint --noout --schema $(EBML_SCHEMA_XSD) matroska_xsd.xml
+	xmllint --noout --schema $(EBML_SCHEMA_XSD) control_xsd.xml
 
 ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl matroska_xsd.xml > $@
+
+control_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml
+	xsltproc transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml > $@
 
 $(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md chapters.md attachments.md cues.md streaming.md menu.md notes.md rfc_backmatter_matroska.md
 	cat $^ | sed -e '/^---/,/^---/d' \
@@ -58,7 +65,7 @@ $(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md rfc_backm
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CHAPTER_CODECS)/" > $@
 
 
-$(OUTPUT_CONTROL).md: index_control.md control.md rfc_backmatter_control.md
+$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md rfc_backmatter_control.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
 

--- a/chapters.md
+++ b/chapters.md
@@ -35,21 +35,21 @@ Edition   | FlagDefault | Default Edition
 Edition 1 | true        | X
 Edition 2 | true        |
 Edition 3 | true        |
-Table: Default edition, all default{#defaultEditionSomeVisibleAllDefault}
+Table: Default edition, all default{#defaultEditionAllDefault}
 
 Edition   | FlagDefault | Default Edition
 :---------|:------------|:---------------
 Edition 1 | false       | X
 Edition 2 | false       |
 Edition 3 | false       |
-Table: Default edition, no default{#defaultEditionAllHiddenNoDefault}
+Table: Default edition, no default{#defaultEditionNoDefault}
 
 Edition   | FlagDefault | Default Edition
 :---------|:------------|:---------------
 Edition 1 | false       |
 Edition 2 | true        | X
 Edition 3 | false       |
-Table: Default edition, with default{#defaultEditionAllHiddenWithDefault}
+Table: Default edition, with default{#defaultEditionWithDefault}
 
 ### EditionFlagOrdered
 

--- a/chapters.md
+++ b/chapters.md
@@ -17,30 +17,6 @@ An `Edition` contains a set of `Edition` flags and **MUST** contain at least one
 Chapters are always inside an `Edition` (or a Chapter itself part of an `Edition`).
 Multiple Editions are allowed. Some of these Editions **MAY** be ordered and others not.
 
-### EditionFlagHidden
-
-When the `EditionFlagHidden` flag is set to `false` it means the `Edition` is visible and selectable
-in a `Matroska Player`.
-All `ChapterAtoms Elements` **MUST** be interpreted with their own `ChapterFlagHidden` flags.
-
-ChapterFlagHidden | False | True | visible
-:-----------------|:------|:-----|:-------
-Chapter 1         |   X   |      | yes
-Chapter 2         |       | X    | no
-Table: ChapterAtom visibility to the user{#chapterVisibility}
-
-When the `EditionFlagHidden` flag is set to `true` the `Edition` is hidden and **SHOULD NOT** be
-selectable in a `Matroska Player`.
-If all `Editions` `EditionFlagHidden` flags are set to `true`, there is no visible `Edition`.
-In this case all `ChapterAtoms Elements` **MUST** also be interpreted as if their `ChapterFlagHidden`
-flag is also set to `true`, regardless with their own `ChapterFlagHidden` flags.
-
-ChapterFlagHidden | False | True | visible
-:-----------------|:------|:-----|:-------
-Chapter 1         |   X   |      | no
-Chapter 2         |       | X    | no
-Table: ChapterAtom visibility in hidden editions{#chapterVisibilityHidden}
-
 ### EditionFlagDefault
 
 Only one `Edition` **SHOULD** have an `EditionFlagDefault` flag set to `true`.
@@ -49,55 +25,31 @@ Only one `Edition` **SHOULD** have an `EditionFlagDefault` flag set to `true`.
 
 The `Default Edition` is the `Edition` that a `Matroska Player` **SHOULD** use for playback by default.
 
-The first `Edition` with both the `EditionFlagDefault` flag set to `true` and the `EditionFlagHidden`
-flag set to `false` is the `Default Edition`.
-When all `EditionFlagDefault` flags are set to `false` and all `EditionFlagHidden` flag set to `true`,
-then the first `Edition` is the `Default Edition`.
-When all `EditionFlagHidden` flags are set to `true`, then the first `Edition` with the
-`EditionFlagDefault` flag set to `true` is the `Default Edition`.
-When all `EditionFlagDefault` flags are set to `false`, then the first `Edition` with the
-`EditionFlagHidden` flag set to `false` is the `Default Edition`.
-When there is no `Edition` with a `EditionFlagDefault` flag are set to `true` and a
-`EditionFlagHidden` flags are set to `false`, then the first `Edition` with the `EditionFlagHidden`
-flag set to `false` is the `Default Edition`.
+The first `Edition` with the `EditionFlagDefault` flag set to `true` is the `Default Edition`.
 
-In other words, in case the `Default Edition` is not obvious, the first `Edition` with a
-`EditionFlagHidden` flag set to `false` **SHOULD** be preferred.
+When all `EditionFlagDefault` flags are set to `false`, then the first `Edition`
+is the `Default Edition`.
 
-Edition   | FlagHidden | FlagDefault | Default Edition
-:---------|:-----------|:------------|:---------------
-Edition 1 | true       | true        |
-Edition 2 | true       | true        |
-Edition 3 | false      | true        | X
-Table: Default edition, some visible, all default{#defaultEditionSomeVisibleAllDefault}
+Edition   | FlagDefault | Default Edition
+:---------|:------------|:---------------
+Edition 1 | true        | X
+Edition 2 | true        |
+Edition 3 | true        |
+Table: Default edition, all default{#defaultEditionSomeVisibleAllDefault}
 
-Edition   | FlagHidden | FlagDefault | Default Edition
-:---------|:-----------|:------------|:---------------
-Edition 1 | true       | false       | X
-Edition 2 | true       | false       |
-Edition 3 | true       | false       |
-Table: Default edition, all hidden, no default{#defaultEditionAllHiddenNoDefault}
+Edition   | FlagDefault | Default Edition
+:---------|:------------|:---------------
+Edition 1 | false       | X
+Edition 2 | false       |
+Edition 3 | false       |
+Table: Default edition, no default{#defaultEditionAllHiddenNoDefault}
 
-Edition   | FlagHidden | FlagDefault | Default Edition
-:---------|:-----------|:------------|:---------------
-Edition 1 | true       | false       |
-Edition 2 | true       | true        | X
-Edition 3 | true       | false       |
-Table: Default edition, all hidden, with default{#defaultEditionAllHiddenWithDefault}
-
-Edition   | FlagHidden | FlagDefault | Default Edition
-:---------|:-----------|:------------|:---------------
-Edition 1 | true       | false       |
-Edition 2 | false      | false       | X
-Edition 3 | false      | false       |
-Table: Default edition, some visible, no default{#defaultEditionSomeVisibleNoDefault}
-
-Edition   | FlagHidden | FlagDefault | Default Edition
-:---------|:-----------|:------------|:---------------
-Edition 1 | true       | false       |
-Edition 2 | true       | true        |
-Edition 3 | false      | false       | X
-Table: Default edition, some visible, some default{#defaultEditionSomeVisibleSomeDefault}
+Edition   | FlagDefault | Default Edition
+:---------|:------------|:---------------
+Edition 1 | false       |
+Edition 2 | true        | X
+Edition 3 | false       |
+Table: Default edition, with default{#defaultEditionAllHiddenWithDefault}
 
 ### EditionFlagOrdered
 
@@ -198,7 +150,7 @@ Chapter 4 | 9000000000      | 8000000000    | -1000000000 (illegal)
 
 ### ChapterFlagHidden
 
-The `ChapterFlagHidden` flag works differently from the `EditionFlagHidden` flag. Each Chapter
+Each Chapter
 `ChapterFlagHidden` flag works independently from parent chapters.
 A `Nested Chapter` with `ChapterFlagHidden` flag set to `false` remains visible even if the
 `Parent Chapter` `ChapterFlagHidden` flag is set to `true`.
@@ -337,7 +289,6 @@ This would translate in the following matroska form :
       <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <EditionFlagDefault>0</EditionFlagDefault>
-    <EditionFlagHidden>0</EditionFlagHidden>
   </EditionEntry>
 </Chapters>
 ```
@@ -475,7 +426,6 @@ of them contain another splitting.
       <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <EditionFlagDefault>0</EditionFlagDefault>
-    <EditionFlagHidden>0</EditionFlagHidden>
   </EditionEntry>
 </Chapters>
 ```

--- a/chapters.md
+++ b/chapters.md
@@ -164,25 +164,6 @@ Chapter 2                | true              | no
  Nested Chapter 2.1      | false             | yes
  Nested Chapter 2.2      | true              | no
 
-### ChapterFlagEnabled
-
-If the `ChapterFlagEnabled` flag is set to `false` a `Matroska Player` **MUST NOT** use this
-`Chapter` and all his `Nested Chapters`.
-For `Simple Chapters`, a `Matroska Player` **MAY** display this enabled `Chapter` with a marker in
-the timeline.
-For `Ordered Chapters` a `Matroska Player` **MUST** use the duration of this enabled `Chapter`.
-
-Chapter + Nested Chapter | ChapterFlagEnabled | used
-:------------------------|:-------------------|:----
-Chapter 1                | true               | yes
-+Nested Chapter 1.1      | true               | yes
-+Nested Chapter 1.2      | false              | no
-++Nested Chapter 1.2.1   | true               | no
-++Nested Chapter 1.2.2   | false              | no
-Chapter 2                | false              | no
-+Nested Chapter 2.1      | true               | no
-+Nested Chapter 2.2      | true               | no
-
 ## Menu features
 
 The menu features are handled like a `chapter codec`. That means each codec has a type,
@@ -226,7 +207,6 @@ This would translate in the following matroska form :
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>2311527</ChapterUID>
@@ -241,7 +221,6 @@ This would translate in the following matroska form :
         <ChapLanguage>fra</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>3430008</ChapterUID>
@@ -256,7 +235,6 @@ This would translate in the following matroska form :
         <ChapLanguage>fra</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>4548489</ChapterUID>
@@ -271,7 +249,6 @@ This would translate in the following matroska form :
         <ChapLanguage>fra</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>5666960</ChapterUID>
@@ -286,7 +263,6 @@ This would translate in the following matroska form :
         <ChapLanguage>fra</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <EditionFlagDefault>0</EditionFlagDefault>
   </EditionEntry>
@@ -332,7 +308,6 @@ of them contain another splitting.
           <ChapLanguage>eng</ChapLanguage>
         </ChapterDisplay>
         <ChapterFlagHidden>0</ChapterFlagHidden>
-        <ChapterFlagEnabled>1</ChapterFlagEnabled>
       </ChapterAtom>
       <ChapterAtom>
         <ChapterUID>3</ChapterUID>
@@ -343,7 +318,6 @@ of them contain another splitting.
           <ChapLanguage>eng</ChapLanguage>
         </ChapterDisplay>
         <ChapterFlagHidden>0</ChapterFlagHidden>
-        <ChapterFlagEnabled>1</ChapterFlagEnabled>
       </ChapterAtom>
       <ChapterAtom>
         <ChapterUID>4</ChapterUID>
@@ -354,7 +328,6 @@ of them contain another splitting.
           <ChapLanguage>eng</ChapLanguage>
         </ChapterDisplay>
         <ChapterFlagHidden>0</ChapterFlagHidden>
-        <ChapterFlagEnabled>1</ChapterFlagEnabled>
       </ChapterAtom>
       <ChapterAtom>
         <ChapterUID>5</ChapterUID>
@@ -365,10 +338,8 @@ of them contain another splitting.
           <ChapLanguage>eng</ChapLanguage>
         </ChapterDisplay>
         <ChapterFlagHidden>0</ChapterFlagHidden>
-        <ChapterFlagEnabled>1</ChapterFlagEnabled>
       </ChapterAtom>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>6</ChapterUID>
@@ -379,7 +350,6 @@ of them contain another splitting.
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>7</ChapterUID>
@@ -390,7 +360,6 @@ of them contain another splitting.
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>8</ChapterUID>
@@ -401,7 +370,6 @@ of them contain another splitting.
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>9</ChapterUID>
@@ -412,7 +380,6 @@ of them contain another splitting.
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <ChapterAtom>
       <ChapterUID>10</ChapterUID>
@@ -423,7 +390,6 @@ of them contain another splitting.
         <ChapLanguage>eng</ChapLanguage>
       </ChapterDisplay>
       <ChapterFlagHidden>0</ChapterFlagHidden>
-      <ChapterFlagEnabled>1</ChapterFlagEnabled>
     </ChapterAtom>
     <EditionFlagDefault>0</EditionFlagDefault>
   </EditionEntry>

--- a/control.md
+++ b/control.md
@@ -1,6 +1,96 @@
 ---
 title: Control Tracks
 ---
+# Edition Flags
+
+## EditionFlagHidden
+
+When the `EditionFlagHidden` flag is set to `false` it means the `Edition` is visible and selectable
+in a `Matroska Player`.
+All `ChapterAtoms Elements` **MUST** be interpreted with their own `ChapterFlagHidden` flags.
+
+ChapterFlagHidden | False | True | visible
+:-----------------|:------|:-----|:-------
+Chapter 1         |   X   |      | yes
+Chapter 2         |       | X    | no
+Table: ChapterAtom visibility to the user{#chapterVisibility}
+
+When the `EditionFlagHidden` flag is set to `true` the `Edition` is hidden and **SHOULD NOT** be
+selectable in a `Matroska Player`.
+If all `Editions` `EditionFlagHidden` flags are set to `true`, there is no visible `Edition`.
+In this case all `ChapterAtoms Elements` **MUST** also be interpreted as if their `ChapterFlagHidden`
+flag is also set to `true`, regardless with their own `ChapterFlagHidden` flags.
+
+ChapterFlagHidden | False | True | visible
+:-----------------|:------|:-----|:-------
+Chapter 1         |   X   |      | no
+Chapter 2         |       | X    | no
+Table: ChapterAtom visibility in hidden editions{#chapterVisibilityHidden}
+
+## EditionFlagDefault
+
+It is **RECOMMENDED** that no more than one `Edition` have an `EditionFlagDefault Flag`
+set to `true`. The first `Edition` with both the `EditionFlagDefault Flag` set to `true`
+and the `EditionFlagHidden Flag` set to `false` is the Default Edition. When all
+`EditionFlagDefault Flags` are set to `false`, then the first `Edition` with the
+`EditionFlagHidden Flag` set to `false` is the Default Edition. The Default Edition
+is the edition that should be used for playback by default.
+
+
+## Default Edition
+
+The `Default Edition` is the `Edition` that a `Matroska Player` **SHOULD** use for playback by default.
+
+The first `Edition` with both the `EditionFlagDefault` flag set to `true` and the `EditionFlagHidden`
+flag set to `false` is the `Default Edition`.
+When all `EditionFlagDefault` flags are set to `false` and all `EditionFlagHidden` flag set to `true`,
+then the first `Edition` is the `Default Edition`.
+When all `EditionFlagHidden` flags are set to `true`, then the first `Edition` with the
+`EditionFlagDefault` flag set to `true` is the `Default Edition`.
+When all `EditionFlagDefault` flags are set to `false`, then the first `Edition` with the
+`EditionFlagHidden` flag set to `false` is the `Default Edition`.
+When there is no `Edition` with a `EditionFlagDefault` flag are set to `true` and a
+`EditionFlagHidden` flags are set to `false`, then the first `Edition` with the `EditionFlagHidden`
+flag set to `false` is the `Default Edition`.
+
+In other words, in case the `Default Edition` is not obvious, the first `Edition` with a
+`EditionFlagHidden` flag set to `false` **SHOULD** be preferred.
+
+Edition   | FlagHidden | FlagDefault | Default Edition
+:---------|:-----------|:------------|:---------------
+Edition 1 | true       | true        |
+Edition 2 | true       | true        |
+Edition 3 | false      | true        | X
+Table: Default edition, some visible, all default{#defaultEditionSomeVisibleAllDefault}
+
+Edition   | FlagHidden | FlagDefault | Default Edition
+:---------|:-----------|:------------|:---------------
+Edition 1 | true       | false       | X
+Edition 2 | true       | false       |
+Edition 3 | true       | false       |
+Table: Default edition, all hidden, no default{#defaultEditionAllHiddenNoDefault}
+
+Edition   | FlagHidden | FlagDefault | Default Edition
+:---------|:-----------|:------------|:---------------
+Edition 1 | true       | false       |
+Edition 2 | true       | true        | X
+Edition 3 | true       | false       |
+Table: Default edition, all hidden, with default{#defaultEditionAllHiddenWithDefault}
+
+Edition   | FlagHidden | FlagDefault | Default Edition
+:---------|:-----------|:------------|:---------------
+Edition 1 | true       | false       |
+Edition 2 | false      | false       | X
+Edition 3 | false      | false       |
+Table: Default edition, some visible, no default{#defaultEditionSomeVisibleNoDefault}
+
+Edition   | FlagHidden | FlagDefault | Default Edition
+:---------|:-----------|:------------|:---------------
+Edition 1 | true       | false       |
+Edition 2 | true       | true        |
+Edition 3 | false      | false       | X
+Table: Default edition, some visible, some default{#defaultEditionSomeVisibleSomeDefault}
+
 # Matroska Schema
 
 Extra elements used to handle Control Tracks and advanced selection features:
@@ -8,4 +98,3 @@ Extra elements used to handle Control Tracks and advanced selection features:
 ## Segment
 ### Chapters
 #### EditionEntry
-##### ChapterAtom

--- a/control.md
+++ b/control.md
@@ -1,0 +1,3 @@
+---
+title: Control Tracks
+---

--- a/control.md
+++ b/control.md
@@ -1,3 +1,11 @@
 ---
 title: Control Tracks
 ---
+# Matroska Schema
+
+Extra elements used to handle Control Tracks and advanced selection features:
+
+## Segment
+### Chapters
+#### EditionEntry
+##### ChapterAtom

--- a/control.md
+++ b/control.md
@@ -99,6 +99,27 @@ flag to `false`, then only the parent `ChapterAtom` and its second child `Chapte
 `ChapterAtom`, which has the `ChapterFlagHidden` flag set to `true`, retains its value
 until its value is toggled to `false` by a `Control Track`.
 
+The `ChapterFlagEnabled` value can be toggled by control tracks.
+
+## ChapterFlagEnabled
+
+If the `ChapterFlagEnabled` flag is set to `false` a `Matroska Player` **MUST NOT** use this
+`Chapter` and all his `Nested Chapters`.
+For `Simple Chapters`, a `Matroska Player` **MAY** display this enabled `Chapter` with a marker in
+the timeline.
+For `Ordered Chapters` a `Matroska Player` **MUST** use the duration of this enabled `Chapter`.
+
+Chapter + Nested Chapter | ChapterFlagEnabled | used
+:------------------------|:-------------------|:----
+Chapter 1                | true               | yes
++Nested Chapter 1.1      | true               | yes
++Nested Chapter 1.2      | false              | no
+++Nested Chapter 1.2.1   | true               | no
+++Nested Chapter 1.2.2   | false              | no
+Chapter 2                | false              | no
++Nested Chapter 2.1      | true               | no
++Nested Chapter 2.2      | true               | no
+
 
 # Matroska Schema
 

--- a/control.md
+++ b/control.md
@@ -91,6 +91,15 @@ Edition 2 | true       | true        |
 Edition 3 | false      | false       | X
 Table: Default edition, some visible, some default{#defaultEditionSomeVisibleSomeDefault}
 
+# Chapter Flags
+
+If a `Control Track` toggles the parent's `ChapterFlagHidden`
+flag to `false`, then only the parent `ChapterAtom` and its second child `ChapterAtom`
+**MUST** be interpreted as if `ChapterFlagHidden` is set to `false`. The first child
+`ChapterAtom`, which has the `ChapterFlagHidden` flag set to `true`, retains its value
+until its value is toggled to `false` by a `Control Track`.
+
+
 # Matroska Schema
 
 Extra elements used to handle Control Tracks and advanced selection features:

--- a/control_elements.xml
+++ b/control_elements.xml
@@ -1,4 +1,9 @@
 <EBMLSchema xmlns="urn:ietf:rfc:8794" docType="matroska" version="4">
+  <element name="EditionFlagHidden" path="\Segment\Chapters\EditionEntry\EditionFlagHidden" id="0x45BD" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set to 1 if an edition is hidden. Hidden editions **SHOULD NOT** be available to the user interface
+(but still to Control Tracks; see (#chapter-flags) on Chapter flags).</documentation>
+    <extension type="webmproject.org" webm="0"/>
+  </element>
   <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">List of tracks on which the chapter applies. If this Element is not present, all tracks apply</documentation>
     <extension type="webmproject.org" webm="0"/>

--- a/control_elements.xml
+++ b/control_elements.xml
@@ -1,0 +1,13 @@
+<EBMLSchema xmlns="urn:ietf:rfc:8794" docType="matroska" version="4">
+  <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">
+    <documentation lang="en" purpose="definition">List of tracks on which the chapter applies. If this Element is not present, all tracks apply</documentation>
+    <extension type="webmproject.org" webm="0"/>
+  </element>
+  <element name="ChapterTrackUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack\ChapterTrackUID" id="0x89" type="uinteger" range="not 0" minOccurs="1">
+    <documentation lang="en" purpose="definition">UID of the Track to apply this chapter to.
+In the absence of a control track, choosing this chapter will select the listed Tracks and deselect unlisted tracks.
+Absence of this Element indicates that the Chapter **SHOULD** be applied to any currently used Tracks.</documentation>
+    <extension type="webmproject.org" webm="0"/>
+    <extension type="libmatroska" cppname="ChapterTrackNumber"/>
+  </element>
+</EBMLSchema>

--- a/control_elements.xml
+++ b/control_elements.xml
@@ -4,6 +4,11 @@
 (but still to Control Tracks; see (#chapter-flags) on Chapter flags).</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
+  <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Set to 1 if the chapter is enabled. It can be enabled/disabled by a Control Track.
+When disabled, the movie **SHOULD** skip all the content between the TimeStart and TimeEnd of this chapter; see (#chapter-flags) on Chapter flags.</documentation>
+    <extension type="webmproject.org" webm="0"/>
+  </element>
   <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">List of tracks on which the chapter applies. If this Element is not present, all tracks apply</documentation>
     <extension type="webmproject.org" webm="0"/>

--- a/diagram.md
+++ b/diagram.md
@@ -170,8 +170,6 @@ points to jump to in video or audio.
 +-----------------------------------------+
 | Chapters | Edition | EditionUID         |
 |          | Entry   |--------------------|
-|          |         | EditionFlagHidden  |
-|          |         |--------------------|
 |          |         | EditionFlagDefault |
 |          |         |--------------------|
 |          |         | EditionFlagOrdered |

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1278,17 +1278,6 @@ If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment
 see (#physical-types) for a complete list of values.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">
-    <documentation lang="en" purpose="definition">List of tracks on which the chapter applies. If this Element is not present, all tracks apply</documentation>
-    <extension type="webmproject.org" webm="0"/>
-  </element>
-  <element name="ChapterTrackUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack\ChapterTrackUID" id="0x89" type="uinteger" range="not 0" minOccurs="1">
-    <documentation lang="en" purpose="definition">UID of the Track to apply this chapter to.
-In the absence of a control track, choosing this chapter will select the listed Tracks and deselect unlisted tracks.
-Absence of this Element indicates that the Chapter **SHOULD** be applied to any currently used Tracks.</documentation>
-    <extension type="webmproject.org" webm="0"/>
-    <extension type="libmatroska" cppname="ChapterTrackNumber"/>
-  </element>
   <element name="ChapterDisplay" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay" id="0x80" type="master">
     <documentation lang="en" purpose="definition">Contains all possible strings to use for the chapter display.</documentation>
     <extension type="webmproject.org" webm="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1253,11 +1253,6 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
 (but still to Control Tracks; see (#chapterflaghidden) on Chapter flags).</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if the chapter is enabled. It can be enabled/disabled by a Control Track.
-When disabled, the movie **SHOULD** skip all the content between the TimeStart and TimeEnd of this chapter; see (#chapterflagenabled) on Chapter flags.</documentation>
-    <extension type="webmproject.org" webm="0"/>
-  </element>
   <element name="ChapterSegmentUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentUID" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1219,11 +1219,6 @@ For more detailed information, look at the Chapters explanation in (#chapters).<
     <documentation lang="en" purpose="definition">A unique ID to identify the edition. It's useful for tagging an edition.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="EditionFlagHidden" path="\Segment\Chapters\EditionEntry\EditionFlagHidden" id="0x45BD" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if an edition is hidden. Hidden editions **SHOULD NOT** be available to the user interface
-(but still to Control Tracks; see (#editionflaghidden) on Chapter flags).</documentation>
-    <extension type="webmproject.org" webm="0"/>
-  </element>
   <element name="EditionFlagDefault" path="\Segment\Chapters\EditionEntry\EditionFlagDefault" id="0x45DB" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if the edition **SHOULD** be used as the default one.</documentation>
     <extension type="webmproject.org" webm="0"/>

--- a/index_control.md
+++ b/index_control.md
@@ -1,0 +1,70 @@
+%%%
+title = "Matroska Media Container Control Track Specifications"
+abbrev = "Matroska Control Track"
+ipr= "trust200902"
+area = "art"
+submissiontype = "IETF"
+workgroup = "cellar"
+date = @BUILD_DATE@
+keyword = ["binary","storage","matroska","ebml","webm","codec"]
+
+[seriesInfo]
+name = "Internet Draft"
+stream = "IETF"
+status = "informational"
+value = "@BUILD_VERSION@"
+
+[[author]]
+initials="S."
+surname="Lhomme"
+fullname="Steve Lhomme"
+[author.address]
+email="slhomme@matroska.org"
+
+[[author]]
+initials="M."
+surname="Bunkus"
+fullname="Moritz Bunkus"
+[author.address]
+email="moritz@bunkus.org"
+
+[[author]]
+initials="D."
+surname="Rice"
+fullname="Dave Rice"
+[author.address]
+email="dave@dericed.com"
+%%%
+
+.# Abstract
+
+This document defines the Control Track usage found in the Matroska container.
+
+{mainmatter}
+
+# Introduction
+
+# Status of this document
+
+This document is a work-in-progress specification defining the Matroska file format as part
+of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
+It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup.
+
+# Security Considerations
+
+This document inherits security considerations from the EBML and Matroska documents.
+
+# IANA Considerations
+
+To be determined.
+
+# Notation and Conventions
+
+The key words "**MUST**", "**MUST NOT**",
+"**REQUIRED**", "**SHALL**", "**SHALL NOT**",
+"**SHOULD**", "**SHOULD NOT**",
+"**RECOMMENDED**", "**NOT RECOMMENDED**",
+"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
+described in BCP 14 [@!RFC2119] [@!RFC8174] 
+when, and only when, they appear in all capitals, as shown here.
+

--- a/rfc_backmatter_control.md
+++ b/rfc_backmatter_control.md
@@ -1,0 +1,2 @@
+
+{backmatter}


### PR DESCRIPTION
The new document is in a dirty state and we may never use it. But it's a way to clean the Control Track reference (an under specified and unused feature) out of the main document.

Fixes #456