### PR TITLE
Remove duplicate rule on the placement of the Cluster Timestamp

### DIFF
--- a/ordering.md
+++ b/ordering.md
@@ -125,8 +125,3 @@ new `Tags Element` written at the end of the `Segment Element`. The file size wi
 * Tags
 * Cues
 * Clusters
-
-## Cluster Timestamp
-
-The `Timestamp Element` **MUST** occur as in storage order before any `SimpleBlock`,
-`BlockGroup`, or `EncryptedBlock`, within the `Cluster Element`.


### PR DESCRIPTION
It's already defined, better, in the Timestamp section
https://github.com/ietf-wg-cellar/matroska-specification/blob/d77cdd7eb536443493d01e589e548cb813e635e0/ebml_matroska.xml#L110