### PR TITLE
Deprecate internal signature on the content

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1078,15 +1078,15 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
     </restriction>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="ContentSignature" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSignature" id="0x47E3" type="binary" maxOccurs="1">
+  <element name="ContentSignature" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSignature" id="0x47E3" type="binary" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A cryptographic signature of the contents.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ContentSigKeyID" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigKeyID" id="0x47E4" type="binary" maxOccurs="1">
+  <element name="ContentSigKeyID" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigKeyID" id="0x47E4" type="binary" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">This is the ID of the private key the data was signed with.</documentation>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ContentSigAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigAlgo" id="0x47E5" type="uinteger" default="0" maxOccurs="1">
+  <element name="ContentSigAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigAlgo" id="0x47E5" type="uinteger" default="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The algorithm used for the signature.</documentation>
     <restriction>
       <enum value="0" label="Not signed"/>
@@ -1094,7 +1094,7 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
     </restriction>
     <extension type="webmproject.org" webm="0"/>
   </element>
-  <element name="ContentSigHashAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigHashAlgo" id="0x47E6" type="uinteger" default="0" maxOccurs="1">
+  <element name="ContentSigHashAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentSigHashAlgo" id="0x47E6" type="uinteger" default="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The hash algorithm used for the signature.</documentation>
     <restriction>
       <enum value="0" label="Not signed"/>


### PR DESCRIPTION
Unlike encryption/compression this is not used by anyone. (maybe in mkvtoolnix @mbunkus ?)

Partially fixes #45 