### PR TITLE
reorder and clarify ChapterTranslate and TrackTranslate elements

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -406,22 +406,29 @@ the decoder **MUST** decode before the decoded data is valid.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="TrackTranslate" path="\Segment\Tracks\TrackEntry\TrackTranslate" id="0x6624" type="master">
-    <documentation lang="en" purpose="definition">The track identification for the given Chapter Codec.</documentation>
-  </element>
-  <element name="TrackTranslateEditionUID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateEditionUID" id="0x66FC" type="uinteger">
-    <documentation lang="en" purpose="definition">Specify an edition UID on which this translation applies. When not specified,
-it means for all editions found in the Segment.</documentation>
-  </element>
-  <element name="TrackTranslateCodec" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateCodec" id="0x66BF" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
-    <restriction>
-      <enum value="0" label="Matroska Script"/>
-      <enum value="1" label="DVD-menu"/>
-    </restriction>
+    <documentation lang="en" purpose="definition">The mapping between this `TrackEntry` and a track value in the given Chapter Codec.</documentation>
+    <documentation lang="en" purpose="rationale">Chapter Codec may need to address content in specific track, but they may not know of the way to identify tracks in Matroska.
+This element and its child elements add a way to map the internal tracks known to the Chapter Codec to the track IDs in Matroska.
+This allows remuxing a file with Chapter Codec without changing the content of the codec data, just the track mapping.</documentation>
   </element>
   <element name="TrackTranslateTrackID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateTrackID" id="0x66A5" type="binary" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The binary value used to represent this track in the chapter codec data.
-The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
+    <documentation lang="en" purpose="definition">The binary value used to represent this `TrackEntry` in the chapter codec data.
+The format depends on the `ChapProcessCodecID` used; see (#chapprocesscodecid-element).</documentation>
+  </element>
+  <element name="TrackTranslateCodec" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateCodec" id="0x66BF" type="uinteger" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">This `TrackTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).</documentation>
+    <restriction>
+      <enum value="0" label="Matroska Script">
+        <documentation lang="en" purpose="definition">Chapter commands using the Matroska Script codec.</documentation>
+      </enum>
+      <enum value="1" label="DVD-menu">
+        <documentation lang="en" purpose="definition">Chapter commands using the DVD-like codec.</documentation>
+      </enum>
+    </restriction>
+  </element>
+  <element name="TrackTranslateEditionUID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateEditionUID" id="0x66FC" type="uinteger">
+    <documentation lang="en" purpose="definition">Specify a chapter edition UID on which this `TrackTranslate` applies.</documentation>
+    <documentation lang="en" purpose="usage notes">When no `TrackTranslateEditionUID` is specified in the `TrackTranslate`, the `TrackTranslate` applies to all chapter editions found in the Segment using the given `TrackTranslateCodec`.</documentation>
   </element>
   <element name="Video" path="\Segment\Tracks\TrackEntry\Video" id="0xE0" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">Video settings.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -56,22 +56,29 @@ but NextUID **SHOULD** be considered authoritative for identifying the Next Segm
     <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment that uses Soft Linking, then this Element is **REQUIRED**.</documentation>
   </element>
   <element name="ChapterTranslate" path="\Segment\Info\ChapterTranslate" id="0x6924" type="master">
-    <documentation lang="en" purpose="definition">A tuple of corresponding ID used by chapter codecs to represent this Segment.</documentation>
-  </element>
-  <element name="ChapterTranslateEditionUID" path="\Segment\Info\ChapterTranslate\ChapterTranslateEditionUID" id="0x69FC" type="uinteger">
-    <documentation lang="en" purpose="definition">Specify an edition UID on which this correspondence applies.
-When not specified, it means for all editions found in the Segment.</documentation>
-  </element>
-  <element name="ChapterTranslateCodec" path="\Segment\Info\ChapterTranslate\ChapterTranslateCodec" id="0x69BF" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
-    <restriction>
-      <enum value="0" label="Matroska Script"/>
-      <enum value="1" label="DVD-menu"/>
-    </restriction>
+    <documentation lang="en" purpose="definition">The mapping between this `Segment` and a segment value in the given Chapter Codec.</documentation>
+    <documentation lang="en" purpose="rationale">Chapter Codec may need to address different segments, but they may not know of the way to identify such segment when stored in Matroska.
+This element and its child elements add a way to map the internal segments known to the Chapter Codec to the Segment IDs in Matroska.
+This allows remuxing a file with Chapter Codec without changing the content of the codec data, just the Segment mapping.</documentation>
   </element>
   <element name="ChapterTranslateID" path="\Segment\Info\ChapterTranslate\ChapterTranslateID" id="0x69A5" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary value used to represent this Segment in the chapter codec data.
 The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
+  </element>
+  <element name="ChapterTranslateCodec" path="\Segment\Info\ChapterTranslate\ChapterTranslateCodec" id="0x69BF" type="uinteger" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">This `ChapterTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).</documentation>
+    <restriction>
+      <enum value="0" label="Matroska Script">
+        <documentation lang="en" purpose="definition">Chapter commands using the Matroska Script codec.</documentation>
+      </enum>
+      <enum value="1" label="DVD-menu">
+        <documentation lang="en" purpose="definition">Chapter commands using the DVD-like codec.</documentation>
+      </enum>
+    </restriction>
+  </element>
+  <element name="ChapterTranslateEditionUID" path="\Segment\Info\ChapterTranslate\ChapterTranslateEditionUID" id="0x69FC" type="uinteger">
+    <documentation lang="en" purpose="definition">Specify a chapter edition UID on which this `ChapterTranslate` applies.</documentation>
+    <documentation lang="en" purpose="usage notes">When no `ChapterTranslateEditionUID` is specified in the `ChapterTranslate`, the `ChapterTranslate` applied to all chapter editions found in the Segment using the given `ChapterTranslateCodec`.</documentation>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Timestamp scale in nanoseconds (1.000.000 means all timestamps in the Segment are expressed in milliseconds).</documentation>


### PR DESCRIPTION
They are used to map internal binary values in codec chapters to actual Matroska tracks and segments.