### PR TITLE
mark the markdown/xml/output as IETF standards

### DIFF
--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -11,7 +11,7 @@ keyword = ["binary","storage","matroska","ebml","tags"]
 [seriesInfo]
 name = "Internet-Draft"
 stream = "IETF"
-status = "informational"
+status = "standard"
 value = "@BUILD_VERSION@"
 
 [[author]]

--- a/index_codec.md
+++ b/index_codec.md
@@ -11,7 +11,7 @@ keyword = ["binary","storage","matroska","ebml","webm","codec"]
 [seriesInfo]
 name = "Internet Draft"
 stream = "IETF"
-status = "informational"
+status = "standard"
 value = "@BUILD_VERSION@"
 
 [[author]]
@@ -73,6 +73,6 @@ The key words "**MUST**", "**MUST NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
 "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174] 
+described in BCP 14 [@!RFC2119] [@!RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 

--- a/index_control.md
+++ b/index_control.md
@@ -11,7 +11,7 @@ keyword = ["binary","storage","matroska","ebml","webm","codec"]
 [seriesInfo]
 name = "Internet Draft"
 stream = "IETF"
-status = "informational"
+status = "standard"
 value = "@BUILD_VERSION@"
 
 [[author]]
@@ -65,6 +65,6 @@ The key words "**MUST**", "**MUST NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
 "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174] 
+described in BCP 14 [@!RFC2119] [@!RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -11,7 +11,7 @@ keyword = ["binary","storage","matroska","ebml","webm"]
 [seriesInfo]
 name = "Internet-Draft"
 stream = "IETF"
-status = "informational"
+status = "standard"
 value = "@BUILD_VERSION@"
 
 [[author]]

--- a/index_tags.md
+++ b/index_tags.md
@@ -11,7 +11,7 @@ keyword = ["binary","storage","matroska","ebml","tags"]
 [seriesInfo]
 name = "Internet-Draft"
 stream = "IETF"
-status = "informational"
+status = "standard"
 value = "@BUILD_VERSION@"
 
 [[author]]
@@ -73,6 +73,6 @@ The key words "**MUST**", "**MUST NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
 "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174] 
+described in BCP 14 [@!RFC2119] [@!RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 


### PR DESCRIPTION
We don't have the RFC numbers yet but that's the goal for these documents.

Fixes issue raised in https://github.com/ietf-wg-cellar/matroska-specification/pull/495#issuecomment-846230313