### PR TITLE
Really deprecate TimeSlice elements

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -188,11 +188,11 @@ The duration of DiscardPadding is not calculated in the duration of the TrackEnt
   <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" maxver="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains slices description.</documentation>
   </element>
-  <element name="TimeSlice" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice" id="0xE8" type="master" maxver="1">
+  <element name="TimeSlice" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice" id="0xE8" type="master" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">Contains extra time information about the data contained in the Block.
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
   </element>
-  <element name="LaceNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\LaceNumber" id="0xCC" type="uinteger" maxver="1" maxOccurs="1">
+  <element name="LaceNumber" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice\LaceNumber" id="0xCC" type="uinteger"  minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">The reverse number of the frame in the lace (0 is the last frame, 1 is the next to last, etc).
 Being able to interpret this Element is not **REQUIRED** for playback.</documentation>
     <extension type="libmatroska" cppname="SliceLaceNumber"/>


### PR DESCRIPTION
A TimeSlice+LaceNumber alone is not sufficient to do anything.

#105 should have marked is a maxver=0 like the other TimeSlice elements.