### PR TITLE
Only use the webm extension to say an element is supported

### DIFF
--- a/control_elements.xml
+++ b/control_elements.xml
@@ -2,22 +2,18 @@
   <element name="EditionFlagHidden" path="\Segment\Chapters\EditionEntry\EditionFlagHidden" id="0x45BD" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if an edition is hidden. Hidden editions **SHOULD NOT** be available to the user interface
 (but still to Control Tracks; see (#chapter-flags) on Chapter flags).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if the chapter is enabled. It can be enabled/disabled by a Control Track.
 When disabled, the movie **SHOULD** skip all the content between the TimeStart and TimeEnd of this chapter; see (#chapter-flags) on Chapter flags.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">List of tracks on which the chapter applies. If this Element is not present, all tracks apply</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTrackUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack\ChapterTrackUID" id="0x89" type="uinteger" range="not 0" minOccurs="1">
     <documentation lang="en" purpose="definition">UID of the Track to apply this chapter to.
 In the absence of a control track, choosing this chapter will select the listed Tracks and deselect unlisted tracks.
 Absence of this Element indicates that the Chapter **SHOULD** be applied to any currently used Tracks.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterTrackNumber"/>
   </element>
 </EBMLSchema>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -25,51 +25,42 @@ A Matroska file is composed of 1 Segment.</documentation>
   <element name="SegmentUID" path="\Segment\Info\SegmentUID" id="0x73A4" type="binary" range="not 0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">A randomly generated unique ID to identify the Segment amongst many others (128 bits).</documentation>
     <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment, then this Element is **REQUIRED**.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="SegmentFilename" path="\Segment\Info\SegmentFilename" id="0x7384" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A filename corresponding to this Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="PrevUID" path="\Segment\Info\PrevUID" id="0x3CB923" type="binary" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">A unique ID to identify the previous Segment of a Linked Segment (128 bits).</documentation>
     <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment that uses Hard Linking,
 then either the PrevUID or the NextUID Element is **REQUIRED**. If a Segment contains a PrevUID but not a NextUID,
 then it **MAY** be considered as the last Segment of the Linked Segment. The PrevUID **MUST NOT** be equal to the SegmentUID.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="PrevFilename" path="\Segment\Info\PrevFilename" id="0x3C83AB" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A filename corresponding to the file of the previous Linked Segment.</documentation>
     <documentation lang="en" purpose="usage notes">Provision of the previous filename is for display convenience,
 but PrevUID **SHOULD** be considered authoritative for identifying the previous Segment in a Linked Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="NextUID" path="\Segment\Info\NextUID" id="0x3EB923" type="binary" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">A unique ID to identify the next Segment of a Linked Segment (128 bits).</documentation>
     <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment that uses Hard Linking,
 then either the PrevUID or the NextUID Element is **REQUIRED**. If a Segment contains a NextUID but not a PrevUID,
 then it **MAY** be considered as the first Segment of the Linked Segment. The NextUID **MUST NOT** be equal to the SegmentUID.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="NextFilename" path="\Segment\Info\NextFilename" id="0x3E83BB" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A filename corresponding to the file of the next Linked Segment.</documentation>
     <documentation lang="en" purpose="usage notes">Provision of the next filename is for display convenience,
 but NextUID **SHOULD** be considered authoritative for identifying the Next Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="SegmentFamily" path="\Segment\Info\SegmentFamily" id="0x4444" type="binary" length="16">
     <documentation lang="en" purpose="definition">A randomly generated unique ID that all Segments of a Linked Segment **MUST** share (128 bits).</documentation>
     <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment that uses Soft Linking, then this Element is **REQUIRED**.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTranslate" path="\Segment\Info\ChapterTranslate" id="0x6924" type="master">
     <documentation lang="en" purpose="definition">A tuple of corresponding ID used by chapter codecs to represent this Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTranslateEditionUID" path="\Segment\Info\ChapterTranslate\ChapterTranslateEditionUID" id="0x69FC" type="uinteger">
     <documentation lang="en" purpose="definition">Specify an edition UID on which this correspondence applies.
 When not specified, it means for all editions found in the Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTranslateCodec" path="\Segment\Info\ChapterTranslate\ChapterTranslateCodec" id="0x69BF" type="uinteger" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
@@ -77,12 +68,10 @@ When not specified, it means for all editions found in the Segment.</documentati
       <enum value="0" label="Matroska Script"/>
       <enum value="1" label="DVD-menu"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterTranslateID" path="\Segment\Info\ChapterTranslate\ChapterTranslateID" id="0x69A5" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary value used to represent this Segment in the chapter codec data.
 The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Timestamp scale in nanoseconds (1.000.000 means all timestamps in the Segment are expressed in milliseconds).</documentation>
@@ -116,19 +105,16 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
   <element name="SilentTracks" path="\Segment\Cluster\SilentTracks" id="0x5854" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">The list of tracks that are not used in that part of the stream.
 It is useful when using overlay tracks on seeking or to decide what track to use.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ClusterSilentTracks"/>
   </element>
   <element name="SilentTrackNumber" path="\Segment\Cluster\SilentTracks\SilentTrackNumber" id="0x58D7" type="uinteger">
     <documentation lang="en" purpose="definition">One of the track number that are not used from now on in the stream.
 It could change later if not specified as silent in a further Cluster.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ClusterSilentTrackNumber"/>
   </element>
   <element name="Position" path="\Segment\Cluster\Position" id="0xA7" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster in the Segment (0 in live streams).
 It might help to resynchronise offset on damaged streams.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ClusterPosition"/>
   </element>
   <element name="PrevSize" path="\Segment\Cluster\PrevSize" id="0xAB" type="uinteger" maxOccurs="1">
@@ -151,7 +137,6 @@ see (#block-structure) on Block Structure.</documentation>
   <element name="BlockVirtual" path="\Segment\Cluster\BlockGroup\BlockVirtual" id="0xA2" type="binary" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A Block with no data. It **MUST** be stored in the stream at the place the real Block would be in display order.
 </documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAdditions" path="\Segment\Cluster\BlockGroup\BlockAdditions" id="0x75A1" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contain additional blocks to complete the main one.
@@ -182,7 +167,6 @@ of this Block and the timestamp of the next Block in "display" order (not coding
   <element name="ReferencePriority" path="\Segment\Cluster\BlockGroup\ReferencePriority" id="0xFA" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">This frame is referenced and has the specified cache priority.
 In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ReferenceBlock" path="\Segment\Cluster\BlockGroup\ReferenceBlock" id="0xFB" type="integer">
     <documentation lang="en" purpose="definition">Timestamp of another frame used as a reference (ie: B or P frame).
@@ -190,12 +174,10 @@ The timestamp is relative to the block it's attached to.</documentation>
   </element>
   <element name="ReferenceVirtual" path="\Segment\Cluster\BlockGroup\ReferenceVirtual" id="0xFD" type="integer" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the data that would otherwise be in position of the virtual block.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecState" path="\Segment\Cluster\BlockGroup\CodecState" id="0xA4" type="binary" minver="2" maxOccurs="1">
     <documentation lang="en" purpose="definition">The new codec state to use. Data interpretation is private to the codec.
 This information **SHOULD** always be referenced by a seek entry.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="DiscardPadding" path="\Segment\Cluster\BlockGroup\DiscardPadding" id="0x75A2" type="integer" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Duration in nanoseconds of the silent data added to the Block
@@ -205,59 +187,48 @@ The duration of DiscardPadding is not calculated in the duration of the TrackEnt
   </element>
   <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains slices description.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TimeSlice" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice" id="0xE8" type="master" maxver="1">
     <documentation lang="en" purpose="definition">Contains extra time information about the data contained in the Block.
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="LaceNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\LaceNumber" id="0xCC" type="uinteger" maxver="1" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The reverse number of the frame in the lace (0 is the last frame, 1 is the next to last, etc).
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="SliceLaceNumber"/>
   </element>
   <element name="FrameNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\FrameNumber" id="0xCD" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The number of the frame to generate from this lace with this delay
 (allow you to generate many frames from the same Block/Frame).</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="SliceFrameNumber"/>
   </element>
   <element name="BlockAdditionID" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\BlockAdditionID" id="0xCB" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The ID of the BlockAdditional Element (0 is the main Block).</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="SliceBlockAddID"/>
   </element>
   <element name="Delay" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\Delay" id="0xCE" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The (scaled) delay to apply to the Element.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="SliceDelay"/>
   </element>
   <element name="SliceDuration" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\SliceDuration" id="0xCF" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The (scaled) duration to apply to the Element.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ReferenceFrame" path="\Segment\Cluster\BlockGroup\ReferenceFrame" id="0xC8" type="master" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains information about the last reference frame. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ReferenceOffset" path="\Segment\Cluster\BlockGroup\ReferenceFrame\ReferenceOffset" id="0xC9" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The relative offset, in bytes, from the previous BlockGroup element for this Smooth FF/RW video track to the containing BlockGroup element. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ReferenceTimestamp" path="\Segment\Cluster\BlockGroup\ReferenceFrame\ReferenceTimestamp" id="0xCA" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The timecode of the BlockGroup pointed to by ReferenceOffset. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ReferenceTimeCode"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="EncryptedBlock" path="\Segment\Cluster\EncryptedBlock" id="0xAF" type="binary" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">Similar to SimpleBlock, see (#simpleblock-structure),
 but the data inside the Block are Transformed (encrypt and/or signed).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="Tracks" path="\Segment\Tracks" id="0x1654AE6B" type="master" maxOccurs="1" recurring="1">
     <documentation lang="en" purpose="definition">A Top-Level Element of information with many tracks described.</documentation>
@@ -304,23 +275,18 @@ See (#default-track-selection) for more details.</documentation>
   </element>
   <element name="FlagHearingImpaired" path="\Segment\Tracks\TrackEntry\FlagHearingImpaired" id="0x55AB" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if that track is suitable for users with hearing impairments, set to 0 if it is unsuitable for users with hearing impairments.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FlagVisualImpaired" path="\Segment\Tracks\TrackEntry\FlagVisualImpaired" id="0x55AC" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if that track is suitable for users with visual impairments, set to 0 if it is unsuitable for users with visual impairments.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FlagTextDescriptions" path="\Segment\Tracks\TrackEntry\FlagTextDescriptions" id="0x55AD" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if that track contains textual descriptions of video content, set to 0 if that track does not contain textual descriptions of video content.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FlagOriginal" path="\Segment\Tracks\TrackEntry\FlagOriginal" id="0x55AE" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if that track is in the content's original language, set to 0 if it is a translation.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FlagCommentary" path="\Segment\Tracks\TrackEntry\FlagCommentary" id="0x55AF" type="uinteger" range="0-1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if that track contains commentary, set to 0 if it does not contain commentary.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if the track **MAY** contain blocks using lacing.</documentation>
@@ -329,13 +295,11 @@ See (#default-track-selection) for more details.</documentation>
   <element name="MinCache" path="\Segment\Tracks\TrackEntry\MinCache" id="0x6DE7" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The minimum number of frames a player **SHOULD** be able to cache during playback.
 If set to 0, the reference pseudo-cache system is not used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="TrackMinCache"/>
   </element>
   <element name="MaxCache" path="\Segment\Tracks\TrackEntry\MaxCache" id="0x6DF8" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The maximum cache size necessary to store referenced frames in and the current frame.
 0 means no cache is needed.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="TrackMaxCache"/>
   </element>
   <element name="DefaultDuration" path="\Segment\Tracks\TrackEntry\DefaultDuration" id="0x23E383" type="uinteger" range="not 0" maxOccurs="1">
@@ -346,51 +310,42 @@ If set to 0, the reference pseudo-cache system is not used.</documentation>
   <element name="DefaultDecodedFieldDuration" path="\Segment\Tracks\TrackEntry\DefaultDecodedFieldDuration" id="0x234E7A" type="uinteger" minver="4" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The period in nanoseconds (not scaled by TimestampScale) between two successive fields at the output of the decoding process,
 see (#defaultdecodedfieldduration) for more information</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="TrackDefaultDecodedFieldDuration"/>
   </element>
   <element name="TrackTimestampScale" path="\Segment\Tracks\TrackEntry\TrackTimestampScale" id="0x23314F" type="float" maxver="3" range="&gt; 0x0p+0" default="0x1p+0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">DEPRECATED, DO NOT USE. The scale to apply on this track to work at normal speed in relation with other tracks
 (mostly used to adjust video speed when the audio length differs).</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="TrackTimecodeScale"/>
   </element>
   <element name="TrackOffset" path="\Segment\Tracks\TrackEntry\TrackOffset" id="0x537F" type="integer" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A value to add to the Block's Timestamp.
 This can be used to adjust the playback offset of a track.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="MaxBlockAdditionID" path="\Segment\Tracks\TrackEntry\MaxBlockAdditionID" id="0x55EE" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The maximum value of BlockAddID ((#blockaddid-element)).
 A value 0 means there is no BlockAdditions ((#blockadditions-element)) for this track.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAdditionMapping" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping" id="0x41E4" type="master" minver="4">
     <documentation lang="en" purpose="definition">Contains elements that extend the track format, by adding content either to each frame,
 with BlockAddID ((#blockaddid-element)), or to the track as a whole
 with BlockAddIDExtraData.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" maxOccurs="1" minver="4" range=">=2">
     <documentation lang="en" purpose="definition">If the track format extension needs content beside frames,
 the value refers to the BlockAddID ((#blockaddid-element)), value being described.
 To keep MaxBlockAdditionID as low as possible, small values **SHOULD** be used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAddIDName" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName" id="0x41A4" type="string" maxOccurs="1" minver="4">
     <documentation lang="en" purpose="definition">A human-friendly name describing the type of BlockAdditional data,
 as defined by the associated Block Additional Mapping.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAddIDType" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDType" id="0x41E7" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" default="0">
     <documentation lang="en" purpose="definition">Stores the registered identifer of the Block Additional Mapping
 to define how the BlockAdditional data should be handled.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="BlockAddIDExtraData" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDExtraData" id="0x41ED" type="binary" maxOccurs="1" minver="4">
     <documentation lang="en" purpose="definition">Extra binary data that the BlockAddIDType can use to interpret the BlockAdditional data.
 The intepretation of the binary data depends on the BlockAddIDType value and the corresponding Block Additional Mapping.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="Name" path="\Segment\Tracks\TrackEntry\Name" id="0x536E" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A human-readable track name.</documentation>
@@ -406,7 +361,6 @@ This Element **MUST** be ignored if the LanguageIETF Element is used in the same
     <documentation lang="en" purpose="definition">Specifies the language of the track according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any Language Elements used in the same TrackEntry **MUST** be ignored.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecID" path="\Segment\Tracks\TrackEntry\CodecID" id="0x86" type="string" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">An ID corresponding to the codec,
@@ -420,31 +374,25 @@ see [@!I-D.ietf-cellar-codec] for more info.</documentation>
   </element>
   <element name="AttachmentLink" path="\Segment\Tracks\TrackEntry\AttachmentLink" id="0x7446" type="uinteger" maxver="3" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The UID of an attachment that is used by this codec.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="TrackAttachmentLink"/>
   </element>
   <element name="CodecSettings" path="\Segment\Tracks\TrackEntry\CodecSettings" id="0x3A9697" type="utf-8" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A string describing the encoding setting used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecInfoURL" path="\Segment\Tracks\TrackEntry\CodecInfoURL" id="0x3B4040" type="string" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">A URL to find information about the codec used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecDownloadURL" path="\Segment\Tracks\TrackEntry\CodecDownloadURL" id="0x26B240" type="string" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">A URL to download about the codec used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecDecodeAll" path="\Segment\Tracks\TrackEntry\CodecDecodeAll" id="0xAA" type="uinteger" minver="2" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The codec can decode potentially damaged data.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackOverlay" path="\Segment\Tracks\TrackEntry\TrackOverlay" id="0x6FAB" type="uinteger">
     <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the Track specified (in the u-integer).
 That means when this track has a gap, see (#silenttracks-element) on SilentTracks,
 the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay matters, the first one is the one that **SHOULD** be used.
 If not found it **SHOULD** be the second, etc.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds.
@@ -459,12 +407,10 @@ the decoder **MUST** decode before the decoded data is valid.</documentation>
   </element>
   <element name="TrackTranslate" path="\Segment\Tracks\TrackEntry\TrackTranslate" id="0x6624" type="master">
     <documentation lang="en" purpose="definition">The track identification for the given Chapter Codec.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackTranslateEditionUID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateEditionUID" id="0x66FC" type="uinteger">
     <documentation lang="en" purpose="definition">Specify an edition UID on which this translation applies. When not specified,
 it means for all editions found in the Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackTranslateCodec" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateCodec" id="0x66BF" type="uinteger" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
@@ -472,12 +418,10 @@ it means for all editions found in the Segment.</documentation>
       <enum value="0" label="Matroska Script"/>
       <enum value="1" label="DVD-menu"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackTranslateTrackID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateTrackID" id="0x66A5" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary value used to represent this track in the chapter codec data.
 The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="Video" path="\Segment\Tracks\TrackEntry\Video" id="0xE0" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Video settings.</documentation>
@@ -515,7 +459,6 @@ with the top line of the top field stored first.</documentation>
 with the top line of the top field stored first.</documentation>
       </enum>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="VideoFieldOrder"/>
   </element>
   <element name="StereoMode" path="\Segment\Tracks\TrackEntry\Video\StereoMode" id="0x53B8" type="uinteger" minver="3" default="0" maxOccurs="1">
@@ -554,7 +497,6 @@ the BlockAdditional Element could contain Alpha data.</documentation>
       <enum value="2" label="left eye"/>
       <enum value="3" label="both eyes"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="PixelWidth" path="\Segment\Tracks\TrackEntry\Video\PixelWidth" id="0xB0" type="uinteger" range="not 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Width of the encoded video frames in pixels.</documentation>
@@ -616,17 +558,14 @@ PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</i
     <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC.
 This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
     <implementation_note note_attribute="minOccurs">ColourSpace **MUST** be set (minOccurs=1) in TrackEntry, when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="VideoColourSpace"/>
   </element>
   <element name="GammaValue" path="\Segment\Tracks\TrackEntry\Video\GammaValue" id="0x2FB523" type="float" minver="0" maxver="0" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Gamma Value.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="VideoGamma"/>
   </element>
   <element name="FrameRate" path="\Segment\Tracks\TrackEntry\Video\FrameRate" id="0x2383E3" type="float" minver="0" maxver="0" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Number of frames per second. This value is Informational only. It is intended for constant frame rate streams, and SHOULD NOT be used for a variable frame rate TrackEntry.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="VideoFrameRate"/>
   </element>
   <element name="Colour" path="\Segment\Tracks\TrackEntry\Video\Colour" id="0x55B0" type="master" minver="4" maxOccurs="1">
@@ -914,7 +853,6 @@ The value of this field should be in the -180 to 180 degree range.</documentatio
   </element>
   <element name="ChannelPositions" path="\Segment\Tracks\TrackEntry\Audio\ChannelPositions" id="0x7D7B" type="binary" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Table of horizontal angles for each successive channel.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="AudioPosition"/>
   </element>
   <element name="BitDepth" path="\Segment\Tracks\TrackEntry\Audio\BitDepth" id="0x6264" type="uinteger" range="not 0" maxOccurs="1">
@@ -924,19 +862,15 @@ The value of this field should be in the -180 to 180 degree range.</documentatio
   <element name="TrackOperation" path="\Segment\Tracks\TrackEntry\TrackOperation" id="0xE2" type="master" minver="3" maxOccurs="1">
     <documentation lang="en" purpose="definition">Operation that needs to be applied on tracks to create this virtual track.
 For more details look at (#track-operation).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackCombinePlanes" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes" id="0xE3" type="master" minver="3" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the list of all video plane tracks that need to be combined to create this 3D track</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackPlane" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes\TrackPlane" id="0xE4" type="master" minver="3" minOccurs="1">
     <documentation lang="en" purpose="definition">Contains a video plane track that need to be combined to create this 3D track</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackPlaneUID" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes\TrackPlane\TrackPlaneUID" id="0xE5" type="uinteger" minver="3" range="not 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The trackUID number of the track representing the plane.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackPlaneType" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes\TrackPlane\TrackPlaneType" id="0xE6" type="uinteger" minver="3" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The kind of plane this track corresponds to.</documentation>
@@ -945,40 +879,32 @@ For more details look at (#track-operation).</documentation>
       <enum value="1" label="right eye"/>
       <enum value="2" label="background"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackJoinBlocks" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackJoinBlocks" id="0xE9" type="master" minver="3" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the list of all tracks whose Blocks need to be combined to create this virtual track</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrackJoinUID" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackJoinBlocks\TrackJoinUID" id="0xED" type="uinteger" minver="3" range="not 0" minOccurs="1">
     <documentation lang="en" purpose="definition">The trackUID number of a track whose blocks are used to create this virtual track.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TrickTrackUID" path="\Segment\Tracks\TrackEntry\TrickTrackUID" id="0xC0" type="uinteger" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The TrackUID of the Smooth FF/RW video in the paired EBML structure corresponding to this video track. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="TrickTrackSegmentUID" path="\Segment\Tracks\TrackEntry\TrickTrackSegmentUID" id="0xC1" type="binary" minver="0" maxver="0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of the Segment containing the track identified by TrickTrackUID. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="TrickTrackFlag" path="\Segment\Tracks\TrackEntry\TrickTrackFlag" id="0xC6" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if this video track is a Smooth FF/RW track. If set to 1, MasterTrackUID and MasterTrackSegUID should must be present and BlockGroups for this track must contain ReferenceFrame structures.
 Otherwise, TrickTrackUID and TrickTrackSegUID must be present if this track has a corresponding Smooth FF/RW track. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="TrickMasterTrackUID" path="\Segment\Tracks\TrackEntry\TrickMasterTrackUID" id="0xC7" type="uinteger" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The TrackUID of the video track in the paired EBML structure that corresponds to this Smooth FF/RW track. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="TrickMasterTrackSegmentUID" path="\Segment\Tracks\TrackEntry\TrickMasterTrackSegmentUID" id="0xC4" type="binary" minver="0" maxver="0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of the Segment containing the track identified by MasterTrackUID. See [@?DivXTrickTrack].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ContentEncodings" path="\Segment\Tracks\TrackEntry\ContentEncodings" id="0x6D80" type="master" maxOccurs="1">
@@ -1017,7 +943,6 @@ Values (big-endian) can be OR'ed.</documentation>
     <documentation lang="en" purpose="definition">Settings describing the compression used.
 This Element **MUST** be present if the value of ContentEncodingType is 0 and absent otherwise.
 Each block **MUST** be decompressable even if no previous block is available in order not to prevent seeking.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentCompAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentCompression\ContentCompAlgo" id="0x4254" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The compression algorithm used.</documentation>
@@ -1027,12 +952,10 @@ Each block **MUST** be decompressable even if no previous block is available in 
       <enum value="2" label="lzo1x"/>
       <enum value="3" label="Header Stripping"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentCompSettings" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentCompression\ContentCompSettings" id="0x4255" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">Settings that might be needed by the decompressor. For Header Stripping (`ContentCompAlgo`=3),
 the bytes that were removed from the beginning of each frames of the track.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentEncryption" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption" id="0x5035" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Settings describing the encryption used.
@@ -1071,11 +994,9 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
   </element>
   <element name="ContentSignature" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSignature" id="0x47E3" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">A cryptographic signature of the contents.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentSigKeyID" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigKeyID" id="0x47E4" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">This is the ID of the private key the data was signed with.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentSigAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigAlgo" id="0x47E5" type="uinteger" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The algorithm used for the signature.</documentation>
@@ -1083,7 +1004,6 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
       <enum value="0" label="Not signed"/>
       <enum value="1" label="RSA"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ContentSigHashAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigHashAlgo" id="0x47E6" type="uinteger" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The hash algorithm used for the signature.</documentation>
@@ -1092,7 +1012,6 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
       <enum value="1" label="SHA1-160"/>
       <enum value="2" label="MD5"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="Cues" path="\Segment\Cues" id="0x1C53BB6B" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">A Top-Level Element to speed seeking access.
@@ -1130,71 +1049,55 @@ If missing the track's DefaultDuration does not apply and no duration informatio
   <element name="CueCodecState" path="\Segment\Cues\CuePoint\CueTrackPositions\CueCodecState" id="0xEA" type="uinteger" minver="2" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Codec State corresponding to this Cue Element.
 0 means that the data is taken from the initial Track Entry.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CueReference" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference" id="0xDB" type="master" minver="2">
     <documentation lang="en" purpose="definition">The Clusters containing the referenced Blocks.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CueRefTime" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefTime" id="0x96" type="uinteger" minver="2" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Timestamp of the referenced Block.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CueRefCluster" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefCluster" id="0x97" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster containing the referenced Block.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CueRefNumber" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefNumber" id="0x535F" type="uinteger" minver="0" maxver="0" range="not 0" default="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Number of the referenced Block of Track X in the specified Cluster.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="CueRefCodecState" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefCodecState" id="0xEB" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Codec State corresponding to this referenced Element.
 0 means that the data is taken from the initial Track Entry.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="Attachments" path="\Segment\Attachments" id="0x1941A469" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contain attached files.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="AttachedFile" path="\Segment\Attachments\AttachedFile" id="0x61A7" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">An attached file.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="Attached"/>
   </element>
   <element name="FileDescription" path="\Segment\Attachments\AttachedFile\FileDescription" id="0x467E" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A human-friendly name for the attached file.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FileName" path="\Segment\Attachments\AttachedFile\FileName" id="0x466E" type="utf-8" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Filename of the attached file.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FileMimeType" path="\Segment\Attachments\AttachedFile\FileMimeType" id="0x4660" type="string" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">MIME type of the file.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="MimeType"/>
   </element>
   <element name="FileData" path="\Segment\Attachments\AttachedFile\FileData" id="0x465C" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The data of the file.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FileUID" path="\Segment\Attachments\AttachedFile\FileUID" id="0x46AE" type="uinteger" range="not 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Unique ID representing the file, as random as possible.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FileReferral" path="\Segment\Attachments\AttachedFile\FileReferral" id="0x4675" type="binary" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A binary value that a track/codec can refer to when the attachment is needed.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="FileUsedStartTime" path="\Segment\Attachments\AttachedFile\FileUsedStartTime" id="0x4661" type="uinteger" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The timecode at which this optimized font attachment comes into context, based on the Segment TimecodeScale. This element is reserved for future use and if written must be the segment start time. See [@?DivXWorldFonts].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="FileUsedEndTime" path="\Segment\Attachments\AttachedFile\FileUsedEndTime" id="0x4662" type="uinteger" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The timecode at which this optimized font attachment goes out of context, based on the Segment TimecodeScale. This element is reserved for future use and if written must be the segment end time. See [@?DivXWorldFonts].</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="Chapters" path="\Segment\Chapters" id="0x1043A770" type="master" maxOccurs="1" recurring="1">
@@ -1208,15 +1111,12 @@ For more detailed information, look at the Chapters explanation in (#chapters).<
   </element>
   <element name="EditionUID" path="\Segment\Chapters\EditionEntry\EditionUID" id="0x45BC" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A unique ID to identify the edition. It's useful for tagging an edition.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="EditionFlagDefault" path="\Segment\Chapters\EditionEntry\EditionFlagDefault" id="0x45DB" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if the edition **SHOULD** be used as the default one.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="EditionFlagOrdered" path="\Segment\Chapters\EditionEntry\EditionFlagOrdered" id="0x45DD" type="uinteger" range="0-1" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify if the chapters can be defined multiple times and the order to play them is enforced.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterAtom" path="\Segment\Chapters\EditionEntry\+ChapterAtom" id="0xB6" type="master" minOccurs="1" recursive="1">
     <documentation lang="en" purpose="definition">Contains the atom information to use as the chapter atom (apply to all tracks).</documentation>
@@ -1243,22 +1143,18 @@ The value **MUST** be strictly greater than the `ChapterTimeStart` of the same `
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Set to 1 if a chapter is hidden. Hidden chapters it **SHOULD NOT** be available to the user interface
 (but still to Control Tracks; see (#chapterflaghidden) on Chapter flags).</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterSegmentUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentUID" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The EditionUID to play from the Segment linked in ChapterSegmentUID.
 If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment is used.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterPhysicalEquiv" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterPhysicalEquiv" id="0x63C3" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the physical equivalent of this ChapterAtom like "DVD" (60) or "SIDE" (50);
 see (#physical-types) for a complete list of values.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapterDisplay" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay" id="0x80" type="master">
     <documentation lang="en" purpose="definition">Contains all possible strings to use for the chapter display.</documentation>
@@ -1280,7 +1176,6 @@ This Element **MUST** be ignored if the ChapLanguageIETF Element is used within 
     <documentation lang="en" purpose="definition">Specifies the language used in the ChapString according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any ChapLanguage Elements used in the same ChapterDisplay **MUST** be ignored.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="ChapCountry" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapCountry" id="0x437E" type="string">
     <documentation lang="en" purpose="definition">The countries corresponding to the string, same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
@@ -1290,25 +1185,21 @@ This Element **MUST** be ignored if the ChapLanguageIETF Element is used within 
   </element>
   <element name="ChapProcess" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess" id="0x6944" type="master">
     <documentation lang="en" purpose="definition">Contains all the commands associated to the Atom.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcess"/>
   </element>
   <element name="ChapProcessCodecID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCodecID" id="0x6955" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the type of the codec used for the processing.
 A value of 0 means native Matroska processing (to be defined), a value of 1 means the DVD command set is used; see (#menu-features) on DVD menus.
 More codec IDs can be added later.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcessCodecID"/>
   </element>
   <element name="ChapProcessPrivate" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessPrivate" id="0x450D" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">Some optional data attached to the ChapProcessCodecID information.
     For ChapProcessCodecID = 1, it is the "DVD level" equivalent; see (#menu-features) on DVD menus.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcessPrivate"/>
   </element>
   <element name="ChapProcessCommand" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCommand" id="0x6911" type="master">
     <documentation lang="en" purpose="definition">Contains all the commands associated to the Atom.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcessCommand"/>
   </element>
   <element name="ChapProcessTime" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCommand\ChapProcessTime" id="0x6922" type="uinteger" minOccurs="1" maxOccurs="1">
@@ -1318,14 +1209,12 @@ More codec IDs can be added later.</documentation>
       <enum value="1" label="before starting playback"/>
       <enum value="2" label="after playback of the chapter"/>
     </restriction>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcessTime"/>
   </element>
   <element name="ChapProcessData" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCommand\ChapProcessData" id="0x6933" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the command information.
 The data **SHOULD** be interpreted depending on the ChapProcessCodecID value. For ChapProcessCodecID = 1,
 the data correspond to the binary DVD cell pre/post commands; see (#menu-features) on DVD menus.</documentation>
-    <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="ChapterProcessData"/>
   </element>
   <element name="Tags" path="\Segment\Tags" id="0x1254C367" type="master">
@@ -1409,17 +1298,14 @@ If the value is 0 at this level, the tags apply to all tracks in the Segment.</d
   <element name="TagEditionUID" path="\Segment\Tags\Tag\Targets\TagEditionUID" id="0x63C9" type="uinteger" default="0">
     <documentation lang="en" purpose="definition">A unique ID to identify the EditionEntry(s) the tags belong to.
 If the value is 0 at this level, the tags apply to all editions in the Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TagChapterUID" path="\Segment\Tags\Tag\Targets\TagChapterUID" id="0x63C4" type="uinteger" default="0">
     <documentation lang="en" purpose="definition">A unique ID to identify the Chapter(s) the tags belong to.
 If the value is 0 at this level, the tags apply to all chapters in the Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TagAttachmentUID" path="\Segment\Tags\Tag\Targets\TagAttachmentUID" id="0x63C6" type="uinteger" default="0">
     <documentation lang="en" purpose="definition">A unique ID to identify the Attachment(s) the tags belong to.
 If the value is 0 at this level, the tags apply to all the attachments in the Segment.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="SimpleTag" path="\Segment\Tags\Tag\+SimpleTag" id="0x67C8" type="master" minOccurs="1" recursive="1">
     <documentation lang="en" purpose="definition">Contains general information about the target.</documentation>
@@ -1441,7 +1327,6 @@ This Element **MUST** be ignored if the TagLanguageIETF Element is used within t
     <documentation lang="en" purpose="definition">Specifies the language used in the TagString according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any TagLanguage Elements used in the same SimpleTag **MUST** be ignored.</documentation>
-    <extension type="webmproject.org" webm="0"/>
   </element>
   <element name="TagDefault" path="\Segment\Tags\Tag\+SimpleTag\TagDefault" id="0x4484" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">A boolean value to indicate if this is the default/original language to use for the given tag.</documentation>


### PR DESCRIPTION
An element is either supported or not. We only need one version in our file.
And it makes more sense to tell the elements that are in WebM than list all the
ones that are not.