### PR TITLE
add a section for nested chapters rules

### DIFF
--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -28,6 +28,34 @@ The translation `ChapterTranslate` in SegmentB would use the following elements:
 The `Matroska Player` **MUST** use the `SegmentFamily` to find all Segments that need translation
 between the chapter codec values and the actual segment it targets.
 
+# Matroska Chapter Codecs and Nested Chapters
+
+When `Nested Chapters` contain chapters codecs -- via the `ChapProcess` Element --
+the enter/leave commands -- ChapProcessTime Element -- **MUST** be executed in a specific order,
+if the Matroska Player supports the chapter codecs included in the chapters.
+
+When starting playback, the `Matroska Player` **MUST** start at the `ChapterTimeStart` of the first chapter of the ordered chapter.
+The enter commands of that chapter **MUST** be executed.
+If that chapter contains `Nested Chapters`, the enter commands of the `Nested Chapter` with the same `ChapterTimeStart` **MUST** be executed.
+If that chapter contains `Nested Chapters`, the enter commands of the `Nested Chapter` with the same `ChapterTimeStart` **MUST** be executed,
+and so on until there is no `Nested Chapter` with the same `ChapterTimeStart`.
+
+When switching from a chapter to another:
+
+* the leave commands (`ChapProcessTime`=2) of the
+chapter **MUST** be executed, then the leave commands of its parent chapter, etc. until the
+common `Parent Chapter` or `Edition` element. The leave command of that `Parent Chapter` or `Edition` element
+**MUST NOT** be executed.
+* the enter commands (`ChapProcessTime`=1) of the `Nested Chapter` of the common `Parent Chapter` or `Edition` element,
+to reach the chapter we switch to, **MUST** be executed, then the enter commands of its `Nested Chapter`
+to reach the chapter we switch to **MUST** be executed, until that chapter is the chapter we switch to.
+The enter commands of that chapter **MUST** be executed as well.
+
+When the last Chapter finished playing -- i.e. its `ChapterTimeEnd` has been reached --
+the `Matroska Player` **MUST** execute its leaved commands, then the leave commands of it's `Parent Chapter`,
+until the parent of the chapter is the Edition.
+
+
 ## Matroska Script (0)
 
 This is the case when `ChapProcessCodecID` = 0\. This is a script language build for

--- a/chapters.md
+++ b/chapters.md
@@ -135,17 +135,17 @@ If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `Chapt
 
 Each Chapter
 `ChapterFlagHidden` flag works independently from parent chapters.
-A `Nested Chapter` with `ChapterFlagHidden` flag set to `false` remains visible even if the
-`Parent Chapter` `ChapterFlagHidden` flag is set to `true`.
+A `Nested Chapter` with a `ChapterFlagHidden` that evaluates to "0" remains visible in the user interface even if the
+`Parent Chapter` `ChapterFlagHidden` flag is set to "1".
 
 Chapter + Nested Chapter | ChapterFlagHidden | visible
 :------------------------|:------------------|:-------
-Chapter 1                | false             | yes
- Nested Chapter 1.1      | false             | yes
- Nested Chapter 1.2      | true              | no
-Chapter 2                | true              | no
- Nested Chapter 2.1      | false             | yes
- Nested Chapter 2.2      | true              | no
+Chapter 1                | 0                 | yes
+ Nested Chapter 1.1      | 0                 | yes
+ Nested Chapter 1.2      | 1                 | no
+Chapter 2                | 1                 | no
+ Nested Chapter 2.1      | 0                 | yes
+ Nested Chapter 2.2      | 1                 | no
 Table: ChapterFlagHidden nested visibility{#ChapterFlagHiddenNested}
 
 ## Menu features

--- a/chapters.md
+++ b/chapters.md
@@ -68,7 +68,7 @@ play those Chapters in their stored order from the timestamp marked in the
 If the `EditionFlagOrdered Flag` evaluates to "0", `Simple Chapters` are used and
 only the `ChapterTimeStart` of a `Chapter` is used as chapter mark to jump to the
 predefined point in the timeline. With `Simple Chapters`, a `Matroska Player` **MUST**
-ignore certain `Chapter Elements`. All these elements are now informational only.
+ignore certain `Chapter Elements`. In that case these elements are informational only.
 
 The following list shows the different Chapter elements only found in `Ordered Chapters`.
 
@@ -96,7 +96,6 @@ about `Hard Linking` and `Medium Linking`.
 
 ## ChapterAtom
 The `ChapterAtom` is also called a `Chapter`.
-A `Chapter` element can be used recursively. Such a child `Chapter` is called `Nested Chapter`.
 
 ### ChapterTimeStart
 The timestamp of the start of `Chapter` with nanosecond accuracy, not scaled by TimestampScale.
@@ -121,6 +120,16 @@ Chapter 2 | 1000000000      | 5000000000    | 4000000000
 Chapter 3 | 6000000000      | 6000000000    | 0
 Chapter 4 | 9000000000      | 8000000000    | Invalid (-1000000000)
 Table: ChapterTimeEnd usage possibilities{#ChapterTimeEndUsage}
+
+### Nested Chapters
+
+A `ChapterAtom` element can contain other `ChapterAtom` elements.
+That element is a `Parent Chapter` and the `ChapterAtom` elements it contains are `Nested Chapters`.
+
+The `ChapterTimeStart` of a `Nested Chapter` **MUST** be greater than or equal to the `ChapterTimeStart` its `Parent Chapter`.
+
+If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `ChapterTimeStart` of that `Nested Chapter`
+**MUST** be smaller than or equal to the `ChapterTimeEnd` of the `Parent Chapter`.
 
 ### ChapterFlagHidden
 

--- a/chapters.md
+++ b/chapters.md
@@ -126,6 +126,9 @@ Table: ChapterTimeEnd usage possibilities{#ChapterTimeEndUsage}
 A `ChapterAtom` element can contain other `ChapterAtom` elements.
 That element is a `Parent Chapter` and the `ChapterAtom` elements it contains are `Nested Chapters`.
 
+Nested Chapters can be useful to tag small parts of a Segment that already have tags or
+add Chapter Codec commands on smaller parts of a Segment that already have Chapter Codec commands.
+
 The `ChapterTimeStart` of a `Nested Chapter` **MUST** be greater than or equal to the `ChapterTimeStart` its `Parent Chapter`.
 
 If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `ChapterTimeStart` of that `Nested Chapter`

--- a/chapters.md
+++ b/chapters.md
@@ -131,6 +131,41 @@ The `ChapterTimeStart` of a `Nested Chapter` **MUST** be greater than or equal t
 If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `ChapterTimeStart` of that `Nested Chapter`
 **MUST** be smaller than or equal to the `ChapterTimeEnd` of the `Parent Chapter`.
 
+### Nested Chapters in Ordered Chapters
+
+When used with Ordered Chapters, `Parent Chapters` **MUST** use the highest `ChapterTimeEnd` value of its direct `Nested Chapters`.
+
+For example, some chapters in a Order Chapter edition:
+
+* Chapter 1: start 10s
+    * Chapter 1.1: start 10s
+         * Chapter 1.1.1: start 10s / end 30s
+         * Chapter 1.1.2: start 30s / end 50s
+    * Chapter 1.2: start 20s / end 25s
+
+A `Matroska Player` should play the content from 10s to 30s (1.1.1), then 30s to 50s (1.1.2),
+then 20s to 25s (1.2).
+
+The `ChapterTimeEnd` value for chapter 1.1.1, 1.1.2 and 1.2 are required to properly define the playback order.
+Chapter 1.1 and 1 don't have a `ChapterTimeEnd` value set, but `ChapterTimeEnd` is required, as they are in an ordered edition.
+They must have the highest `ChapterTimeEnd` value of their children.
+So Chapter 1.1 would get the highest between "30s" and "50s", so "50s".
+Chapter 1 would get the highest between "50s" and "25s", so "50s".
+But it doesn't correspond to the actual duration of Chapter 1 which is playing 10-30s, 30-50s, 20-25s.
+This layout of nested ordered chapters is not valid. It should be split as follows:
+
+* Chapter 1: start 10s / end 50s
+    * Chapter 1.1: start 10s / end 50s
+         * Chapter 1.1.1: start 10s / end 30s
+         * Chapter 1.1.2: start 30s / end 50s
+* Chapter 2: start 20s / end 25s
+    * Chapter 2.1: start 20s / end 25s
+
+In order to be able to set a valid `ChapterTimeEnd` on a `Parent Chapter` elements,
+all direct `Nested Chapters` of that `Parent Chapter` **MUST** have consecutive timestamps.
+In other words, the following `ChapterTimeStart` of a direct `Nested Chapter` **MUST** be the same
+as the `ChapterTimeEnd` of the previous direct `Nested Chapter`, unless it is the first `Nested Chapter` at that level.
+
 ### ChapterFlagHidden
 
 Each Chapter

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1310,7 +1310,7 @@ the last frame it includes, especially for the `ChapterAtom` using the last fram
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if a chapter is hidden. Hidden chapters it **SHOULD NOT** be available to the user interface
+    <documentation lang="en" purpose="definition">Set to 1 if a chapter is hidden. Hidden chapters **SHOULD NOT** be available to the user interface
 (but still to Control Tracks; see (#chapterflaghidden) on Chapter flags).</documentation>
   </element>
   <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">


### PR DESCRIPTION
Also clean the ChapterFlagHidden table, there's no true/false in Matroska.

Fixes #232 by making explicit the rules that were found in DvdMenuXtractor and VLC and explaining why some usage are not possible.