### PR TITLE
avs3 (IEEE 1857.10) video codec mapping

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -272,6 +272,16 @@ Description: Individual pictures of AVS2-P2 stored as described in the second pa
 
 Initialization: none.
 
+### V_AVS3
+
+Codec ID: V_AVS3
+
+Codec Name: AVS3-P2/IEEE1857.10
+
+Description: Individual pictures of AVS3-P2 stored as described in the second part of [@!IEEE1857.10].
+
+Initialization: none.
+
 ### V_REAL/RV10
 
 Codec ID: V_REAL/RV10

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -276,9 +276,9 @@ Initialization: none.
 
 Codec ID: V_AVS3
 
-Codec Name: AVS3-P2/IEEE1857.10
+Codec Name: AVS3-P2/IEEE.1857.10
 
-Description: Individual pictures of AVS3-P2 stored as described in the second part of [@!IEEE1857.10].
+Description: Individual pictures of AVS3-P2 stored as described in the second part of [@!IEEE.1857-10].
 
 Initialization: none.
 

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -21,7 +21,7 @@
   </front>
 </reference>
 
-<reference anchor="IEEE.1857_10" target="https://standards.ieee.org/standard/1857_10-2021.html">
+<reference anchor="IEEE.1857-10" target="https://standards.ieee.org/standard/1857_10-2021.html">
   <front>
     <title>IEEE Standard for Third Generation Video Coding</title>
     <author>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -21,6 +21,16 @@
   </front>
 </reference>
 
+<reference anchor="IEEE.1857_10" target="https://standards.ieee.org/standard/1857_10-2021.html">
+  <front>
+    <title>IEEE Standard for Third Generation Video Coding</title>
+    <author>
+      <organization>IEEE</organization>
+    </author>
+    <date year="2021" month="November" day="9"/>
+  </front>
+</reference>
+
 <reference anchor="IEEE.754" target="https://standards.ieee.org/standard/754-2019.html">
   <front>
     <title>IEEE Standard for Binary Floating-Point Arithmetic</title>


### PR DESCRIPTION
Standard document:
1857.10-2021 - IEEE Standard for Third Generation Video Coding (https://standards.ieee.org/standard/1857_10-2021.html)

Encoding tool:
Ffmpeg with avs3 enabled: https://github.com/xatabhk/FFmpeg-avs2-avs3/releases/tag/n4.4-dev-avs3
Command line:

             ffmpeg -i xxxx.mp4 -vcodec avs3 -acodec copy xxxx_avs3.mkv
             ffmpeg -i xxxx.mp4 -vcodec avs3 -acodec copy xxxx_avs3.mkv`

Players:
(1) Ffmpeg with avs3 enabled: (https://github.com/xatabhk/FFmpeg-avs2-avs3/releases/tag/n4.4-dev-avs3):
Command line:

             ffplay xxxx_avs3.mkv
(2) VLC 3.0.x with avs3 enabled: https://github.com/xatabhk/vlc-3.0-avs2-avs3/releases
(3) Mpc-hc 1.9.x with avs3 enabled: https://gitee.com/zhengtianbo/cavs-avs2-avs3_decoder_added_to_mpc_hc/releases

Avs3-MKV samples:
https://github.com/xatabhk/avs2-avs3-video-samples