### PR TITLE
Add subtitle->audio track linking

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -448,7 +448,7 @@ see [@!I-D.ietf-cellar-codec] for more info.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackOverlay" path="\Segment\Tracks\TrackEntry\TrackOverlay" id="0x6FAB" type="uinteger">
-    <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the Track specified (in the u-integer).
+    <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the Track UID specified (in the u-integer).
 That means when this track has a gap, see (#silenttracks-element) on SilentTracks,
 the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay matters, the first one is the one that **SHOULD** be used.
 If not found it **SHOULD** be the second, etc.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -454,6 +454,12 @@ the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay
 If not found it **SHOULD** be the second, etc.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
+  <element name="TrackLink" path="\Segment\Tracks\TrackEntry\TrackLink" id="0x6FAC" type="uinteger">
+    <documentation lang="en" purpose="definition">Specify that subtitle track is suitable for use with the audio Track UID specified (in the u-integer).
+Multiple subtitle tracks may link to the same audio track, and the same subtitle track may link to multiple audio tracks by providing multiple TrackLink elements.
+</documentation>
+    <extension type="webmproject.org" webm="0"/>
+  </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds.
 This value **MUST** be subtracted from each block timestamp in order to get the actual timestamp.

--- a/notes.md
+++ b/notes.md
@@ -327,6 +327,27 @@ Overlay tracks **SHOULD** be rendered in the same channel as the track its linke
 When content is found in such a track, it **SHOULD** be played on the rendering channel
 instead of the original track.
 
+## Track Links
+
+A track link indicates that a given subtitle track is suitable for use with a given audio track,
+and that it **SHOULD** be eligible for autoselection when that audio track is selected.
+
+For instance:
+- A subtitle track containing a translation of an audio track in another language should be
+  linked to that track, but should not be linked to another audio track featuring a dub
+  into the same language with a different translation.
+  A subtitle track containing a transcription of the dub, if present, should be linked to the dub audio track.
+- A forced subtitle track containing onscreen text consistent with the dialogue in an audio track
+  of the same language should be linked to that track, but should not be linked to another audio track
+  featuring a different translation into the same language.
+- A subtitle track containing a transcription of an audio commentary track should be linked to
+  that audio commentary track, but not to other tracks featuring separate commentary recordings.
+
+Track links are only necessary when the set of tracks available creates ambiguity about which
+subtitles are appropriate for which audio, and function as a hint to the player to improve
+its automatic track selection behavior. In cases where there is no such ambiguity, there is
+no need to explicitly specify track links.
+
 ## Multi-planar and 3D videos
 
 There are two different ways to compress 3D videos: have each eye track in a separate track


### PR DESCRIPTION
Useful for cases where the appropriate tracks are otherwise ambiguous; see added notes.md section for a few examples.

Also clarified that `TrackOverlay` refers to tracks by their UIDs rather than their numbers; as far as I can tell this is the intent, but I can't find anything existing confirming this either way (nor any implementation code), so I could be wrong, but it seems consistent with other elements.

Previously it was suggested that `TrackLink` should go in a dedicated container element with maxOccurs=1, but I don't see any particular technical reason for that, and `TrackOverlay` already allows multiple instances without a container, though I can add one if that's a policy for newly-added elements or something.