### PR TITLE
Clean segment linking explanations

### DIFF
--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -4,7 +4,29 @@ title: Chapter Codecs
 
 # Matroska Chapter Codecs
 
-*TODO*
+Chapter codecs are a way to add more complex playback features than the usual linear playback.
+
+Some `ChapProcess` elements hold commands to execute when entering/leaving a chapter.
+
+When chapter codecs are used the `EditionFlagOrdered` of the edition they belong to **MUST** be set.
+
+## Segment Linking
+
+Chapter Codecs can reference another `Segment` and jump to that `Segment`.
+
+The Chapter Codecs **MAY** store the Segment information in their own format, possibly not using the `SegmentUID` format.
+The `ChapterTranslate` element and its child elements **SHOULD** be used
+to link the internal chapter codec representation, the chapter codec number and the actual Segment it represents.
+
+For example if a chapter codec of type "1" in SegmentA needs to link to SegmentB,
+it can store that information as "SegB" in its internal data.
+
+The translation `ChapterTranslate` in SegmentB would use the following elements:
+* `ChapterTranslate\ChapterTranslateCodec` = 1
+* `ChapterTranslate\ChapterTranslateID` = "SegB"
+
+The `Matroska Player` **MUST** use the `SegmentFamily` to find all Segments that need translation
+between the chapter codec values and the actual segment it targets.
 
 ## Matroska Script (0)
 

--- a/chapters.md
+++ b/chapters.md
@@ -88,13 +88,11 @@ flag is set to `true`.
 #### Ordered-Edition and Matroska Segment-Linking
 
 - Hard Linking: `Ordered-Chapters` supersedes the `Hard Linking`.
-- Soft Linking: In this complex system `Ordered Chapters` are **REQUIRED** and a
-`Chapter CODEC` **MUST** interpret the `ChapProcess` of all chapters.
 - Medium Linking: `Ordered Chapters` are used in a normal way and can be combined
 with the `ChapterSegmentUID` element which establishes a link to another Segment.
 
 See (#linked-segments) on the Linked Segments for more information
-about `Hard Linking`, `Soft Linking`, and `Medium Linking`.
+about `Hard Linking` and `Medium Linking`.
 
 ## ChapterAtom
 The `ChapterAtom` is also called a `Chapter`.

--- a/chapters.md
+++ b/chapters.md
@@ -65,7 +65,7 @@ excluded. If an `Edition` of `Ordered Chapters` is enabled, then the `Matroska P
 play those Chapters in their stored order from the timestamp marked in the
 `ChapterTimeStart Element` to the timestamp marked in to `ChapterTimeEnd Element`.
 
-If the `EditionFlagOrdered Flag` is set to `false`, `Simple Chapters` are used and
+If the `EditionFlagOrdered Flag` evaluates to "0", `Simple Chapters` are used and
 only the `ChapterTimeStart` of a `Chapter` is used as chapter mark to jump to the
 predefined point in the timeline. With `Simple Chapters`, a `Matroska Player` **MUST**
 ignore certain `Chapter Elements`. All these elements are now informational only.

--- a/chapters.md
+++ b/chapters.md
@@ -78,7 +78,6 @@ The following list shows the different Chapter elements only found in `Ordered C
 | ChapterAtom/ChapterSegmentEditionUID  |
 | ChapterAtom/ChapterTrack              |
 | ChapterAtom/ChapProcess               |
-| Info/SegmentFamily                    |
 | Info/ChapterTranslate                 |
 | TrackEntry/TrackTranslate             |
 Table: elements only found in ordered chapters{#orderedOnly}

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1318,6 +1318,7 @@ When disabled, the movie **SHOULD** skip all the content between the TimeStart a
   </element>
   <element name="ChapterSegmentUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentUID" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
+    <documentation lang="en" purpose="usage notes">The value **MUST NOT** be the `SegmentUID` value of the `Segment` it belongs to.</documentation>
     <implementation_note note_attribute="minOccurs">ChapterSegmentUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
   </element>
   <element name="ChapterSegmentEditionUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentEditionUID" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -53,7 +53,7 @@ but NextUID **SHOULD** be considered authoritative for identifying the Next Segm
   </element>
   <element name="SegmentFamily" path="\Segment\Info\SegmentFamily" id="0x4444" type="binary" length="16">
     <documentation lang="en" purpose="definition">A randomly generated unique ID that all Segments of a Linked Segment **MUST** share (128 bits).</documentation>
-    <documentation lang="en" purpose="usage notes">If the Segment is a part of a Linked Segment that uses Soft Linking, then this Element is **REQUIRED**.</documentation>
+    <documentation lang="en" purpose="usage notes">If the Segment Info contains a `ChapterTranslate` element, this Element is **REQUIRED**.</documentation>
   </element>
   <element name="ChapterTranslate" path="\Segment\Info\ChapterTranslate" id="0x6924" type="master">
     <documentation lang="en" purpose="definition">The mapping between this `Segment` and a segment value in the given Chapter Codec.</documentation>

--- a/notes.md
+++ b/notes.md
@@ -590,12 +590,13 @@ in order to have seamless transition between segments.
 
 ## Hard Linking
 
-Hard Linking (also called splitting) is the process of creating a `Linked Segment`
-by relating multiple `Segment Elements` using the `NextUID` and `PrevUID` Elements.
-Within a `Linked Segment`, the timestamps of each `Segment` **MUST** follow consecutively
-in linking order.
+Hard Linking, also called splitting, is the process of creating a `Linked Segment`
+by linking multiple `Segment Elements` using the `NextUID` and `PrevUID` Elements.
 
 All `Segments` within a `Hard Linked Segment` **MUST** use the same `Tracks` list and `TimestampScale`.
+
+Within a `Linked Segment`, the timestamps of `Block` and `SimpleBlock` **MUST** follow consecutively
+the timestamps of `Block` and `SimpleBlock` from the previous `Segment` in linking order.
 
 With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST**
 only reference the current `Segment`. With Hard Linking, the `NextUID` and `PrevUID` **MUST**

--- a/notes.md
+++ b/notes.md
@@ -591,6 +591,9 @@ in order to have seamless transition between segments.
 All `Segments` within a `Linked Segment` **MAY** set a `SegmentFamily` with a common value to make
 it easier for a `Matroska Player` to know which `Segments` are meant to be played together.
 
+The `SegmentFilename`, `PrevFilename` and `NextFilename` elements **MAY** also give hints on
+the original filenames that were used when the Segment links were created, in case some `SegmentUID` are damaged.
+
 ## Hard Linking
 
 Hard Linking, also called splitting, is the process of creating a `Linked Segment`

--- a/notes.md
+++ b/notes.md
@@ -576,12 +576,15 @@ of `MuxingApp Element` in the above example is '26 - 21' or '5'.
 
 # Linked Segments
 
-Matroska provides several methods to link two or many `Segment Elements` together to create
-a `Linked Segment`. A `Linked Segment` is a set of multiple `Segments` related together into
-a single presentation by using Hard Linking, Medium Linking, or Soft Linking. All `Segments`
-within a `Linked Segment` **MUST** utilize the same track numbers and timescale. All `Segments`
-within a `Linked Segment` **MUST** be stored within the same directory. All `Segments`
-within a `Linked Segment` **MUST** store a `SegmentUID`.
+Matroska provides several methods to link two or more `Segment Elements` together to create
+a `Linked Segment`. A `Linked Segment` is a set of multiple `Segments` linked together into
+a single presentation by using Hard Linking, Medium Linking, or Soft Linking.
+
+All `Segments` within a `Linked Segment` **MUST** have a `SegmentUID`.
+
+All `Segments` within a `Linked Segment` **SHOULD** be stored within the same directory
+or be accessible quickly based on their `SegmentUID`
+in order to have seamless transition between segments.
 
 ## Hard Linking
 
@@ -589,6 +592,9 @@ Hard Linking (also called splitting) is the process of creating a `Linked Segmen
 by relating multiple `Segment Elements` using the `NextUID` and `PrevUID` Elements.
 Within a `Linked Segment`, the timestamps of each `Segment` **MUST** follow consecutively
 in linking order.
+
+All `Segments` within a `Hard Linked Segment` **MUST** use the same `Tracks` list and `TimestampScale`.
+
 With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST**
 only reference the current `Segment`. With Hard Linking, the `NextUID` and `PrevUID` **MUST**
 reference the respective `SegmentUID` values of the next and previous `Segments`.

--- a/notes.md
+++ b/notes.md
@@ -599,7 +599,7 @@ Within a `Linked Segment`, the timestamps of `Block` and `SimpleBlock` **MUST** 
 the timestamps of `Block` and `SimpleBlock` from the previous `Segment` in linking order.
 
 With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST** only reference the current `Segment`.
-The `NextUID` and `PrevUID` **MUST** reference the respective `SegmentUID` values of the next and previous `Segments`.
+The `NextUID` and `PrevUID` reference the respective `SegmentUID` values of the next and previous `Segments`.
 
 The first `Segment` of a `Linked Segment` **SHOULD** have a `NextUID Element` and **MUST NOT** have a `PrevUID Element`.
 The last `Segment` of a `Linked Segment` **SHOULD** have a `PrevUID Element` and **MUST NOT** have a `NextUID Element`.

--- a/notes.md
+++ b/notes.md
@@ -654,11 +654,13 @@ Table: Hard Linking with mixed UID links{#hardLinkingMixedUIDs}
 
 ## Medium Linking
 
-Medium Linking creates relationships between `Segments` using Ordered Chapters and the
-`ChapterSegmentUID Element`. A `Segment Edition` with Ordered Chapters **MAY** contain
+Medium Linking creates relationships between `Segments` using Ordered Chapters ((#editionflagordered)) and the
+`ChapterSegmentUID Element`. A `Chapter Edition` with Ordered Chapters **MAY** contain
 Chapter elements that reference timestamp ranges from other `Segments`. The `Segment`
 referenced by the Ordered Chapter via the `ChapterSegmentUID Element` **SHOULD** be played as
-part of a Linked Segment. The timestamps of Segment content referenced by Ordered Chapters
+part of a Linked Segment.
+
+The timestamps of Segment content referenced by Ordered Chapters
 **MUST** be adjusted according to the cumulative duration of the the previous Ordered Chapters.
 
 As an example a file named `intro.mkv` could have a `SegmentUID` of "0xb16a58609fc7e60653a60c984fc11ead".
@@ -695,7 +697,8 @@ Segment. A `Matroska Player` **MUST** play these linked `Edition`.
 
 ## Soft Linking
 
-Soft Linking is used by codec chapters. They can reference another `Segment` and jump to
+Soft Linking is used by Chapter Codecs ((#ordered-edition-and-matroska-segment-linking)).
+Chapter Codecs can reference another `Segment` and jump to
 that `Segment`. The way the `Segments` are described are internal to the chapter codec and
 unknown to the Matroska level. But there are `Elements` within the `Info Element`
 (such as `ChapterTranslate`) that can translate a value representing a `Segment` in the

--- a/notes.md
+++ b/notes.md
@@ -614,7 +614,8 @@ For each node of the chain of `Segments` of a `Linked Segment` at least one `Seg
 
 In a chain of `Segments` of a `Linked Segment` the `NextUID` always takes precedence over the `PrevUID`.
 So if SegmentA has a `NextUID` to SegmentB and SegmentB has a `PrevUID` to SegmentC,
-the link to use is `NextUID`.
+the link to use is `NextUID` between SegmentA and SegmentB, SegmentC is not part of the Linked Segment.
+
 If SegmentB has a `PrevUID` to SegmentA but SegmentA has no `NextUID`, then the Matroska Player
 **MAY** consider these two Segments linked as SegmentA followed by SegmentB.
 

--- a/notes.md
+++ b/notes.md
@@ -588,6 +588,9 @@ All `Segments` within a `Linked Segment` **SHOULD** be stored within the same di
 or be accessible quickly based on their `SegmentUID`
 in order to have seamless transition between segments.
 
+All `Segments` within a `Linked Segment` **MAY** set a `SegmentFamily` with a common value to make
+it easier for a `Matroska Player` to know which `Segments` are meant to be played together.
+
 ## Hard Linking
 
 Hard Linking, also called splitting, is the process of creating a `Linked Segment`
@@ -696,9 +699,7 @@ Soft Linking is used by codec chapters. They can reference another `Segment` and
 that `Segment`. The way the `Segments` are described are internal to the chapter codec and
 unknown to the Matroska level. But there are `Elements` within the `Info Element`
 (such as `ChapterTranslate`) that can translate a value representing a `Segment` in the
-chapter codec and to the current `SegmentUID`. All `Segments` that could be used in a `Linked Segment`
-in this way **SHOULD** be marked as members of the same family via the `SegmentFamily Element`,
-so that the `Matroska Player` can quickly switch from one to the other.
+chapter codec and to the current `SegmentUID`.
 
 
 

--- a/notes.md
+++ b/notes.md
@@ -601,13 +601,14 @@ the timestamps of `Block` and `SimpleBlock` from the previous `Segment` in linki
 With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST** only reference the current `Segment`.
 The `NextUID` and `PrevUID` reference the respective `SegmentUID` values of the next and previous `Segments`.
 
-The first `Segment` of a `Linked Segment` **SHOULD** have a `NextUID Element` and **MUST NOT** have a `PrevUID Element`.
-The last `Segment` of a `Linked Segment` **SHOULD** have a `PrevUID Element` and **MUST NOT** have a `NextUID Element`.
-The middle `Segments` of a `Linked Segment` **SHOULD** have both a `NextUID Element` and a `PrevUID Element`.
+The first `Segment` of a `Linked Segment` **MUST NOT** have a `PrevUID Element`.
+The last `Segment` of a `Linked Segment` **MUST NOT** have a `NextUID Element`.
 
-In a chain of `Linked Segments` the `NextUID` always takes precedence over the `PrevUID`.
-So if SegmentA has a NextUID to SegmentB and SegmentB has a PrevUID to SegmentC,
-the link to use is SegmentA to SegmentB.
+For each node of the chain of `Segments` of a `Linked Segment` at least one `Segment` **MUST** reference the other `Segment` of the node.
+
+In a chain of `Segments` of a `Linked Segment` the `NextUID` always takes precedence over the `PrevUID`.
+So if SegmentA has a `NextUID` to SegmentB and SegmentB has a `PrevUID` to SegmentC,
+the link to use is `NextUID`.
 If SegmentB has a PrevUID to SegmentA but SegmentA has no NextUID, then the Matroska Player
 **MAY** consider these two Segments linked as SegmentA followed by SegmentB.
 

--- a/notes.md
+++ b/notes.md
@@ -580,7 +580,7 @@ of `MuxingApp Element` in the above example is '26 - 21' or '5'.
 
 Matroska provides several methods to link two or more `Segment Elements` together to create
 a `Linked Segment`. A `Linked Segment` is a set of multiple `Segments` linked together into
-a single presentation by using Hard Linking, Medium Linking, or Soft Linking.
+a single presentation by using Hard Linking or Medium Linking.
 
 All `Segments` within a `Linked Segment` **MUST** have a `SegmentUID`.
 
@@ -697,15 +697,6 @@ A `Matroska Player` **MUST** play the content of the linked Segment from the
 
 When the `ChapterSegmentEditionUID` is set to a valid `EditionUID` from the linked
 Segment. A `Matroska Player` **MUST** play these linked `Edition`.
-
-## Soft Linking
-
-Soft Linking is used by Chapter Codecs ((#ordered-edition-and-matroska-segment-linking)).
-Chapter Codecs can reference another `Segment` and jump to
-that `Segment`. The way the `Segments` are described are internal to the chapter codec and
-unknown to the Matroska level. But there are `Elements` within the `Info Element`
-(such as `ChapterTranslate`) that can translate a value representing a `Segment` in the
-chapter codec and to the current `SegmentUID`.
 
 
 

--- a/notes.md
+++ b/notes.md
@@ -609,44 +609,44 @@ For each node of the chain of `Segments` of a `Linked Segment` at least one `Seg
 In a chain of `Segments` of a `Linked Segment` the `NextUID` always takes precedence over the `PrevUID`.
 So if SegmentA has a `NextUID` to SegmentB and SegmentB has a `PrevUID` to SegmentC,
 the link to use is `NextUID`.
-If SegmentB has a PrevUID to SegmentA but SegmentA has no NextUID, then the Matroska Player
+If SegmentB has a `PrevUID` to SegmentA but SegmentA has no `NextUID`, then the Matroska Player
 **MAY** consider these two Segments linked as SegmentA followed by SegmentB.
 
 As an example, three `Segments` can be Hard Linked as a `Linked Segment` through
-cross-referencing each other with `SegmentUID`, `PrevUID`, and `NextUID`, as in this table.
+cross-referencing each other with `SegmentUID`, `PrevUID`, and `NextUID`, as in this table:
 
 file name   | `SegmentUID`                      | `PrevUID`                         | `NextUID`
 :-----------|:----------------------------------|:----------------------------------|:---------
-`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | n/a                               | a77b3598941cb803 eac0fcdafe44fac9
+`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | Invalid                           | a77b3598941cb803 eac0fcdafe44fac9
 `middle.mkv`| a77b3598941cb803 eac0fcdafe44fac9 | 71000c23cd310998 53fbc94dd984a5dd | 6c92285fa6d3e827 b198d120ea3ac674
-`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | a77b3598941cb803 eac0fcdafe44fac9 | n/a
+`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | a77b3598941cb803 eac0fcdafe44fac9 | Invalid
 Table: Usual Hard Linking UIDs{#hardLinkingUIDs}
 
-An other example where only the `NextUID` Element is used.
+An other example where only the `NextUID` Element is used:
 
 file name   | `SegmentUID`                      | `PrevUID`                         | `NextUID`
 :-----------|:----------------------------------|:----------------------------------|:---------
-`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | n/a                               | a77b3598941cb803 eac0fcdafe44fac9
+`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | Invalid                           | a77b3598941cb803 eac0fcdafe44fac9
 `middle.mkv`| a77b3598941cb803 eac0fcdafe44fac9 | n/a                               | 6c92285fa6d3e827 b198d120ea3ac674
-`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | n/a                               | n/a
+`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | n/a                               | Invalid
 Table: Hard Linking without PrevUID{#hardLinkingWoPrevUID}
 
-A next example where only the `PrevUID` Element is used.
+An example where only the `PrevUID` Element is used:
 
 file name   | `SegmentUID`                      | `PrevUID`                         | `NextUID`
 :-----------|:----------------------------------|:----------------------------------|:---------
-`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | n/a                               | n/a
+`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | Invalid                           | n/a
 `middle.mkv`| a77b3598941cb803 eac0fcdafe44fac9 | 71000c23cd310998 53fbc94dd984a5dd | n/a
-`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | a77b3598941cb803 eac0fcdafe44fac9 | n/a
+`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | a77b3598941cb803 eac0fcdafe44fac9 | Invalid
 Table: Hard Linking without NextUID{#hardLinkingWoNextUID}
 
-In this example only the `middle.mkv` is using the `PrevUID` and `NextUID` Elements.
+In this example only the `middle.mkv` is using the `PrevUID` and `NextUID` Elements:
 
 file name   | `SegmentUID`                      | `PrevUID`                         | `NextUID`
 :-----------|:----------------------------------|:----------------------------------|:---------
-`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | n/a                               | n/a
+`start.mkv` | 71000c23cd310998 53fbc94dd984a5dd | Invalid                           | n/a
 `middle.mkv`| a77b3598941cb803 eac0fcdafe44fac9 | 71000c23cd310998 53fbc94dd984a5dd | 6c92285fa6d3e827 b198d120ea3ac674
-`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | n/a                               | n/a
+`end.mkv`   | 6c92285fa6d3e827 b198d120ea3ac674 | n/a                               | Invalid
 Table: Hard Linking with mixed UID links{#hardLinkingMixedUIDs}
 
 ## Medium Linking

--- a/notes.md
+++ b/notes.md
@@ -598,15 +598,12 @@ All `Segments` within a `Hard Linked Segment` **MUST** use the same `Tracks` lis
 Within a `Linked Segment`, the timestamps of `Block` and `SimpleBlock` **MUST** follow consecutively
 the timestamps of `Block` and `SimpleBlock` from the previous `Segment` in linking order.
 
-With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST**
-only reference the current `Segment`. With Hard Linking, the `NextUID` and `PrevUID` **MUST**
-reference the respective `SegmentUID` values of the next and previous `Segments`.
-The first `Segment` of a `Linked Segment` **SHOULD** have a `NextUID Element` and **MUST NOT**
-have a `PrevUID Element`.
-The last `Segment` of a `Linked Segment` **SHOULD** have a `PrevUID Element` and **MUST NOT**
-have a `NextUID Element`.
-The middle `Segments` of a `Linked Segment` **SHOULD** have both a `NextUID Element`
-and a `PrevUID Element`.
+With Hard Linking, the chapters of any `Segment` within the `Linked Segment` **MUST** only reference the current `Segment`.
+The `NextUID` and `PrevUID` **MUST** reference the respective `SegmentUID` values of the next and previous `Segments`.
+
+The first `Segment` of a `Linked Segment` **SHOULD** have a `NextUID Element` and **MUST NOT** have a `PrevUID Element`.
+The last `Segment` of a `Linked Segment` **SHOULD** have a `PrevUID Element` and **MUST NOT** have a `NextUID Element`.
+The middle `Segments` of a `Linked Segment` **SHOULD** have both a `NextUID Element` and a `PrevUID Element`.
 
 In a chain of `Linked Segments` the `NextUID` always takes precedence over the `PrevUID`.
 So if SegmentA has a NextUID to SegmentB and SegmentB has a PrevUID to SegmentC,

--- a/notes.md
+++ b/notes.md
@@ -672,31 +672,33 @@ The first chapter references the `Segment` of `intro.mkv` with the use of a `Cha
 `ChapterSegmentEditionUID`, `ChapterTimeStart`, and optionally a `ChapterTimeEnd` element.
 The second chapter references content within the `Segment` of `program.mkv`. A `Matroska Player`
 **SHOULD** recognize the `Linked Segment` created by the use of `ChapterSegmentUID` in an enabled
-`Edition` and present the reference content of the two `Segments` together.
+`Edition` and present the reference content of the two `Segments` as a single presentation.
 
-The `ChapterSegmentUID` is a binary value and the base element to set up a
-`Linked Chapter` in 2 variations: the Linked-Duration linking and the Linked-Edition
-linking. For both variations, the following 3 conditions **MUST** be met:
+The `ChapterSegmentUID` represents the Segment that holds the content to play in place of the `Linked Chapter`.
+The `ChapterSegmentUID` **MUST NOT** be the `SegmentUID` of its own `Segment`.
 
- 1. The `EditionFlagOrdered Flag` **MUST** be true.
- 2. The `ChapterSegmentUID` **MUST NOT** be the `SegmentUID` of its own `Segment`.
- 3. The linked Segments **MUST** BE in the same folder.
+There are 2 ways to use a chapter link:
+* Linked-Duration linking,
+* Linked-Edition linking
 
-### Variation 1: Linked-Duration
+### Linked-Duration
 
-Two more conditions **MUST** be met:
+A `Matroska Player` **MUST** play the content of the linked Segment
+from the `ChapterTimeStart` until `ChapterTimeEnd` timestamp in place of the `Linked Chapter`.
 
- 1. `ChapterTimeStart` and `ChapterTimeEnd` timestamps **MUST** be in the range of the
-    linked Segment duration.
- 2. `ChapterSegmentEditionUID` **MUST NOT** be set.
+`ChapterTimeStart` and `ChapterTimeEnd` represent timestamps in the Linked Segment matching the value of `ChapterSegmentUID`.
+Their values **MUST** be in the range of the linked Segment duration.
 
-A `Matroska Player` **MUST** play the content of the linked Segment from the
-`ChapterTimeStart` until `ChapterTimeEnd` timestamp.
+The `ChapterTimeEnd` value **MUST** be set when using linked-duration chapter linking.
+`ChapterSegmentEditionUID` **MUST NOT** be set.
 
-### Variation 2: Linked-Edition
+### Linked-Edition
 
-When the `ChapterSegmentEditionUID` is set to a valid `EditionUID` from the linked
-Segment. A `Matroska Player` **MUST** play these linked `Edition`.
+A `Matroska Player` **MUST** play the whole linked `Edition` of the linked Segment in place of the `Linked Chapter`.
+
+`ChapterSegmentEditionUID` represents a valid Edition from the Linked Segment matching the value of `ChapterSegmentUID`.
+
+When using linked-edition chapter linking. `ChapterTimeEnd` **MUST NOT** be set.
 
 
 

--- a/notes.md
+++ b/notes.md
@@ -574,6 +574,8 @@ an `Element` is calculated by subtracting the position of the `Element Data` of
 the containing `Segment Element` from the position of that `Element`, the `Segment Position`
 of `MuxingApp Element` in the above example is '26 - 21' or '5'.
 
+
+
 # Linked Segments
 
 Matroska provides several methods to link two or more `Segment Elements` together to create
@@ -698,6 +700,8 @@ unknown to the Matroska level. But there are `Elements` within the `Info Element
 chapter codec and to the current `SegmentUID`. All `Segments` that could be used in a `Linked Segment`
 in this way **SHOULD** be marked as members of the same family via the `SegmentFamily Element`,
 so that the `Matroska Player` can quickly switch from one to the other.
+
+
 
 # Track Flags
 


### PR DESCRIPTION
* soft linking is not a real segment linking, it's a way to seek into other segments, there's no virtual segment involved (single presentation)
* SegmentFilename, PrevFilename and NextFilename are mostly for file recovery
* SegmentFamily is a generic thing usable by segment linking *and* chapter codec seeking
* mark the NextUID/PrevUID as invalid for the first/last linked segment
* make at least one NextUID/PrevUID mandatory per link node
* group/split rules that apply to hard linking, medium linking or both
* +add an example of chapter codec seeking/linking

Fixes #490