### PR TITLE
allow chapter duration of 0

### DIFF
--- a/chapters.md
+++ b/chapters.md
@@ -109,6 +109,11 @@ A `Matroska Player` calculates the duration of this `Chapter` using the differen
 `ChapterTimeEnd` and `ChapterTimeStart`.
 The end timestamp **MUST** be greater than or equal to the start timestamp.
 
+When the `ChapterTimeEnd` timestamp is equal to the `ChapterTimeStart` timestamp,
+the timestamps is included in the `Chapter`. It can be useful to put markers in
+a file or add chapter commands with ordered chapter commands without having to play anything;
+see (#chapprocess-element).
+
 Chapter   | Start timestamp | End timestamp | Duration
 :---------|:----------------|:--------------|:-----
 Chapter 1 | 0               | 1000000000    | 1000000000

--- a/chapters.md
+++ b/chapters.md
@@ -107,13 +107,13 @@ The timestamp of the end of `Chapter` with nanosecond accuracy, not scaled by Ti
 The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
 A `Matroska Player` calculates the duration of this `Chapter` using the difference between the
 `ChapterTimeEnd` and `ChapterTimeStart`.
-The end timestamp **MUST** be strictly greater than the start timestamp.
+The end timestamp **MUST** be greater than or equal to the start timestamp.
 
 Chapter   | Start timestamp | End timestamp | Duration
 :---------|:----------------|:--------------|:-----
 Chapter 1 | 0               | 1000000000    | 1000000000
 Chapter 2 | 1000000000      | 5000000000    | 4000000000
-Chapter 3 | 6000000000      | 6000000000    | Invalid (0)
+Chapter 3 | 6000000000      | 6000000000    | 0
 Chapter 4 | 9000000000      | 8000000000    | Invalid (-1000000000)
 Table: ChapterTimeEnd usage possibilities{#ChapterTimeEndUsage}
 

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1304,7 +1304,10 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
   <element name="ChapterTimeEnd" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeEnd" id="0x92" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">Timestamp of the end of Chapter (timestamp excluded, not scaled).
 The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
-    <documentation lang="en" purpose="usage notes">If the Edition is an ordered edition, see (#editionflagordered),  then this Element is **REQUIRED**.</documentation>
+    <documentation lang="en" purpose="usage notes">The `ChapterTimeEnd` timestamp value being excluded, it **MUST** take in account the duration of
+the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.
+
+If the Edition is an ordered edition, see (#editionflagordered),  then this Element is **REQUIRED**.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1303,7 +1303,7 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
   </element>
   <element name="ChapterTimeEnd" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTimeEnd" id="0x92" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">Timestamp of the end of Chapter (timestamp excluded, not scaled).
-The value **MUST** be strictly greater than the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
+The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
     <documentation lang="en" purpose="usage notes">If the Edition is an ordered edition, see (#editionflagordered),  then this Element is **REQUIRED**.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1305,9 +1305,8 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
     <documentation lang="en" purpose="definition">Timestamp of the end of Chapter (timestamp excluded, not scaled).
 The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
     <documentation lang="en" purpose="usage notes">The `ChapterTimeEnd` timestamp value being excluded, it **MUST** take in account the duration of
-the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.
-
-If the Edition is an ordered edition, see (#editionflagordered),  then this Element is **REQUIRED**.</documentation>
+the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.</documentation>
+    <implementation_note note_attribute="minOccurs">ChapterTimeEnd **MUST** be set (minOccurs=1) the Edition is an ordered edition; see (#editionflagordered)</implementation_note>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">


### PR DESCRIPTION
There can be segments with just chapters containing commands.

In ordered chapters the content will not play anything, it may seek to the
position for nothing but that's not a big deal.

Fixes #542