### PR TITLE
Rewrite timestamp intepretations using ticks

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -85,7 +85,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <extension type="libmatroska" cppname="TimecodeScale"/>
   </element>
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Duration of the Segment, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
   </element>
   <element name="DateUTC" path="\Segment\Info\DateUTC" id="0x4461" type="date" maxOccurs="1">
     <documentation lang="en" purpose="definition">The date and time that the Segment was created by the muxing application or library.</documentation>
@@ -195,7 +195,7 @@ If the `BlockGroup` doesn't have any `ReferenceBlock` element, then the `Block` 
 This information **SHOULD** always be referenced by a seek entry.</documentation>
   </element>
   <element name="DiscardPadding" path="\Segment\Cluster\BlockGroup\DiscardPadding" id="0x75A2" type="integer" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Duration in nanoseconds of the silent data added to the Block
+    <documentation lang="en" purpose="definition">Duration of the silent data added to the Block, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks)
 (padding at the end of the Block for positive value, at the beginning of the Block for negative value).
 The duration of DiscardPadding is not calculated in the duration of the TrackEntry and **SHOULD** be discarded during playback.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -336,13 +336,13 @@ If set to 0, the reference pseudo-cache system is not used.</documentation>
     <extension type="libmatroska" cppname="TrackMaxCache"/>
   </element>
   <element name="DefaultDuration" path="\Segment\Tracks\TrackEntry\DefaultDuration" id="0x23E383" type="uinteger" range="not 0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Number of nanoseconds per frame, not scaled/in Matroska Ticks; see (#timestamp-ticks)
+    <documentation lang="en" purpose="definition">Number of nanoseconds per frame, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks)
 (frame in the Matroska sense -- one Element put into a (Simple)Block).</documentation>
     <extension type="libmatroska" cppname="TrackDefaultDuration"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="DefaultDecodedFieldDuration" path="\Segment\Tracks\TrackEntry\DefaultDecodedFieldDuration" id="0x234E7A" type="uinteger" minver="4" range="not 0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The period in nanoseconds between two successive fields at the output of the decoding process, not scaled/in Matroska Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">The period between two successive fields at the output of the decoding process, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
 see (#defaultdecodedfieldduration) for more information</documentation>
     <extension type="libmatroska" cppname="TrackDefaultDecodedFieldDuration"/>
     <extension type="stream copy" keep="1"/>
@@ -354,7 +354,7 @@ see (#defaultdecodedfieldduration) for more information</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackOffset" path="\Segment\Tracks\TrackEntry\TrackOffset" id="0x537F" type="integer" minver="0" maxver="0" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A value to add to the Block's Timestamp, not scaled/in Matroska Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">A value to add to the Block's Timestamp, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
 This can be used to adjust the playback offset of a track.</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
@@ -435,15 +435,15 @@ the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay
 If not found it **SHOULD** be the second, etc.</documentation>
   </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds/Matroska Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
 This value **MUST** be subtracted from each block timestamp in order to get the actual timestamp.
 The value **SHOULD** be small so the muxing of tracks with the same actual timestamp are in the same Cluster.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="SeekPreRoll" path="\Segment\Tracks\TrackEntry\SeekPreRoll" id="0x56BB" type="uinteger" minver="4" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">After a discontinuity, SeekPreRoll is the duration in nanoseconds of the data
-the decoder **MUST** decode before the decoded data is valid.</documentation>
+    <documentation lang="en" purpose="definition">After a discontinuity, SeekPreRoll is the duration of the data
+the decoder **MUST** decode before the decoded data is valid, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>
@@ -1178,7 +1178,7 @@ All entries are local to the Segment.</documentation>
     <documentation lang="en" purpose="definition">Contains all information relative to a seek point in the Segment.</documentation>
   </element>
   <element name="CueTime" path="\Segment\Cues\CuePoint\CueTime" id="0xB3" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Absolute timestamp according to the Segment time base, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Absolute timestamp of the seek point, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).</documentation>
   </element>
   <element name="CueTrackPositions" path="\Segment\Cues\CuePoint\CueTrackPositions" id="0xB7" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">Contain positions for different tracks corresponding to the timestamp.</documentation>
@@ -1210,7 +1210,7 @@ If missing the track's DefaultDuration does not apply and no duration informatio
     <documentation lang="en" purpose="definition">The Clusters containing the referenced Blocks.</documentation>
   </element>
   <element name="CueRefTime" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefTime" id="0x96" type="uinteger" minver="2" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the referenced Block, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Timestamp of the referenced Block, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).</documentation>
   </element>
   <element name="CueRefCluster" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefCluster" id="0x97" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster containing the referenced Block.</documentation>
@@ -1298,11 +1298,11 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterTimeStart" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeStart" id="0x91" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the start of Chapter, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Timestamp of the start of Chapter, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterTimeEnd" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeEnd" id="0x92" type="uinteger" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the end of Chapter timestamp excluded, not scaled/in Matroska Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">Timestamp of the end of Chapter timestamp excluded, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
 The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
     <documentation lang="en" purpose="usage notes">The `ChapterTimeEnd` timestamp value being excluded, it **MUST** take in account the duration of
 the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -436,7 +436,8 @@ If not found it **SHOULD** be the second, etc.</documentation>
   </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
-This value **MUST** be subtracted from each block timestamp in order to get the actual timestamp.
+It represents the amount of codec samples that will be discarded by the decoder during playback.
+This timestamp value **MUST** be subtracted from each frame timestamp in order to get the timestamp that will be actually played.
 The value **SHOULD** be small so the muxing of tracks with the same actual timestamp are in the same Cluster.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -81,11 +81,11 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <documentation lang="en" purpose="usage notes">When no `ChapterTranslateEditionUID` is specified in the `ChapterTranslate`, the `ChapterTranslate` applied to all chapter editions found in the Segment using the given `ChapterTranslateCodec`.</documentation>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Base tick for all scaled timestamps, based in nanoseconds. 1.000.000 means scaled timestamps in the Segment are expressed in milliseconds; see (#timestamps) on how to interpret Timestamps.</documentation>
+    <documentation lang="en" purpose="definition">Base unit for Segment Ticks and Track Ticks, in nanoseconds. A TimestampScale value of 1.000.000 means scaled timestamps in the Segment are expressed in milliseconds; see (#timestamps) on how to interpret timestamps.</documentation>
     <extension type="libmatroska" cppname="TimecodeScale"/>
   </element>
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds, based on TimestampScale/in Segment Ticks; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
   </element>
   <element name="DateUTC" path="\Segment\Info\DateUTC" id="0x4461" type="date" maxOccurs="1">
     <documentation lang="en" purpose="definition">The date and time that the Segment was created by the muxing application or library.</documentation>
@@ -106,7 +106,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <documentation lang="en" purpose="definition">The Top-Level Element containing the (monolithic) Block structure.</documentation>
   </element>
   <element name="Timestamp" path="\Segment\Cluster\Timestamp" id="0xE7" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Absolute timestamp of the cluster, based on TimestampScale/in Segment Ticks; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Absolute timestamp of the cluster, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
     <documentation lang="en" purpose="usage notes">This element **SHOULD** be the first child element of the Cluster it belongs to,
 or the second if that Cluster contains a CRC-32 element ((#crc-32)).</documentation>
     <extension type="libmatroska" cppname="ClusterTimecode"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -166,7 +166,7 @@ If BlockAddIDType of the corresponding block is 0, this value is also the value 
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="BlockDuration" path="\Segment\Cluster\BlockGroup\BlockDuration" id="0x9B" type="uinteger" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The duration of the Block, in Track Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">The duration of the Block, expressed in Track Ticks; see (#timestamp-ticks).
 The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available),
 or when there is a break in a track like for subtitle tracks.</documentation>
     <implementation_note note_attribute="minOccurs">BlockDuration **MUST** be set (minOccurs=1) if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
@@ -178,7 +178,7 @@ of this Block and the timestamp of the next Block in "display" order (not coding
 In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
   </element>
   <element name="ReferenceBlock" path="\Segment\Cluster\BlockGroup\ReferenceBlock" id="0xFB" type="integer">
-    <documentation lang="en" purpose="definition">A timestamp value, relative to the timestamp of the Block in this BlockGroup, in Track Ticks; see (#timestamp-ticks).
+    <documentation lang="en" purpose="definition">A timestamp value, relative to the timestamp of the Block in this BlockGroup, expressed in Track Ticks; see (#timestamp-ticks).
 This is used to reference other frames necessary to decode this frame.
 The relative value **SHOULD** correspond to a valid `Block` this `Block` depends on.
 Historically Matroska Writer didn't write the actual `Block(s)` this `Block` depends on, but *some* `Block` in the past.
@@ -237,7 +237,7 @@ Being able to interpret this Element is not **REQUIRED** for playback.</document
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ReferenceTimestamp" path="\Segment\Cluster\BlockGroup\ReferenceFrame\ReferenceTimestamp" id="0xCA" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timestamp of the BlockGroup pointed to by ReferenceOffset, in Track Ticks; see (#timestamp-ticks). See [@?DivXTrickTrack].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp of the BlockGroup pointed to by ReferenceOffset, expressed in Track Ticks; see (#timestamp-ticks). See [@?DivXTrickTrack].</documentation>
     <extension type="libmatroska" cppname="ReferenceTimeCode"/>
     <extension type="divx.com" divx="1"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -222,11 +222,11 @@ Being able to interpret this Element is not **REQUIRED** for playback.</document
     <extension type="libmatroska" cppname="SliceBlockAddID"/>
   </element>
   <element name="Delay" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\Delay" id="0xCE" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The (scaled) delay to apply to the Element.</documentation>
+    <documentation lang="en" purpose="definition">The delay to apply to the Element, expressed in Track Ticks; see (#timestamp-ticks).</documentation>
     <extension type="libmatroska" cppname="SliceDelay"/>
   </element>
   <element name="SliceDuration" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\SliceDuration" id="0xCF" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The (scaled) duration to apply to the Element.</documentation>
+    <documentation lang="en" purpose="definition">The duration to apply to the Element, expressed in Track Ticks; see (#timestamp-ticks).</documentation>
   </element>
   <element name="ReferenceFrame" path="\Segment\Cluster\BlockGroup\ReferenceFrame" id="0xC8" type="master" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains information about the last reference frame. See [@?DivXTrickTrack].</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -85,7 +85,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <extension type="libmatroska" cppname="TimecodeScale"/>
   </element>
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds based on TimestampScale.</documentation>
+    <documentation lang="en" purpose="definition">Duration of the Segment in nanoseconds, based on TimestampScale/in Segment Ticks; see (#timestamp-ticks).</documentation>
   </element>
   <element name="DateUTC" path="\Segment\Info\DateUTC" id="0x4461" type="date" maxOccurs="1">
     <documentation lang="en" purpose="definition">The date and time that the Segment was created by the muxing application or library.</documentation>
@@ -106,7 +106,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <documentation lang="en" purpose="definition">The Top-Level Element containing the (monolithic) Block structure.</documentation>
   </element>
   <element name="Timestamp" path="\Segment\Cluster\Timestamp" id="0xE7" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Absolute timestamp of the cluster (based on TimestampScale).</documentation>
+    <documentation lang="en" purpose="definition">Absolute timestamp of the cluster, based on TimestampScale/in Segment Ticks; see (#timestamp-ticks).</documentation>
     <documentation lang="en" purpose="usage notes">This element **SHOULD** be the first child element of the Cluster it belongs to,
 or the second if that Cluster contains a CRC-32 element ((#crc-32)).</documentation>
     <extension type="libmatroska" cppname="ClusterTimecode"/>
@@ -166,7 +166,7 @@ If BlockAddIDType of the corresponding block is 0, this value is also the value 
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="BlockDuration" path="\Segment\Cluster\BlockGroup\BlockDuration" id="0x9B" type="uinteger" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale).
+    <documentation lang="en" purpose="definition">The duration of the Block, in Track Ticks; see (#timestamp-ticks).
 The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available),
 or when there is a break in a track like for subtitle tracks.</documentation>
     <implementation_note note_attribute="minOccurs">BlockDuration **MUST** be set (minOccurs=1) if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
@@ -178,7 +178,7 @@ of this Block and the timestamp of the next Block in "display" order (not coding
 In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
   </element>
   <element name="ReferenceBlock" path="\Segment\Cluster\BlockGroup\ReferenceBlock" id="0xFB" type="integer">
-    <documentation lang="en" purpose="definition">A timestamp value, relative to the timestamp of the Block in this BlockGroup.
+    <documentation lang="en" purpose="definition">A timestamp value, relative to the timestamp of the Block in this BlockGroup, in Track Ticks; see (#timestamp-ticks).
 This is used to reference other frames necessary to decode this frame.
 The relative value **SHOULD** correspond to a valid `Block` this `Block` depends on.
 Historically Matroska Writer didn't write the actual `Block(s)` this `Block` depends on, but *some* `Block` in the past.
@@ -237,7 +237,7 @@ Being able to interpret this Element is not **REQUIRED** for playback.</document
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ReferenceTimestamp" path="\Segment\Cluster\BlockGroup\ReferenceFrame\ReferenceTimestamp" id="0xCA" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timecode of the BlockGroup pointed to by ReferenceOffset. See [@?DivXTrickTrack].</documentation>
+    <documentation lang="en" purpose="definition">The timecode of the BlockGroup pointed to by ReferenceOffset, in Track Ticks; see (#timestamp-ticks). See [@?DivXTrickTrack].</documentation>
     <extension type="libmatroska" cppname="ReferenceTimeCode"/>
     <extension type="divx.com" divx="1"/>
   </element>
@@ -336,13 +336,13 @@ If set to 0, the reference pseudo-cache system is not used.</documentation>
     <extension type="libmatroska" cppname="TrackMaxCache"/>
   </element>
   <element name="DefaultDuration" path="\Segment\Tracks\TrackEntry\DefaultDuration" id="0x23E383" type="uinteger" range="not 0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Number of nanoseconds (not scaled via TimestampScale) per frame
+    <documentation lang="en" purpose="definition">Number of nanoseconds per frame, not scaled/in Matroska Ticks; see (#timestamp-ticks)
 (frame in the Matroska sense -- one Element put into a (Simple)Block).</documentation>
     <extension type="libmatroska" cppname="TrackDefaultDuration"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="DefaultDecodedFieldDuration" path="\Segment\Tracks\TrackEntry\DefaultDecodedFieldDuration" id="0x234E7A" type="uinteger" minver="4" range="not 0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The period in nanoseconds (not scaled by TimestampScale) between two successive fields at the output of the decoding process,
+    <documentation lang="en" purpose="definition">The period in nanoseconds between two successive fields at the output of the decoding process, not scaled/in Matroska Ticks; see (#timestamp-ticks).
 see (#defaultdecodedfieldduration) for more information</documentation>
     <extension type="libmatroska" cppname="TrackDefaultDecodedFieldDuration"/>
     <extension type="stream copy" keep="1"/>
@@ -354,7 +354,7 @@ see (#defaultdecodedfieldduration) for more information</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackOffset" path="\Segment\Tracks\TrackEntry\TrackOffset" id="0x537F" type="integer" minver="0" maxver="0" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A value to add to the Block's Timestamp.
+    <documentation lang="en" purpose="definition">A value to add to the Block's Timestamp, not scaled/in Matroska Ticks; see (#timestamp-ticks).
 This can be used to adjust the playback offset of a track.</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
@@ -435,7 +435,7 @@ the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay
 If not found it **SHOULD** be the second, etc.</documentation>
   </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds.
+    <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay in nanoseconds/Matroska Ticks; see (#timestamp-ticks).
 This value **MUST** be subtracted from each block timestamp in order to get the actual timestamp.
 The value **SHOULD** be small so the muxing of tracks with the same actual timestamp are in the same Cluster.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -1178,7 +1178,7 @@ All entries are local to the Segment.</documentation>
     <documentation lang="en" purpose="definition">Contains all information relative to a seek point in the Segment.</documentation>
   </element>
   <element name="CueTime" path="\Segment\Cues\CuePoint\CueTime" id="0xB3" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Absolute timestamp according to the Segment time base.</documentation>
+    <documentation lang="en" purpose="definition">Absolute timestamp according to the Segment time base, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
   </element>
   <element name="CueTrackPositions" path="\Segment\Cues\CuePoint\CueTrackPositions" id="0xB7" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">Contain positions for different tracks corresponding to the timestamp.</documentation>
@@ -1210,7 +1210,7 @@ If missing the track's DefaultDuration does not apply and no duration informatio
     <documentation lang="en" purpose="definition">The Clusters containing the referenced Blocks.</documentation>
   </element>
   <element name="CueRefTime" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefTime" id="0x96" type="uinteger" minver="2" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the referenced Block.</documentation>
+    <documentation lang="en" purpose="definition">Timestamp of the referenced Block, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
   </element>
   <element name="CueRefCluster" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefCluster" id="0x97" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster containing the referenced Block.</documentation>
@@ -1298,11 +1298,11 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterTimeStart" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeStart" id="0x91" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the start of Chapter (not scaled).</documentation>
+    <documentation lang="en" purpose="definition">Timestamp of the start of Chapter, not scaled/in Matroska Ticks; see (#timestamp-ticks).</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterTimeEnd" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeEnd" id="0x92" type="uinteger" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the end of Chapter (timestamp excluded, not scaled).
+    <documentation lang="en" purpose="definition">Timestamp of the end of Chapter timestamp excluded, not scaled/in Matroska Ticks; see (#timestamp-ticks).
 The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
     <documentation lang="en" purpose="usage notes">The `ChapterTimeEnd` timestamp value being excluded, it **MUST** take in account the duration of
 the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -237,7 +237,7 @@ Being able to interpret this Element is not **REQUIRED** for playback.</document
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="ReferenceTimestamp" path="\Segment\Cluster\BlockGroup\ReferenceFrame\ReferenceTimestamp" id="0xCA" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timecode of the BlockGroup pointed to by ReferenceOffset, in Track Ticks; see (#timestamp-ticks). See [@?DivXTrickTrack].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp of the BlockGroup pointed to by ReferenceOffset, in Track Ticks; see (#timestamp-ticks). See [@?DivXTrickTrack].</documentation>
     <extension type="libmatroska" cppname="ReferenceTimeCode"/>
     <extension type="divx.com" divx="1"/>
   </element>
@@ -1252,11 +1252,13 @@ If missing, the track's DefaultDuration does not apply and no duration informati
     <documentation lang="en" purpose="definition">A binary value that a track/codec can refer to when the attachment is needed.</documentation>
   </element>
   <element name="FileUsedStartTime" path="\Segment\Attachments\AttachedFile\FileUsedStartTime" id="0x4661" type="uinteger" minver="0" maxver="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timecode at which this optimized font attachment comes into context, based on the Segment TimecodeScale. This element is reserved for future use and if written must be the segment start time. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment comes into context, expressed in Segment Ticks which is based on TimestampScale. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="usage notes">This element is reserved for future use and if written **MUST** be the segment start timestamp.</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="FileUsedEndTime" path="\Segment\Attachments\AttachedFile\FileUsedEndTime" id="0x4662" type="uinteger" minver="0" maxver="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timecode at which this optimized font attachment goes out of context, based on the Segment TimecodeScale. This element is reserved for future use and if written must be the segment end time. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment goes out of context, expressed in Segment Ticks which is based on TimestampScale. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="usage notes">This element is reserved for future use and if written **MUST** be the segment end timestamp.</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="Chapters" path="\Segment\Chapters" id="0x1043A770" type="master" maxOccurs="1" recurring="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -81,7 +81,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <documentation lang="en" purpose="usage notes">When no `ChapterTranslateEditionUID` is specified in the `ChapterTranslate`, the `ChapterTranslate` applied to all chapter editions found in the Segment using the given `ChapterTranslateCodec`.</documentation>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Base tick for all scaled timestamps, based in nanoseconds (1.000.000 means all timestamps in the Segment are expressed in milliseconds).</documentation>
+    <documentation lang="en" purpose="definition">Base tick for all scaled timestamps, based in nanoseconds. 1.000.000 means scaled timestamps in the Segment are expressed in milliseconds; see (#timestamps) on how to interpret Timestamps.</documentation>
     <extension type="libmatroska" cppname="TimecodeScale"/>
   </element>
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1195,8 +1195,8 @@ with 0 being the first possible position for an Element inside that Cluster.</do
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="CueDuration" path="\Segment\Cues\CuePoint\CueTrackPositions\CueDuration" id="0xB2" type="uinteger" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The duration of the block according to the Segment time base.
-If missing the track's DefaultDuration does not apply and no duration information is available in terms of the cues.</documentation>
+    <documentation lang="en" purpose="definition">The duration of the block, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).
+If missing, the track's DefaultDuration does not apply and no duration information is available in terms of the cues.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="CueBlockNumber" path="\Segment\Cues\CuePoint\CueTrackPositions\CueBlockNumber" id="0x5378" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -81,7 +81,7 @@ The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-elem
     <documentation lang="en" purpose="usage notes">When no `ChapterTranslateEditionUID` is specified in the `ChapterTranslate`, the `ChapterTranslate` applied to all chapter editions found in the Segment using the given `ChapterTranslateCodec`.</documentation>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp scale in nanoseconds (1.000.000 means all timestamps in the Segment are expressed in milliseconds).</documentation>
+    <documentation lang="en" purpose="definition">Base tick for all scaled timestamps, based in nanoseconds (1.000.000 means all timestamps in the Segment are expressed in milliseconds).</documentation>
     <extension type="libmatroska" cppname="TimecodeScale"/>
   </element>
   <element name="Duration" path="\Segment\Info\Duration" id="0x4489" type="float" range="&gt; 0x0p+0" maxOccurs="1">

--- a/notes.md
+++ b/notes.md
@@ -302,6 +302,7 @@ The elements storing values in Segment Ticks are:
 
 * `Cluster\Timestamp`; defined in (#timestamp-element)
 * `Info\Duration` is stored as a floating point but the same formula applies; defined in (#duration-element)
+* `CuePoint\CueTrackPositions\CueDuration`; defined in (#cueduration-element)
 
 ### Track Ticks
 

--- a/notes.md
+++ b/notes.md
@@ -297,6 +297,16 @@ This allows storing smaller integer values in the elements.
 Timestamp values in `BlockGroup` and `SimpleBlock` elements **MAY** also use the `TrackTimestampScale` element
 to scale the timestamps more in tune with each Track sampling frequency.
 
+## Timestamp Ticks
+
+All timestamp values in Matroska are expressed in multiples of a tick.
+There are three types of ticks possible:
+
+* Matroska Ticks: timestamps stored directly in nanoseconds.
+* Segment Ticks: timestamps expressed in "TimestampScale" nanoseconds.
+* Track Ticks: timestamps expressed in "TimestampScale * TrackTimestampScale" nanoseconds.
+
+When the `TrackTimestampScale` is interpreted as "1.0", Track Ticks are equivalent to Segment Ticks.
 
 ## Block Timestamps
 

--- a/notes.md
+++ b/notes.md
@@ -293,6 +293,8 @@ in nanoseconds of the element, with the following formula:
 
 This allows storing smaller integer values in the elements.
 
+When using the default value of `TimestampScale` of "1,000,000", one Segment Tick represents one millisecond.
+
 The elements storing values in Segment Ticks are:
 
 * `Cluster\Timestamp`; defined in (#timestamp-element)
@@ -307,6 +309,8 @@ to get the timestamp in nanoseconds of the element, with the following formula:
 
 This allows storing smaller integer values in the elements.
 The resulting floating point values of the timestamps are still expressed in nanoseconds.
+
+When using the default values for `TimestampScale` and `TrackTimestampScale` of "1,000,000" and of "1.0" respectively, one Track Tick represents one millisecond.
 
 The elements storing values in Track Ticks are:
 

--- a/notes.md
+++ b/notes.md
@@ -328,23 +328,20 @@ So using a value other than "1.0" **MAY** not work in many places.
 
 ## Block Timestamps
 
-The `Block Element`'s timestamp **MUST** be a signed integer that represents the
-`Raw Timestamp` relative to the `Cluster`'s `Timestamp Element`, multiplied by the
-`TimestampScale Element`. See (#timestampscale) for more information.
+A `Block Element` and `SimpleBlock Element` timestamp is the time when the decoded data of the first
+frame in the Block/SimpleBlock **MUST** be presented, if the track of that Block/SimpleBlock is selected for playback.
+This is also known as the Presentation Timestamp (PTS).
 
-The `Block Element`'s timestamp **MUST** be represented by a 16bit signed integer (sint16).
-The `Block`'s timestamp has a range of -32768 to +32767 units. When using the default value
-of the `TimestampScale Element`, each integer represents 1ms. The maximum time span of
-`Block Elements` in a `Cluster` using the default `TimestampScale Element` of 1ms is 65536ms.
+The `Block Element` and `SimpleBlock Element` store their timestamps as signed integers, relative
+to the `Cluster\Timestamp` value of the `Cluster` they are stored in.
+To get the timestamp of a `Block` or `SimpleBlock` in nanoseconds you have to use the following formula:
 
-If a `Cluster`'s `Timestamp Element` is set to zero, it is possible to have `Block Elements`
-with a negative `Raw Timestamp`. `Block Elements` with a negative `Raw Timestamp` are not valid.
+    Cluster\Timestamp + (signed timestamp * TimestampScale * TrackTimestampScale)
 
-## Raw Timestamp
+The `Block Element` and `SimpleBlock Element` store their timestamps as 16bit signed integers,
+allowing a range from "-32768" to "+32767" Track Ticks.
+Although these values can be negative, when added to the `Cluster\Timestamp`, the resulting timestamp **MUST NOT** be negative.
 
-The exact time of an object **SHOULD** be represented in nanoseconds. To find out a `Block`'s
-`Raw Timestamp`, you need the `Block`'s `Timestamp Element`, the `Cluster`'s `Timestamp Element`,
-and the `TimestampScale Element`.
 
 ## TimestampScale
 

--- a/notes.md
+++ b/notes.md
@@ -344,8 +344,16 @@ To get the timestamp of a `Block` or `SimpleBlock` in nanoseconds you have to us
 
 The `Block Element` and `SimpleBlock Element` store their timestamps as 16bit signed integers,
 allowing a range from "-32768" to "+32767" Track Ticks.
-Although these values can be negative, when added to the `Cluster\Timestamp`, the resulting timestamp **MUST NOT** be negative.
+Although these values can be negative, when added to the `Cluster\Timestamp`, the resulting frame timestamp **SHOULD NOT** be negative.
 
+When a `CodecDelay Element` is set, its value **MUST** be substracted from each Block timestamp of that track.
+To get the timestamp in nanoseconds of the first frame in a `Block` or `SimpleBlock`, the formula becomes:
+
+    (Cluster\Timestamp * TimestampScale) + (signed timestamp * TimestampScale * TrackTimestampScale) - CodecDelay
+
+The resulting frame timestamp **SHOULD NOT** be negative.
+
+During playback, when a frame has a negative timestamp, the content **MUST** be decoded by the decoder but not played to the user.
 
 ## TimestampScale Rounding
 

--- a/notes.md
+++ b/notes.md
@@ -279,9 +279,11 @@ The elements storing values in Matroska Ticks/nanoseconds are:
 
 * `TrackEntry\DefaultDuration`; defined in (#defaultduration-element)
 * `TrackEntry\DefaultDecodedFieldDuration`; defined in (#defaultdecodedfieldduration-element)
+* `TrackEntry\SeekPreRoll`; defined in (#seekpreroll-element)
+* `TrackEntry\CodecDelay`; defined in (#codecdelay-element)
+* `BlockGroup\DiscardPadding`; defined in (#discardpadding-element)
 * `ChapterAtom\ChapterTimeStart`; defined in (#chaptertimestart-element)
 * `ChapterAtom\ChapterTimeEnd`; defined in (#chaptertimeend-element)
-* `TrackEntry\CodecDelay`; defined in (#codecdelay-element)
 * `CuePoint\CueTime`; defined in (#cuetime-element)
 * `CueReference\CueRefTime`; defined in (#cuetime-element)
 

--- a/notes.md
+++ b/notes.md
@@ -294,6 +294,9 @@ in nanoseconds of the element, with the following formula:
 
 This allows storing smaller integer values in the elements.
 
+Timestamp values in `BlockGroup` and `SimpleBlock` elements **MAY** also use the `TrackTimestampScale` element
+to scale the timestamps more in tune with each Track sampling frequency.
+
 
 ## Block Timestamps
 

--- a/notes.md
+++ b/notes.md
@@ -267,7 +267,7 @@ was called Timecode, the `TimestampScale Element` was called TimecodeScale, the
 
 ## Raw And Scaled Timestamps
 
-There are 2 types of Timestamps in Matroska, the raw ones stored in nanoseconds and the scaled timestamps.
+There are 2 types of Timestamps in Matroska, the raw ones stored in nanoseconds and the `scaled` timestamps.
 
 The elements with raw timetamps in nanoseconds are:
 
@@ -280,14 +280,14 @@ The elements with raw timetamps in nanoseconds are:
 * `CuePoint\CueTime`; defined in (#cuetime-element)
 * `CueReference\CueRefTime`; defined in (#cuetime-element)
 
-The elements with scaled timestamps are:
+The elements with `scaled` timestamps are:
 
 * `Info\Duration`; defined in (#duration-element)
 * `Cluster\BlockGroup\Block` and `Cluster\SimpleBlock` timestamps; detailed in (#block-timestamps)
 * `Cluster\BlockGroup\BlockDuration`; defined in (#blockduration-element)
 * `Cluster\BlockGroup\ReferenceBlock`; defined in (#referenceblock-element)
 
-Scaled timestamps involve the use of the `TimestampScale Element` of the Segment to get the timestamp
+`Scaled` timestamps involve the use of the `TimestampScale Element` of the Segment to get the timestamp
 in nanoseconds of the element, with the following formula:
 
     timestamp in nanosecond = element value * TimestampScale

--- a/notes.md
+++ b/notes.md
@@ -317,8 +317,10 @@ The elements storing values in Track Ticks are:
 When the `TrackTimestampScale` is interpreted as "1.0", Track Ticks are equivalent to Segment Ticks
 and give an integer value in nanoseconds. This is the most common case as `TrackTimestampScale` is usually omitted.
 
-A different value of `TrackTimestampScale` **MAY** be used
+A value of `TrackTimestampScale` other than "1.0" **MAY** be used
 to scale the timestamps more in tune with each Track sampling frequency.
+For historical reasons, a lot of Matroska readers don't take the `TrackTimestampScale` value in account.
+So using a value other than "1.0" **MAY** not work in many places.
 
 ## Block Timestamps
 

--- a/notes.md
+++ b/notes.md
@@ -343,27 +343,6 @@ allowing a range from "-32768" to "+32767" Track Ticks.
 Although these values can be negative, when added to the `Cluster\Timestamp`, the resulting timestamp **MUST NOT** be negative.
 
 
-## TimestampScale
-
-The `TimestampScale Element` is used to calculate the `Raw Timestamp` of a `Block`.
-The timestamp is obtained by adding the `Block`'s timestamp to the `Cluster`'s `Timestamp Element`,
-and then multiplying that result by the `TimestampScale`. The result will be the `Block`'s `Raw Timestamp`
-in nanoseconds. The formula for this would look like:
-
-    (a + b) * c
-
-    a = `Block`'s Timestamp
-    b = `Cluster`'s Timestamp
-    c = `TimestampScale`
-
-For example, assume a `Cluster`'s `Timestamp` has a value of 564264, the `Block` has a `Timestamp`
-of 1233, and the `TimestampScale Element` is the default of 1000000.
-
-    (1233 + 564264) * 1000000 = 565497000000
-
-So, the `Block` in this example has a specific time of 565497000000 in nanoseconds.
-In milliseconds this would be 565497ms.
-
 ## TimestampScale Rounding
 
 Because the default value of `TimestampScale` is 1000000, which makes each integer in the

--- a/notes.md
+++ b/notes.md
@@ -267,7 +267,8 @@ was called Timecode, the `TimestampScale Element` was called TimecodeScale, the
 
 ## Timestamp Ticks
 
-All timestamp values in Matroska are expressed in multiples of a tick, stored as integers.
+All timestamp values in Matroska are expressed in multiples of a tick.
+They are usually stored as integers.
 There are three types of ticks possible:
 
 ### Matroska Ticks
@@ -298,7 +299,7 @@ When using the default value of `TimestampScale` of "1,000,000", one Segment Tic
 The elements storing values in Segment Ticks are:
 
 * `Cluster\Timestamp`; defined in (#timestamp-element)
-* `Info\Duration`; defined in (#duration-element)
+* `Info\Duration` is stored as a floating point but the same formula applies; defined in (#duration-element)
 
 ### Track Ticks
 

--- a/notes.md
+++ b/notes.md
@@ -295,13 +295,6 @@ in nanoseconds of the element, with the following formula:
 This allows storing smaller integer values in the elements.
 
 
-## Timestamp Types
-
-* Absolute Timestamp = Block+Cluster
-* Relative Timestamp = Block
-* Scaled Timestamp = Block+Cluster
-* Raw Timestamp = (Block+Cluster)\*TimestampScale\*TrackTimestampScale
-
 ## Block Timestamps
 
 The `Block Element`'s timestamp **MUST** be a signed integer that represents the
@@ -452,7 +445,7 @@ is calculated using:
 
 `(Block's Timestamp + Cluster's Timestamp) * TimestampScale * TrackTimestampScale `
 
-So, a Block from the PAL track above that had a Scaled Timestamp, see (#timestamp-types), of 100
+So, a Block from the PAL track above that had a Scaled Timestamp, see (#timestampscale), of 100
 seconds would have a `Raw Timestamp` of 104.66666667 seconds, and so would be stored in that
 part of the file.
 

--- a/notes.md
+++ b/notes.md
@@ -309,7 +309,8 @@ The elements storing values in Segment Ticks are:
 Elements in Segment Ticks involve the use of the `TimestampScale Element` of the Segment and the `TrackTimestampScale Element` of the Track
 to get the timestamp in nanoseconds of the element, with the following formula:
 
-    timestamp in nanosecond = element value * TimestampScale * TrackTimestampScale
+    timestamp in nanoseconds =
+        element value * TrackTimestampScale * TimestampScale
 
 This allows storing smaller integer values in the elements.
 The resulting floating point values of the timestamps are still expressed in nanoseconds.
@@ -340,7 +341,8 @@ The `Block Element` and `SimpleBlock Element` store their timestamps as signed i
 to the `Cluster\Timestamp` value of the `Cluster` they are stored in.
 To get the timestamp of a `Block` or `SimpleBlock` in nanoseconds you have to use the following formula:
 
-    (Cluster\Timestamp * TimestampScale) + (signed timestamp * TimestampScale * TrackTimestampScale)
+    ( Cluster\Timestamp + ( block timestamp * TrackTimestampScale ) ) *
+    TimestampScale
 
 The `Block Element` and `SimpleBlock Element` store their timestamps as 16bit signed integers,
 allowing a range from "-32768" to "+32767" Track Ticks.
@@ -349,7 +351,8 @@ Although these values can be negative, when added to the `Cluster\Timestamp`, th
 When a `CodecDelay Element` is set, its value **MUST** be substracted from each Block timestamp of that track.
 To get the timestamp in nanoseconds of the first frame in a `Block` or `SimpleBlock`, the formula becomes:
 
-    (Cluster\Timestamp * TimestampScale) + (signed timestamp * TimestampScale * TrackTimestampScale) - CodecDelay
+    ( ( Cluster\Timestamp + ( block timestamp * TrackTimestampScale ) ) *
+      TimestampScale ) - CodecDelay
 
 The resulting frame timestamp **SHOULD NOT** be negative.
 

--- a/notes.md
+++ b/notes.md
@@ -429,66 +429,6 @@ For video tracks, the sampling frequency is the one that **MAY** be stored as a 
 The `Matroska Muxer` **MAY** also know the accurate value from the source material.
 
 
-## TrackTimestampScale
-
-The `TrackTimestampScale Element` is used align tracks that would otherwise be played at
-different speeds. An example of this would be if you have a film that was originally recorded
-at 24fps video. When playing this back through a PAL broadcasting system, it is standard to
-speed up the film to 25fps to match the 25fps display speed of the PAL broadcasting standard.
-However, when broadcasting the video through NTSC, it is typical to leave the film at its
-original speed. If you wanted to make a single file where there was one video stream,
-and an audio stream used from the PAL broadcast, as well as an audio stream used from the NTSC
-broadcast, you would have the problem that the PAL audio stream would be 1/24th faster than
-the NTSC audio stream, quickly leading to problems. It is possible to stretch out the PAL
-audio track and re-encode it at a slower speed, however when dealing with lossy audio codecs,
-this often results in a loss of audio quality and/or larger file sizes.
-
-This is the type of problem that `TrackTimestampScale` was designed to fix. Using it,
-the video can be played back at a speed that will synch with either the NTSC or the PAL
-audio stream, depending on which is being used for playback.
-To continue the above example:
-
-    Track 1: Video
-    Track 2: NTSC Audio
-    Track 3: PAL Audio
-
-Because the NTSC track is at the original speed, it will used as the default value of 1.0 for
-its `TrackTimestampScale`. The video will also be aligned to the NTSC track with the default value of 1.0.
-
-The `TrackTimestampScale` value to use for the PAL track would be calculated by
-determining how much faster the PAL track is than the NTSC track. In this case,
-because we know the video for the NTSC audio is being played back at 24fps and the video
-for the PAL audio is being played back at 25fps, the calculation would be:
-
-25/24 is almost 1.04166666666666666667
-
-When writing a file that uses a non-default `TrackTimestampScale`, the values of the `Block`'s
-timestamp are whatever they would be when normally storing the track with a default value for
-the `TrackTimestampScale`. However, the data is interleaved a little differently.
-Data **SHOULD** be interleaved by its Raw Timestamp, in the order handed back
-from the encoder. The `Raw Timestamp` of a `Block` from a track using `TrackTimestampScale`
-is calculated using:
-
-`(Block's Timestamp + Cluster's Timestamp) * TimestampScale * TrackTimestampScale `
-
-So, a Block from the PAL track above that had a Scaled Timestamp, of 100
-seconds would have a `Raw Timestamp` of 104.66666667 seconds, and so would be stored in that
-part of the file.
-
-When playing back a track using the `TrackTimestampScale`, if the track is being played by itself,
-there is no need to scale it. From the above example, when playing the Video with the NTSC Audio,
-neither are scaled. However, when playing back the Video with the PAL Audio, the timestamps
-from the PAL Audio track are scaled using the `TrackTimestampScale`, resulting in the video
-playing back in synch with the audio.
-
-It would be possible for a `Matroska Player` to also adjust the audio's samplerate at the
-same time as adjusting the timestamps if you wanted to play the two audio streams synchronously.
-It would also be possible to adjust the video to match the audio's speed. However,
-for playback, the selected track(s) timestamps **SHOULD** be adjusted if they need to be scaled.
-
-While the above example deals specifically with audio tracks, this element can be used
-to align video, audio, subtitles, or any other type of track contained in a Matroska file.
-
 # Encryption
 
 Encryption in Matroska is designed in a very generic style to allow people to

--- a/notes.md
+++ b/notes.md
@@ -265,6 +265,36 @@ was called Timecode, the `TimestampScale Element` was called TimecodeScale, the
 `TrackTimestampScale Element` was called TrackTimecodeScale and the
 `ReferenceTimestamp Element` was called ReferenceTimeCode.
 
+## Raw And Scaled Timestamps
+
+There are 2 types of Timestamps in Matroska, the raw ones stored in nanoseconds and the scaled timestamps.
+
+The elements with raw timetamps in nanoseconds are:
+
+* `Cluster\Timestamp`; defined in (#timestamp-element)
+* `TrackEntry\DefaultDuration`; defined in (#defaultduration-element)
+* `TrackEntry\DefaultDecodedFieldDuration`; defined in (#defaultdecodedfieldduration-element)
+* `ChapterAtom\ChapterTimeStart`; defined in (#chaptertimestart-element)
+* `ChapterAtom\ChapterTimeEnd`; defined in (#chaptertimeend-element)
+* `TrackEntry\CodecDelay`; defined in (#codecdelay-element)
+* `CuePoint\CueTime`; defined in (#cuetime-element)
+* `CueReference\CueRefTime`; defined in (#cuetime-element)
+
+The elements with scaled timestamps are:
+
+* `Info\Duration`; defined in (#duration-element)
+* `Cluster\BlockGroup\Block` and `Cluster\SimpleBlock` timestamps; detailed in (#block-timestamps)
+* `Cluster\BlockGroup\BlockDuration`; defined in (#blockduration-element)
+* `Cluster\BlockGroup\ReferenceBlock`; defined in (#referenceblock-element)
+
+Scaled timestamps involve the use of the `TimestampScale Element` of the Segment to get the timestamp
+in nanoseconds of the element, with the following formula:
+
+    timestamp in nanosecond = element value * TimestampScale
+
+This allows storing smaller integer values in the elements.
+
+
 ## Timestamp Types
 
 * Absolute Timestamp = Block+Cluster

--- a/notes.md
+++ b/notes.md
@@ -265,13 +265,17 @@ was called Timecode, the `TimestampScale Element` was called TimecodeScale, the
 `TrackTimestampScale Element` was called TrackTimecodeScale and the
 `ReferenceTimestamp Element` was called ReferenceTimeCode.
 
-## Raw And Scaled Timestamps
+## Timestamp Ticks
 
-There are 2 types of Timestamps in Matroska, the raw ones stored in nanoseconds and the `scaled` timestamps.
+All timestamp values in Matroska are expressed in multiples of a tick, stored as integers.
+There are three types of ticks possible:
 
-The elements with raw timetamps in nanoseconds are:
+### Matroska Ticks
 
-* `Cluster\Timestamp`; defined in (#timestamp-element)
+For such elements, the timestamp value is stored directly in nanoseconds.
+
+The elements storing values in Matroska Ticks/nanoseconds are:
+
 * `TrackEntry\DefaultDuration`; defined in (#defaultduration-element)
 * `TrackEntry\DefaultDecodedFieldDuration`; defined in (#defaultdecodedfieldduration-element)
 * `ChapterAtom\ChapterTimeStart`; defined in (#chaptertimestart-element)
@@ -280,33 +284,41 @@ The elements with raw timetamps in nanoseconds are:
 * `CuePoint\CueTime`; defined in (#cuetime-element)
 * `CueReference\CueRefTime`; defined in (#cuetime-element)
 
-The elements with `scaled` timestamps are:
+### Segment Ticks
 
-* `Info\Duration`; defined in (#duration-element)
-* `Cluster\BlockGroup\Block` and `Cluster\SimpleBlock` timestamps; detailed in (#block-timestamps)
-* `Cluster\BlockGroup\BlockDuration`; defined in (#blockduration-element)
-* `Cluster\BlockGroup\ReferenceBlock`; defined in (#referenceblock-element)
-
-`Scaled` timestamps involve the use of the `TimestampScale Element` of the Segment to get the timestamp
+Elements in Segment Ticks involve the use of the `TimestampScale Element` of the Segment to get the timestamp
 in nanoseconds of the element, with the following formula:
 
     timestamp in nanosecond = element value * TimestampScale
 
 This allows storing smaller integer values in the elements.
 
-Timestamp values in `BlockGroup` and `SimpleBlock` elements **MAY** also use the `TrackTimestampScale` element
+The elements storing values in Segment Ticks are:
+
+* `Cluster\Timestamp`; defined in (#timestamp-element)
+* `Info\Duration`; defined in (#duration-element)
+
+### Track Ticks
+
+Elements in Segment Ticks involve the use of the `TimestampScale Element` of the Segment and the `TrackTimestampScale Element` of the Track
+to get the timestamp in nanoseconds of the element, with the following formula:
+
+    timestamp in nanosecond = element value * TimestampScale * TrackTimestampScale
+
+This allows storing smaller integer values in the elements.
+The resulting floating point values of the timestamps are still expressed in nanoseconds.
+
+The elements storing values in Track Ticks are:
+
+* `Cluster\BlockGroup\Block` and `Cluster\SimpleBlock` timestamps; detailed in (#block-timestamps)
+* `Cluster\BlockGroup\BlockDuration`; defined in (#blockduration-element)
+* `Cluster\BlockGroup\ReferenceBlock`; defined in (#referenceblock-element)
+
+When the `TrackTimestampScale` is interpreted as "1.0", Track Ticks are equivalent to Segment Ticks
+and give an integer value in nanoseconds. This is the most common case as `TrackTimestampScale` is usually omitted.
+
+A different value of `TrackTimestampScale` **MAY** be used
 to scale the timestamps more in tune with each Track sampling frequency.
-
-## Timestamp Ticks
-
-All timestamp values in Matroska are expressed in multiples of a tick.
-There are three types of ticks possible:
-
-* Matroska Ticks: timestamps stored directly in nanoseconds.
-* Segment Ticks: timestamps expressed in "TimestampScale" nanoseconds.
-* Track Ticks: timestamps expressed in "TimestampScale * TrackTimestampScale" nanoseconds.
-
-When the `TrackTimestampScale` is interpreted as "1.0", Track Ticks are equivalent to Segment Ticks.
 
 ## Block Timestamps
 


### PR DESCRIPTION
Draft: the Block, TrackTimestampScale are not rewritten yet

The notion of Matroska/Segment/Track ticks is introduced to make it easier to know what formula to apply. For example `Cluster\Timestamp` is using the `TimestampScale` but **NOT** the `TrackTimestampScale`.

The `Info\Duration` is expressed in Segment Ticks, but it's in floating point which is odd, only Track Ticks may be in floating point due to  `TrackTimestampScale`.

Fixes #517