### PR TITLE
make BlockGroup\Slices max version 1

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -203,7 +203,7 @@ This information **SHOULD** always be referenced by a seek entry.</documentation
 The duration of DiscardPadding is not calculated in the duration of the TrackEntry and **SHOULD** be discarded during playback.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" maxOccurs="1">
+  <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" maxver="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains slices description.</documentation>
     <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="0"/>


### PR DESCRIPTION
All child elements are either maxver 0 or 1. We don't need to allow it any further.