### PR TITLE
tag TrackUID as preserved during stream copy using an extension

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -241,8 +241,7 @@ but the data inside the Block are Transformed (encrypt and/or signed).</document
 though the design allows an unlimited number).</documentation>
   </element>
   <element name="TrackUID" path="\Segment\Tracks\TrackEntry\TrackUID" id="0x73C5" type="uinteger" range="not 0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A unique ID to identify the Track.
-This **SHOULD** be kept the same when making a direct stream copy of the Track to another file.</documentation>
+    <documentation lang="en" purpose="definition">A unique ID to identify the Track.</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackType" path="\Segment\Tracks\TrackEntry\TrackType" id="0x83" type="uinteger" range="1-254" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -243,6 +243,7 @@ though the design allows an unlimited number).</documentation>
   <element name="TrackUID" path="\Segment\Tracks\TrackEntry\TrackUID" id="0x73C5" type="uinteger" range="not 0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">A unique ID to identify the Track.
 This **SHOULD** be kept the same when making a direct stream copy of the Track to another file.</documentation>
+    <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackType" path="\Segment\Tracks\TrackEntry\TrackType" id="0x83" type="uinteger" range="1-254" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">A set of track types coded on 8 bits.</documentation>

--- a/transforms/schema_clean.xsl
+++ b/transforms/schema_clean.xsl
@@ -51,6 +51,7 @@
             <xsl:attribute name="unknownsizeallowed"><xsl:value-of select="@unknownsizeallowed"/></xsl:attribute>
         </xsl:if>
         <xsl:apply-templates select="ebml:documentation"/>
+        <xsl:apply-templates select="ebml:extension[@type='stream copy']"/>
         <xsl:apply-templates select="ebml:implementation_note"/>
         <xsl:if test="ebml:restriction">
             <restriction>
@@ -87,6 +88,13 @@
         <xsl:attribute name="note_attribute"><xsl:value-of select="@note_attribute"/></xsl:attribute>
         <xsl:apply-templates/>
     </implementation_note>
+  </xsl:template>
+  <xsl:template match="ebml:extension[@type='stream copy']">
+    <documentation>
+        <xsl:attribute name="lang">eng</xsl:attribute>
+        <xsl:attribute name="purpose">usage notes</xsl:attribute>
+        The value of this Element **SHOULD** be kept the same when making a direct stream copy to another file.
+    </documentation>
   </xsl:template>
 
   <!-- HTML tags found in documentation -->


### PR DESCRIPTION
Generate the text from the text in the spec from the tag.

This will help for #370 to use the same normative text for other elements that need to be copied untouched.
This can also help when generating code to tell some elements need special processing.