### PR TITLE
Expand the tocdepth to 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,7 @@ $(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.m
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
 
 %.xml: %.md
-	$(MMARK) $< | awk '/<?rfc toc=/ && !modif { printf("<?rfc tocdepth=\"6\"?>\n"); modif=1 } {print}' | \
-		sed -e "s/submissionType=/sortRefs=\"true\" submissionType=/" \
+	$(MMARK) $< | sed -e "s/submissionType=/sortRefs=\"true\" tocDepth=\"4\" submissionType=/" \
 		> $@
 
 %.html: %.xml


### PR DESCRIPTION
The default `tocDepth` is 3. 4 might be a bit verbose but for the Matroska Elements that gives a better granularity.

The issue is mostly with `Tracks` + `TrackEntry` that needs to use finer granularity when 3 is used. Maybe merging these levels into one using XSLT might give nicer results without forcing everything else to have a `tocDepth` of 4 and give too many details in the index/Table Of Content.