### PR TITLE
Clean ReferenceBlock definition

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -169,8 +169,13 @@ of this Block and the timestamp of the next Block in "display" order (not coding
 In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
   </element>
   <element name="ReferenceBlock" path="\Segment\Cluster\BlockGroup\ReferenceBlock" id="0xFB" type="integer">
-    <documentation lang="en" purpose="definition">Timestamp of another frame used as a reference (ie: B or P frame).
-The timestamp is relative to the block it's attached to.
+    <documentation lang="en" purpose="definition">A timestamp value, relative to the timestamp of the Block in this BlockGroup.
+This is used to reference other frames necessary to decode this frame.
+The relative value **SHOULD** correspond to a valid `Block` this `Block` depends on.
+Historically Matroska Writer didn't write the actual `Block(s)` this `Block` depends on, but *some* `Block` in the past.
+
+The value "0" **MAY** also be used to signify this `Block` cannot be decoded on its own, but without knownledge of which `Block` is necessary. In this case, other `ReferenceBlock` **MUST NOT** be found in the same `BlockGroup`.
+
 If the `BlockGroup` doesn't have any `ReferenceBlock` element, then the `Block` it contains can be decoded without using any other `Block` data.</documentation>
   </element>
   <element name="ReferenceVirtual" path="\Segment\Cluster\BlockGroup\ReferenceVirtual" id="0xFD" type="integer" minver="0" maxver="0" maxOccurs="1">


### PR DESCRIPTION
Following the discussion in #419 here are some conclusion

* we can assume `ReferenceBlock` present means the `BlockGroup` can't be decoded on its own
* the absence of `ReferenceBlock` means the `BlockGroup` can be decoded on its own, (most) audio codec and subtitle codec won't be affected. Video codecs should already be handled by existing muxers as shown by the analysis below
* it's supposed to be a proper Block timestamp referenced and it's actually the case in known implementations
* it's usually not the proper referenced block in existing implementations, so we mention it's not really reliable (too bad for editing files at the container level)
* "0" sounds like a better value in this case, rather than lying about it

We're effectively compatible with [WebM](https://w3c.github.io/mse-byte-stream-format-webm/#webm-random-access-points). As we don't need an "unknown interpretation when the element is not present".

libavformat sets a dummy value (not proper reference) when a `Block` is not a keyframe (and in the rare case it's actually writing a `BlockGroup`)
https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/matroskaenc.c#L2112

libwebm also sets a dummy value
https://aomedia.googlesource.com/aom/+/refs/heads/master/third_party/libwebm/mkvmuxer/mkvmuxer.cc#2584
https://aomedia.googlesource.com/aom/+/refs/heads/master/third_party/libwebm/mkvmuxer/mkvmuxer.cc#3584
then writes it
https://aomedia.googlesource.com/aom/+/refs/heads/master/third_party/libwebm/mkvmuxer/mkvmuxerutil.cc#72
https://aomedia.googlesource.com/aom/+/refs/heads/master/third_party/libwebm/mkvmuxer/mkvmuxerutil.cc#139

mkvtoolnix is more refined and allows a past and post reference timestamp
https://gitlab.com/mbunkus/mkvtoolnix/-/blob/main/src/merge/libmatroska_extensions.cpp#L53
But according to Moritz it's not that clean either https://github.com/ietf-wg-cellar/matroska-specification/issues/419#issuecomment-851012632