### PR TITLE
Move the ChapterSegmentUID section into the Medium Linking section

### DIFF
--- a/chapters.md
+++ b/chapters.md
@@ -97,32 +97,6 @@ with the `ChapterSegmentUID` element which establishes a link to another Segment
 See (#linked-segments) on the Linked Segments for more information
 about `Hard Linking`, `Soft Linking`, and `Medium Linking`.
 
-### ChapterSegmentUID
-
-The `ChapterSegmentUID` is a binary value and the base element to set up a
-`Linked Chapter` in 2 variations: the Linked-Duration linking and the Linked-Edition
-linking. For both variations, the following 3 conditions **MUST** be met:
-
- 1. The `EditionFlagOrdered Flag` **MUST** be true.
- 2. The `ChapterSegmentUID` **MUST NOT** be the `SegmentUID` of its own `Segment`.
- 3. The linked Segments **MUST** BE in the same folder.
-
-#### Variation 1: Linked-Duration
-
-Two more conditions **MUST** be met:
-
- 1. `ChapterTimeStart` and `ChapterTimeEnd` timestamps **MUST** be in the range of the
-    linked Segment duration.
- 2. `ChapterSegmentEditionUID` **MUST** be not set.
-
-A `Matroska Player` **MUST** play the content of the linked Segment from the
-`ChapterTimeStart` until `ChapterTimeEnd` timestamp.
-
-#### Variation 2: Linked-Edition
-
-When the `ChapterSegmentEditionUID` is set to a valid `EditionUID` from the linked
-Segment. A `Matroska Player` **MUST** play these linked `Edition`.
-
 ## ChapterAtom
 The `ChapterAtom` is also called a `Chapter`.
 A `Chapter` element can be used recursively. Such a child `Chapter` is called `Nested Chapter`.

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1146,11 +1146,11 @@ The value **MUST** be strictly greater than the `ChapterTimeStart` of the same `
   </element>
   <element name="ChapterSegmentUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentUID" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
-    <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>
+    <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The EditionUID to play from the Segment linked in ChapterSegmentUID.
-If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment is used.</documentation>
+If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment is used; see (#medium-linking) on medium-linking Segments.</documentation>
   </element>
   <element name="ChapterPhysicalEquiv" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterPhysicalEquiv" id="0x63C3" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the physical equivalent of this ChapterAtom like "DVD" (60) or "SIDE" (50);

--- a/notes.md
+++ b/notes.md
@@ -248,6 +248,30 @@ The second chapter references content within the `Segment` of `program.mkv`. A `
 **SHOULD** recognize the `Linked Segment` created by the use of `ChapterSegmentUID` in an enabled
 `Edition` and present the reference content of the two `Segments` together.
 
+The `ChapterSegmentUID` is a binary value and the base element to set up a
+`Linked Chapter` in 2 variations: the Linked-Duration linking and the Linked-Edition
+linking. For both variations, the following 3 conditions **MUST** be met:
+
+ 1. The `EditionFlagOrdered Flag` **MUST** be true.
+ 2. The `ChapterSegmentUID` **MUST NOT** be the `SegmentUID` of its own `Segment`.
+ 3. The linked Segments **MUST** BE in the same folder.
+
+### Variation 1: Linked-Duration
+
+Two more conditions **MUST** be met:
+
+ 1. `ChapterTimeStart` and `ChapterTimeEnd` timestamps **MUST** be in the range of the
+    linked Segment duration.
+ 2. `ChapterSegmentEditionUID` **MUST NOT** be set.
+
+A `Matroska Player` **MUST** play the content of the linked Segment from the
+`ChapterTimeStart` until `ChapterTimeEnd` timestamp.
+
+### Variation 2: Linked-Edition
+
+When the `ChapterSegmentEditionUID` is set to a valid `EditionUID` from the linked
+Segment. A `Matroska Player` **MUST** play these linked `Edition`.
+
 ## Soft Linking
 
 Soft Linking is used by codec chapters. They can reference another `Segment` and jump to


### PR DESCRIPTION
Also add links to that section in the related elements.

Replaces #488.
Ref #267.