### PR TITLE
make AlphaMode mandatory

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -484,7 +484,7 @@ with the top line of the top field stored first.</documentation>
     <extension type="libmatroska" cppname="VideoStereoMode"/>
   </element>
   <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if the BlockAdditional Element **MAY** contain Alpha data.</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if the BlockAdditional Element with BlockAddID of "1" contains Alpha data.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoAlphaMode"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -483,7 +483,7 @@ with the top line of the top field stored first.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoStereoMode"/>
   </element>
-  <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" maxOccurs="1">
+  <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Alpha Video Mode. Presence of this Element indicates that
 the BlockAdditional Element could contain Alpha data.</documentation>
     <extension type="webmproject.org" webm="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -484,7 +484,17 @@ with the top line of the top field stored first.</documentation>
     <extension type="libmatroska" cppname="VideoStereoMode"/>
   </element>
   <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if the BlockAdditional Element with BlockAddID of "1" contains Alpha data.</documentation>
+    <documentation lang="en" purpose="definition">Indicate whether the BlockAdditional Element with BlockAddID of "1" contains Alpha data, as defined by to the Codec Mapping for the `CodecID`.
+Undefined values **SHOULD NOT** be used as the behavior of known implementations is different (considered either as 0 or 1).</documentation>
+    <restriction>
+      <enum value="0" label="none">
+        <documentation lang="en" purpose="definition">The BlockAdditional Element with BlockAddID of "1" does not exist or **SHOULD NOT** be considered as containing such data.</documentation>
+      </enum>
+      <enum value="1" label="present">
+        <documentation lang="en" purpose="definition">The BlockAdditional Element with BlockAddID of "1" contains alpha channel data.</documentation>
+      </enum>
+    </restriction>
+
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoAlphaMode"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -484,8 +484,7 @@ with the top line of the top field stored first.</documentation>
     <extension type="libmatroska" cppname="VideoStereoMode"/>
   </element>
   <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Alpha Video Mode. Presence of this Element indicates that
-the BlockAdditional Element could contain Alpha data.</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if the BlockAdditional Element **MAY** contain Alpha data.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoAlphaMode"/>
   </element>


### PR DESCRIPTION
This is a WebM thing loosely defined. I'm not sure where the default value
came from.

Having just the presence of the element present to signal something is at odd
with all other elements. The default value in this case has no use. And
following the discussions in #501 elements with a default value would preferably
be mandatory. But that's not possible with the "presence" signaling something.

So just remove the default value.

Both libavformat [1] and libwebm [2] write a value of 1 when they want to signal
it.

[1] https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/matroskaenc.c#L1274
[2] https://aomedia.googlesource.com/aom/+/refs/heads/master/third_party/libwebm/mkvmuxer/mkvmuxer.cc#1522