### PR TITLE
add a stronger normative range for the ProjectionPose values

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -881,8 +881,8 @@ redundant framing information while preserving versioning and semantics between 
     <documentation lang="en" purpose="definition">Specifies a yaw rotation to the projection.
 
 Value represents a clockwise rotation, in degrees, around the up vector. This rotation must be applied
-before any `ProjectionPosePitch` or `ProjectionPoseRoll` rotations.
-The value of this field should be in the -180 to 180 degree range.</documentation>
+before any `ProjectionPosePitch` or `ProjectionPoseRoll` rotations.</documentation>
+<documentation lang="en" purpose="usage notes">The value of this field **MUST** be in the -180 to 180 degree range, both included.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoProjectionPoseYaw"/>
   </element>
@@ -890,8 +890,8 @@ The value of this field should be in the -180 to 180 degree range.</documentatio
     <documentation lang="en" purpose="definition">Specifies a pitch rotation to the projection.
 
 Value represents a counter-clockwise rotation, in degrees, around the right vector. This rotation must be applied
-after the `ProjectionPoseYaw` rotation and before the `ProjectionPoseRoll` rotation.
-The value of this field should be in the -90 to 90 degree range.</documentation>
+after the `ProjectionPoseYaw` rotation and before the `ProjectionPoseRoll` rotation.</documentation>
+<documentation lang="en" purpose="usage notes">The value of this field **MUST** be in the -90 to 90 degree range, both included.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoProjectionPosePitch"/>
   </element>
@@ -899,8 +899,8 @@ The value of this field should be in the -90 to 90 degree range.</documentation>
     <documentation lang="en" purpose="definition">Specifies a roll rotation to the projection.
 
 Value represents a counter-clockwise rotation, in degrees, around the forward vector. This rotation must be applied
-after the `ProjectionPoseYaw` and `ProjectionPosePitch` rotations.
-The value of this field should be in the -180 to 180 degree range.</documentation>
+after the `ProjectionPoseYaw` and `ProjectionPosePitch` rotations.</documentation>
+<documentation lang="en" purpose="usage notes">The value of this field **MUST** be in the -180 to 180 degree range, both included.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoProjectionPoseRoll"/>
   </element>


### PR DESCRIPTION
Fixes #480

Unfortunately the range attribute format may not be precise enough to declare which boundaries are included or excluded and might be tricky with signed values. Plus float in hexa is not very readable so we need a proper text value anyway.

Will collide with #466 