### PR TITLE
fix some Markdown formatting

### DIFF
--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -115,7 +115,7 @@
         <xsl:text>| </xsl:text>
         <xsl:value-of select="@note_attribute"/>
         <xsl:text> | </xsl:text>
-        <xsl:value-of select="."/>
+        <xsl:value-of select="translate(.,'&#xa;','')"/>
         <xsl:text> |&#xa;</xsl:text>
       </xsl:for-each>
       <xsl:text>Table: </xsl:text><xsl:value-of select="@name"/><xsl:text> implementation notes{#</xsl:text><xsl:value-of select="@name"/><xsl:text>Notes}&#xa;</xsl:text>

--- a/transforms/schema_clean.xsl
+++ b/transforms/schema_clean.xsl
@@ -95,7 +95,7 @@
     <documentation>
         <xsl:attribute name="lang">eng</xsl:attribute>
         <xsl:attribute name="purpose">usage notes</xsl:attribute>
-        The value of this Element **SHOULD** be kept the same when making a direct stream copy to another file.
+        <xsl:text>The value of this Element **SHOULD** be kept the same when making a direct stream copy to another file.</xsl:text>
     </documentation>
   </xsl:template>
 


### PR DESCRIPTION
- note attributes table entries on multiple lines should be one
- usage notes should use <xsl:text> for plain text