### PR TITLE
forbid non mandatory default values that are not 0

### DIFF
--- a/index_matroska.md
+++ b/index_matroska.md
@@ -132,7 +132,7 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 ## Matroska Design
 
-All top-levels elements (Segment and direct sub-elements) are coded on 4 octets -- i.e. class D elements.
+The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
 # Language Codes
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -135,12 +135,12 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
 Matroska writers **MUST NOT** use  EBML Empty Elements, elements present in the file but with a length of zero,
-if the element has a default value is not 0 for integers/dates and 0x0p+0 for floats.
+if the element has a default value that is not 0 for integers/dates and 0x0p+0 for floats.
 This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
-Therefore any element that is not mandatory **SHOULD NOT** have a default value.
+Therefore any element that is not mandatory **SHOULD NOT** have a default value, so that Empty Elements cannot be used.
 
 A default value of 0 for integers/dates and 0x0p+0 for floats are tolerated as a zero length is correctly handled by legacy parsers.
-In this case an Empty Element is both interpreted as the default value or 0 for numbers.
+In this case, an Empty Element is both interpreted as the default value and 0 for numbers.
 
 # Language Codes
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -134,13 +134,18 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
-Matroska writers **MUST NOT** use  EBML Empty Elements, elements present in the file but with a length of zero,
+Matroska writers **MUST NOT** use EBML Empty Elements, elements present in the file but with a length of zero,
 if the element has a default value that is not 0 for integers/dates and 0x0p+0 for floats.
 This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
 Therefore any element that is not mandatory **SHOULD NOT** have a default value, so that Empty Elements cannot be used.
 
 A default value of 0 for integers/dates and 0x0p+0 for floats are tolerated as a zero length is correctly handled by legacy parsers.
 In this case, an Empty Element is both interpreted as the default value and 0 for numbers.
+
+Strings cannot have an empty string as default value, due to a limitation of the EBML Schema.
+So, based on the rules above, any strings that is not mandatory **SHOULD NOT** have a default value, so that Empty Elements cannot be used.
+And Matroska writers **MUST NOT** use EBML Empty Elements if the element is a string element.
+In that case the writer **MUST** either omit the element if it is mandatory and unique or write it with its value.
 
 # Language Codes
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -134,6 +134,13 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
+Matroska doesn't allow using EBML Empty Elements, elements present in the file but with a length of zero.
+This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
+Therefore any element that is not mandatory **SHOULD NOT** have a default value.
+
+A default value of 0 for integers/dates is tolerated as a zero length is correctly handled by legacy parsers.
+In this case an Empty Element is both interpreted as the default value or 0 for numbers.
+
 # Language Codes
 
 Matroska from version 1 through 3 uses language codes that can be either the 3 letters

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -134,7 +134,8 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
-Matroska doesn't allow using EBML Empty Elements, elements present in the file but with a length of zero.
+Matroska writers **MUST NOT** use  EBML Empty Elements, elements present in the file but with a length of zero,
+if the element has a default value is not 0 for integers/dates and 0x0p+0 for floats.
 This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
 Therefore any element that is not mandatory **SHOULD NOT** have a default value.
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -138,7 +138,7 @@ Matroska doesn't allow using EBML Empty Elements, elements present in the file b
 This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
 Therefore any element that is not mandatory **SHOULD NOT** have a default value.
 
-A default value of 0 for integers/dates is tolerated as a zero length is correctly handled by legacy parsers.
+A default value of 0 for integers/dates and 0x0p+0 for floats are tolerated as a zero length is correctly handled by legacy parsers.
 In this case an Empty Element is both interpreted as the default value or 0 for numbers.
 
 # Language Codes

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -134,18 +134,15 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
-Matroska writers **MUST NOT** use EBML Empty Elements, elements present in the file but with a length of zero,
-if the element has a default value that is not 0 for integers/dates and 0x0p+0 for floats.
-This is to preserve compatibility with existing parsers that didn't interpret this EBML feature properly.
-Therefore any element that is not mandatory **SHOULD NOT** have a default value, so that Empty Elements cannot be used.
+Legacy EBML/Matroska parsers did not handle Empty Elements properly, elements present in the file but with a length of zero.
+They always assumed the value was 0 for integers/dates and 0x0p+0 for floats, no matter the default value of the element which should have been used instead.
+Therefore Matroska writers **MUST NOT** use EBML Empty Elements, if the element has a default value that is not 0 for integers/dates and 0x0p+0 for floats.
 
-A default value of 0 for integers/dates and 0x0p+0 for floats are tolerated as a zero length is correctly handled by legacy parsers.
-In this case, an Empty Element is both interpreted as the default value and 0 for numbers.
+When adding new elements to Matroska, these rules **MUST** be followed:
 
-Strings cannot have an empty string as default value, due to a limitation of the EBML Schema.
-So, based on the rules above, any strings that is not mandatory **SHOULD NOT** have a default value, so that Empty Elements cannot be used.
-And Matroska writers **MUST NOT** use EBML Empty Elements if the element is a string element.
-In that case the writer **MUST** either omit the element if it is mandatory and unique or write it with its value.
+* A non-mandatory integer/date Element **MUST NOT** have a default value other than 0.
+* A non-mandatory float Element **MUST NOT** have a default value other than 0x0p+0.
+* A non-mandatory string Element  **MUST NOT** have a default value, as empty string cannot be defined in the XML Schema.
 
 # Language Codes
 


### PR DESCRIPTION
Due to legacy code we can't use Empty Elements with non zero defaults. We can't make something legal now that will break older parsers.

This makes some element temporarily invalid.

Fixes #500

Draft until #495 is merged.