### PR TITLE
mark strings with no default value as not usable if empty

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -385,7 +385,7 @@ the value refers to the BlockAddID ((#blockaddid-element)), value being describe
 To keep MaxBlockAdditionID as low as possible, small values **SHOULD** be used.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="BlockAddIDName" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName" id="0x41A4" type="string" maxOccurs="1" minver="4">
+  <element name="BlockAddIDName" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName" id="0x41A4" type="string" length="&gt; 0" maxOccurs="1" minver="4">
     <documentation lang="en" purpose="definition">A human-friendly name describing the type of BlockAdditional data,
 as defined by the associated Block Additional Mapping.</documentation>
     <extension type="webmproject.org" webm="0"/>
@@ -410,13 +410,13 @@ see (#language-codes) on language codes.
 This Element **MUST** be ignored if the LanguageIETF Element is used in the same TrackEntry.</documentation>
     <extension type="libmatroska" cppname="TrackLanguage"/>
   </element>
-  <element name="LanguageIETF" path="\Segment\Tracks\TrackEntry\LanguageIETF" id="0x22B59D" type="string" minver="4" maxOccurs="1">
+  <element name="LanguageIETF" path="\Segment\Tracks\TrackEntry\LanguageIETF" id="0x22B59D" type="string" length="&gt; 0" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specifies the language of the track according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any Language Elements used in the same TrackEntry **MUST** be ignored.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="CodecID" path="\Segment\Tracks\TrackEntry\CodecID" id="0x86" type="string" minOccurs="1" maxOccurs="1">
+  <element name="CodecID" path="\Segment\Tracks\TrackEntry\CodecID" id="0x86" type="string" length="&gt; 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">An ID corresponding to the codec,
 see [@!I-D.ietf-cellar-codec] for more info.</documentation>
   </element>
@@ -435,11 +435,11 @@ see [@!I-D.ietf-cellar-codec] for more info.</documentation>
     <documentation lang="en" purpose="definition">A string describing the encoding setting used.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="CodecInfoURL" path="\Segment\Tracks\TrackEntry\CodecInfoURL" id="0x3B4040" type="string" minver="0" maxver="0">
+  <element name="CodecInfoURL" path="\Segment\Tracks\TrackEntry\CodecInfoURL" id="0x3B4040" type="string" length="&gt; 0" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">A URL to find information about the codec used.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="CodecDownloadURL" path="\Segment\Tracks\TrackEntry\CodecDownloadURL" id="0x26B240" type="string" minver="0" maxver="0">
+  <element name="CodecDownloadURL" path="\Segment\Tracks\TrackEntry\CodecDownloadURL" id="0x26B240" type="string" length="&gt; 0" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">A URL to download about the codec used.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
@@ -1179,7 +1179,7 @@ If missing the track's DefaultDuration does not apply and no duration informatio
     <documentation lang="en" purpose="definition">Filename of the attached file.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="FileMimeType" path="\Segment\Attachments\AttachedFile\FileMimeType" id="0x4660" type="string" minOccurs="1" maxOccurs="1">
+  <element name="FileMimeType" path="\Segment\Attachments\AttachedFile\FileMimeType" id="0x4660" type="string" length="&gt; 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">MIME type of the file.</documentation>
     <extension type="webmproject.org" webm="0"/>
     <extension type="libmatroska" cppname="MimeType"/>
@@ -1306,13 +1306,13 @@ This Element **MUST** be ignored if the ChapLanguageIETF Element is used within 
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="ChapterLanguage"/>
   </element>
-  <element name="ChapLanguageIETF" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapLanguageIETF" id="0x437D" type="string" minver="4">
+  <element name="ChapLanguageIETF" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapLanguageIETF" id="0x437D" type="string" length="&gt; 0" minver="4">
     <documentation lang="en" purpose="definition">Specifies the language used in the ChapString according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any ChapLanguage Elements used in the same ChapterDisplay **MUST** be ignored.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ChapCountry" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapCountry" id="0x437E" type="string">
+  <element name="ChapCountry" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapCountry" id="0x437E" type="string" length="&gt; 0">
     <documentation lang="en" purpose="definition">The countries corresponding to the string, same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
 This Element **MUST** be ignored if the ChapLanguageIETF Element is used within the same ChapterDisplay Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -1401,7 +1401,7 @@ If empty or not present, then the Tag describes everything in the Segment.</docu
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="TagTargetTypeValue"/>
   </element>
-  <element name="TargetType" path="\Segment\Tags\Tag\Targets\TargetType" id="0x63CA" type="string" maxOccurs="1">
+  <element name="TargetType" path="\Segment\Tags\Tag\Targets\TargetType" id="0x63CA" type="string" length="&gt; 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">An informational string that can be used to display the logical level of the target like "ALBUM", "TRACK", "MOVIE", "CHAPTER", etc
 ; see Section 6.4 of [@!I-D.ietf-cellar-tags].</documentation>
     <restriction>
@@ -1467,7 +1467,7 @@ This Element **MUST** be ignored if the TagLanguageIETF Element is used within t
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="TagLangue"/>
   </element>
-  <element name="TagLanguageIETF" path="\Segment\Tags\Tag\+SimpleTag\TagLanguageIETF" id="0x447B" type="string" minver="4" maxOccurs="1">
+  <element name="TagLanguageIETF" path="\Segment\Tags\Tag\+SimpleTag\TagLanguageIETF" id="0x447B" type="string" length="&gt; 0" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specifies the language used in the TagString according to [@!BCP47]
 and using the IANA Language Subtag Registry [@!IANALangRegistry].
 If this Element is used, then any TagLanguage Elements used in the same SimpleTag **MUST** be ignored.</documentation>


### PR DESCRIPTION
Wether it's a mandatory or non-mandatory element, if a string has no default
value, and it's written in the file it should have a value, otherwise don't write
it.

For mandatory an empty string could be a way cancel the default value. But we
allow it for elements with a default value.

It may be legal in EBML to write empty strings for some reason, but
we don't have the use case in Matroska.