### PR TITLE
Clean chapterend section

### DIFF
--- a/chapters.md
+++ b/chapters.md
@@ -134,7 +134,6 @@ For `Simple Chapters` this is the position of the chapter markers in the timelin
 ### ChapterTimeEnd
 The timestamp of the end of `Chapter` with nanosecond accuracy, not scaled by TimestampScale.
 The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
-The end timestamp is used when the `EditionFlagOrdered` flag of the `Edition` is set to `true`.
 A `Matroska Player` calculates the duration of this `Chapter` using the difference between the
 `ChapterTimeEnd` and `ChapterTimeStart`.
 The end timestamp **MUST** be strictly greater than the start timestamp.

--- a/chapters.md
+++ b/chapters.md
@@ -137,16 +137,14 @@ The end timestamp is used when the `EditionFlagOrdered` flag of the `Edition` is
 The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
 A `Matroska Player` calculates the duration of this `Chapter` using the difference between the
 `ChapterTimeEnd` and `ChapterTimeStart`.
-The end timestamp **MUST** be greater than the start timestamp otherwise the duration would be
-negative which is illegal.
-If the duration of a `Chapter` is 0, this `Chapter` **MUST** be ignored.
+The end timestamp **MUST** be strictly greater than the start timestamp.
 
 Chapter   | Start timestamp | End timestamp | Duration
 :---------|:----------------|:--------------|:-----
 Chapter 1 | 0               | 1000000000    | 1000000000
 Chapter 2 | 1000000000      | 5000000000    | 4000000000
-Chapter 3 | 6000000000      | 6000000000    | 0 (chapter not used)
-Chapter 4 | 9000000000      | 8000000000    | -1000000000 (illegal)
+Chapter 3 | 6000000000      | 6000000000    | Invalid (0)
+Chapter 4 | 9000000000      | 8000000000    | Invalid (-1000000000)
 Table: ChapterTimeEnd usage possibilities{#ChapterTimeEndUsage}
 
 ### ChapterFlagHidden

--- a/chapters.md
+++ b/chapters.md
@@ -128,11 +128,11 @@ The `ChapterAtom` is also called a `Chapter`.
 A `Chapter` element can be used recursively. Such a child `Chapter` is called `Nested Chapter`.
 
 ### ChapterTimeStart
-A not scaled timestamp of the start of `Chapter` with nanosecond accuracy.
+The timestamp of the start of `Chapter` with nanosecond accuracy, not scaled by TimestampScale.
 For `Simple Chapters` this is the position of the chapter markers in the timeline.
 
 ### ChapterTimeEnd
-A not scaled timestamp of the end of `Chapter` with nanosecond accuracy.
+The timestamp of the end of `Chapter` with nanosecond accuracy, not scaled by TimestampScale.
 The end timestamp is used when the `EditionFlagOrdered` flag of the `Edition` is set to `true`.
 The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
 A `Matroska Player` calculates the duration of this `Chapter` using the difference between the

--- a/chapters.md
+++ b/chapters.md
@@ -133,8 +133,8 @@ For `Simple Chapters` this is the position of the chapter markers in the timelin
 
 ### ChapterTimeEnd
 The timestamp of the end of `Chapter` with nanosecond accuracy, not scaled by TimestampScale.
-The end timestamp is used when the `EditionFlagOrdered` flag of the `Edition` is set to `true`.
 The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
+The end timestamp is used when the `EditionFlagOrdered` flag of the `Edition` is set to `true`.
 A `Matroska Player` calculates the duration of this `Chapter` using the difference between the
 `ChapterTimeEnd` and `ChapterTimeStart`.
 The end timestamp **MUST** be strictly greater than the start timestamp.


### PR DESCRIPTION
The text is inconsistent with the `ChapterTimeEnd` definition in the EBML Schema.

Fixes #478.

Draft until #495 is merged.