### PR TITLE
Move the deprecated elements at the end of the specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bootstrap.mak
 ebml_matroska_elements.md
 ebml_matroska_elements4rfc.md
 control_elements4rfc.md
+*_deprecated4rfc.md
 matroska_tagging_registry.md
 control_xsd.xml
 matroska_xsd.xml

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,13 @@ check: matroska_xsd.xml control_xsd.xml $(EBML_SCHEMA_XSD)
 ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl matroska_xsd.xml > $@
 
+matroska_deprecated4rfc.md: transforms/ebml_schema2markdown4deprecated.xsl matroska_xsd.xml
+	xsltproc transforms/ebml_schema2markdown4deprecated.xsl matroska_xsd.xml > $@
+
 control_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml > $@
 
-$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md notes.md chapters.md attachments.md cues.md streaming.md iana.md rfc_backmatter_matroska.md
+$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md notes.md chapters.md attachments.md cues.md streaming.md iana.md matroska_deprecated4rfc.md rfc_backmatter_matroska.md
 	cat $^ | sed -e '/^---/,/^---/d' \
 	             -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_MATROSKA)/" > $@

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_
 control_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4rfc.xsl control_xsd.xml > $@
 
-$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md notes.md chapters.md attachments.md cues.md streaming.md rfc_backmatter_matroska.md
+$(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md notes.md chapters.md attachments.md cues.md streaming.md iana.md rfc_backmatter_matroska.md
 	cat $^ | sed -e '/^---/,/^---/d' \
 	             -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_MATROSKA)/" > $@

--- a/iana.md
+++ b/iana.md
@@ -1,0 +1,5 @@
+# IANA Considerations
+
+## Matroska Element IDs Registry
+
+## ChapterCodecID Registry

--- a/iana.md
+++ b/iana.md
@@ -3,3 +3,13 @@
 ## Matroska Element IDs Registry
 
 ## ChapterCodecID Registry
+
+## Historic Deprecated Element IDs Registry
+
+As Matroska evolved since 2002 many parts that were considered for use in the format were never
+used and often incorrectly designed. Many of the elements that were then defined are not
+found in any known files but were part of public specs. DivX also had a few custom elements that
+were designed for custom features.
+
+We list these elements that have a known ID that **SHOULD** not be reused to avoid colliding
+with existing files.

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -91,10 +91,6 @@ Attacks on a `Matroska Reader` could include:
   check that the data adheres to expectations.
 - A `Matroska Attachment` with an inaccurate mime-type.
 
-# IANA Considerations
-
-To be determined.
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",

--- a/transforms/ebml_schema2markdown4deprecated.xsl
+++ b/transforms/ebml_schema2markdown4deprecated.xsl
@@ -10,11 +10,6 @@
      <xsl:text>### </xsl:text>
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
-    <xsl:if test="@name">
-      <xsl:text>name:&#xa;: </xsl:text>
-      <xsl:value-of select="@name"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
     <xsl:if test="@path">
       <xsl:text>path:&#xa;: `</xsl:text>
       <xsl:value-of select="@path"/>

--- a/transforms/ebml_schema2markdown4deprecated.xsl
+++ b/transforms/ebml_schema2markdown4deprecated.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:str="http://exslt.org/strings" xmlns:ebml="urn:ietf:rfc:8794" >
+  <xsl:output encoding="UTF-8" method="text" version="1.0" indent="yes"/>
+  <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'"/>
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+  <xsl:template match="ebml:EBMLSchema">
+    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and @maxver='0']"/>
+  </xsl:template>
+  <xsl:template match="ebml:element">
+     <xsl:text>### </xsl:text>
+    <xsl:value-of select="@name"/>
+    <xsl:text> Element&#xa;&#xa;</xsl:text>
+    <xsl:if test="@name">
+      <xsl:text>name:&#xa;: </xsl:text>
+      <xsl:value-of select="@name"/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@path">
+      <xsl:text>path:&#xa;: `</xsl:text>
+      <xsl:value-of select="@path"/>
+      <xsl:text>`&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@id">
+      <xsl:text>id:&#xa;: </xsl:text>
+      <xsl:value-of select="@id"/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@type">
+      <xsl:text>type:&#xa;: </xsl:text>
+      <xsl:value-of select="@type"/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:for-each select="ebml:documentation">
+      <xsl:choose>
+        <xsl:when test="@purpose">
+          <xsl:value-of select="@purpose"/>
+        </xsl:when>
+        <xsl:otherwise>documentation</xsl:otherwise>
+      </xsl:choose>
+      <xsl:text>:&#xa;: </xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:for-each>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+</xsl:stylesheet>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -4,7 +4,7 @@
   <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'"/>
   <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
   <xsl:template match="ebml:EBMLSchema">
-    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment')]"/>
+    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and not(@maxver='0')]"/>
   </xsl:template>
   <xsl:template match="ebml:element">
     <xsl:text>#</xsl:text>


### PR DESCRIPTION
And move the IANA Considerations at the end.

Maybe we need to define what fields should be in the registry ? At least the ID, the name, and likely the path.
It might use the same registry fields as the regular/used Matroska IDs.

Fixes #305 