### PR TITLE
Remove some default values/make some elements mandatory

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -461,7 +461,7 @@ with the top line of the top field stored first.</documentation>
     </restriction>
     <extension type="libmatroska" cppname="VideoFieldOrder"/>
   </element>
-  <element name="StereoMode" path="\Segment\Tracks\TrackEntry\Video\StereoMode" id="0x53B8" type="uinteger" minver="3" default="0" maxOccurs="1">
+  <element name="StereoMode" path="\Segment\Tracks\TrackEntry\Video\StereoMode" id="0x53B8" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Stereo-3D video mode. There are some more details in (#multi-planar-and-3d-videos).</documentation>
     <restriction>
       <enum value="0" label="mono"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -192,7 +192,7 @@ The duration of DiscardPadding is not calculated in the duration of the TrackEnt
     <documentation lang="en" purpose="definition">Contains extra time information about the data contained in the Block.
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
   </element>
-  <element name="LaceNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\LaceNumber" id="0xCC" type="uinteger" maxver="1" default="0" maxOccurs="1">
+  <element name="LaceNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\LaceNumber" id="0xCC" type="uinteger" maxver="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The reverse number of the frame in the lace (0 is the last frame, 1 is the next to last, etc).
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
     <extension type="libmatroska" cppname="SliceLaceNumber"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1043,7 +1043,7 @@ with 0 being the first possible position for an Element inside that Cluster.</do
 If missing the track's DefaultDuration does not apply and no duration information is available in terms of the cues.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="CueBlockNumber" path="\Segment\Cues\CuePoint\CueTrackPositions\CueBlockNumber" id="0x5378" type="uinteger" range="not 0" default="1" maxOccurs="1">
+  <element name="CueBlockNumber" path="\Segment\Cues\CuePoint\CueTrackPositions\CueBlockNumber" id="0x5378" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Number of the Block in the specified Cluster.</documentation>
   </element>
   <element name="CueCodecState" path="\Segment\Cues\CuePoint\CueTrackPositions\CueCodecState" id="0xEA" type="uinteger" minver="2" default="0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -534,7 +534,7 @@ PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</im
 PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
     <extension type="libmatroska" cppname="VideoDisplayHeight"/>
   </element>
-  <element name="DisplayUnit" path="\Segment\Tracks\TrackEntry\Video\DisplayUnit" id="0x54B2" type="uinteger" default="0" maxOccurs="1">
+  <element name="DisplayUnit" path="\Segment\Tracks\TrackEntry\Video\DisplayUnit" id="0x54B2" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">How DisplayWidth &amp; DisplayHeight are interpreted.</documentation>
     <restriction>
       <enum value="0" label="pixels"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -545,7 +545,7 @@ PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</i
     </restriction>
     <extension type="libmatroska" cppname="VideoDisplayUnit"/>
   </element>
-  <element name="AspectRatioType" path="\Segment\Tracks\TrackEntry\Video\AspectRatioType" id="0x54B3" type="uinteger" default="0" maxOccurs="1">
+  <element name="AspectRatioType" path="\Segment\Tracks\TrackEntry\Video\AspectRatioType" id="0x54B3" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the possible modifications to the aspect ratio.</documentation>
     <restriction>
       <enum value="0" label="free resizing"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -394,7 +394,7 @@ That means when this track has a gap, see (#silenttracks-element) on SilentTrack
 the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay matters, the first one is the one that **SHOULD** be used.
 If not found it **SHOULD** be the second, etc.</documentation>
   </element>
-  <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" default="0" maxOccurs="1">
+  <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds.
 This value **MUST** be subtracted from each block timestamp in order to get the actual timestamp.
 The value **SHOULD** be small so the muxing of tracks with the same actual timestamp are in the same Cluster.</documentation>


### PR DESCRIPTION
Having a default value when an element is not mandatory is confusing. We don't want to allow 0-length elements (#453).

Following the analysis in #310 here are some easy fixes.

Each commit explains one of the changes.