### PR TITLE
make ChapterTimeEnd not mandatory on parent chapters in ordered editions

### DIFF
--- a/chapters.md
+++ b/chapters.md
@@ -83,7 +83,7 @@ The following list shows the different Chapter elements only found in `Ordered C
 Table: elements only found in ordered chapters{#orderedOnly}
 
 Furthermore there are other EBML `Elements` which could be used if the `EditionFlagOrdered`
-flag is set to `true`.
+evaluates to "1".
 
 #### Ordered-Edition and Matroska Segment-Linking
 

--- a/chapters.md
+++ b/chapters.md
@@ -136,27 +136,11 @@ If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `Chapt
 
 ### Nested Chapters in Ordered Chapters
 
-Consider some chapters in a Ordered Chapter edition:
+The `ChapterTimeEnd` of the lowest level of `Nested Chapters` **MUST** be set for Ordered Chapters.
 
-* Chapter 1: start 10s
-    * Chapter 1.1: start 10s
-         * Chapter 1.1.1: start 10s / end 30s
-         * Chapter 1.1.2: start 45s / end 50s
-    * Chapter 1.2: start 40s / end 45s
-
-A `Matroska Player` should play the content from 10s to 30s (1.1.1), then 45s to 50s (1.1.2),
-then 40s to 45s (1.2).
-
-If Chapter 1.1 had a `ChapterTimeEnd` it should include the content that is actually
-played, so it should be "50s". So when the `Parent Chapter` `ChapterTimeEnd` is set,
-it **MUST** use the highest `ChapterTimeEnd` value of its direct `Nested Chapters`.
-
-But if the `Matroska Player` doesn't read the lower `Nested Chapters`,
-it would actually play "10s" to "50s" which is not what is expected.
-So the `ChapterTimeEnd` of the lowest level of `Nested Chapters` **MUST** be used for playback.
-
-In the `ChapterTimeEnd` value of a `Parent Chapter` is useless for playback.
-When used with Ordered Chapters, the `ChapterTimeEnd` is **NOT RECOMMENDED** in `Parent Chapters`.
+When used with Ordered Chapters, the `ChapterTimeEnd` value of a `Parent Chapter` is useless for playback
+as the proper playback sections are described in its `Nested Chapters`.
+The `ChapterTimeEnd` **SHOULD NOT** be set in `Parent Chapters` and **MUST** be ignored for playback.
 
 ### ChapterFlagHidden
 

--- a/chapters.md
+++ b/chapters.md
@@ -169,6 +169,21 @@ all direct `Nested Chapters` of that `Parent Chapter` **MUST** have consecutive 
 In other words, the following `ChapterTimeStart` of a direct `Nested Chapter` **MUST** be the same
 as the `ChapterTimeEnd` of the previous direct `Nested Chapter`, unless it is the first `Nested Chapter` at that level.
 
+For example, consider this slightly different playback sequence which plays a part of a gap after the main content:
+
+* Chapter 1: start 10s
+    * Chapter 1.1: start 10s
+         * Chapter 1.1.1: start 10s / end 30s
+         * Chapter 1.1.2: start 40s / end 50s
+    * Chapter 1.2: start 35s / end 40s
+
+The `ChapterTimeEnd` and `ChapterTimeStart` of chapters 1.1.1 and 1.1.2 are not consecutive.
+The `ChapterTimeEnd` of chapter 1.1 cannot be set to "50s" otherwise the `Matroska Player`
+might interpret it as playing from "10s" to "50s" and compute the duration using that.
+Chapter 1 would also use "10s" to "50s" which is not correct as it would include "30s" to "35s"
+which is not used. It is not possible to set `ChapterTimeEnd` of Chapter 1 appropriately unless it's not
+used by the `Matroska Player`. If it's ignored by the player there is no real use of setting it.
+
 ### ChapterFlagHidden
 
 Each Chapter

--- a/chapters.md
+++ b/chapters.md
@@ -136,53 +136,27 @@ If the `Parent Chapter` of a `Nested Chapter` has a `ChapterTimeEnd`, the `Chapt
 
 ### Nested Chapters in Ordered Chapters
 
-When used with Ordered Chapters, `Parent Chapters` **MUST** use the highest `ChapterTimeEnd` value of its direct `Nested Chapters`.
-
-For example, some chapters in a Order Chapter edition:
+Consider some chapters in a Ordered Chapter edition:
 
 * Chapter 1: start 10s
     * Chapter 1.1: start 10s
          * Chapter 1.1.1: start 10s / end 30s
-         * Chapter 1.1.2: start 30s / end 50s
-    * Chapter 1.2: start 20s / end 25s
+         * Chapter 1.1.2: start 45s / end 50s
+    * Chapter 1.2: start 40s / end 45s
 
-A `Matroska Player` should play the content from 10s to 30s (1.1.1), then 30s to 50s (1.1.2),
-then 20s to 25s (1.2).
+A `Matroska Player` should play the content from 10s to 30s (1.1.1), then 45s to 50s (1.1.2),
+then 40s to 45s (1.2).
 
-The `ChapterTimeEnd` value for chapter 1.1.1, 1.1.2 and 1.2 are required to properly define the playback order.
-Chapter 1.1 and 1 don't have a `ChapterTimeEnd` value set, but `ChapterTimeEnd` is required, as they are in an ordered edition.
-They must have the highest `ChapterTimeEnd` value of their children.
-So Chapter 1.1 would get the highest between "30s" and "50s", so "50s".
-Chapter 1 would get the highest between "50s" and "25s", so "50s".
-But it doesn't correspond to the actual duration of Chapter 1 which is playing 10-30s, 30-50s, 20-25s.
-This layout of nested ordered chapters is not valid. It should be split as follows:
+If Chapter 1.1 had a `ChapterTimeEnd` it should include the content that is actually
+played, so it should be "50s". So when the `Parent Chapter` `ChapterTimeEnd` is set,
+it **MUST** use the highest `ChapterTimeEnd` value of its direct `Nested Chapters`.
 
-* Chapter 1: start 10s / end 50s
-    * Chapter 1.1: start 10s / end 50s
-         * Chapter 1.1.1: start 10s / end 30s
-         * Chapter 1.1.2: start 30s / end 50s
-* Chapter 2: start 20s / end 25s
-    * Chapter 2.1: start 20s / end 25s
+But if the `Matroska Player` doesn't read the lower `Nested Chapters`,
+it would actually play "10s" to "50s" which is not what is expected.
+So the `ChapterTimeEnd` of the lowest level of `Nested Chapters` **MUST** be used for playback.
 
-In order to be able to set a valid `ChapterTimeEnd` on a `Parent Chapter` elements,
-all direct `Nested Chapters` of that `Parent Chapter` **MUST** have consecutive timestamps.
-In other words, the following `ChapterTimeStart` of a direct `Nested Chapter` **MUST** be the same
-as the `ChapterTimeEnd` of the previous direct `Nested Chapter`, unless it is the first `Nested Chapter` at that level.
-
-For example, consider this slightly different playback sequence which plays a part of a gap after the main content:
-
-* Chapter 1: start 10s
-    * Chapter 1.1: start 10s
-         * Chapter 1.1.1: start 10s / end 30s
-         * Chapter 1.1.2: start 40s / end 50s
-    * Chapter 1.2: start 35s / end 40s
-
-The `ChapterTimeEnd` and `ChapterTimeStart` of chapters 1.1.1 and 1.1.2 are not consecutive.
-The `ChapterTimeEnd` of chapter 1.1 cannot be set to "50s" otherwise the `Matroska Player`
-might interpret it as playing from "10s" to "50s" and compute the duration using that.
-Chapter 1 would also use "10s" to "50s" which is not correct as it would include "30s" to "35s"
-which is not used. It is not possible to set `ChapterTimeEnd` of Chapter 1 appropriately unless it's not
-used by the `Matroska Player`. If it's ignored by the player there is no real use of setting it.
+In the `ChapterTimeEnd` value of a `Parent Chapter` is useless for playback.
+When used with Ordered Chapters, the `ChapterTimeEnd` is **NOT RECOMMENDED** in `Parent Chapters`.
 
 ### ChapterFlagHidden
 

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1306,7 +1306,7 @@ Use for WebVTT cue identifier storage [@!WebVTT].</documentation>
 The value **MUST** be greater than or equal to the `ChapterTimeStart` of the same `ChapterAtom`.</documentation>
     <documentation lang="en" purpose="usage notes">The `ChapterTimeEnd` timestamp value being excluded, it **MUST** take in account the duration of
 the last frame it includes, especially for the `ChapterAtom` using the last frames of the `Segment`.</documentation>
-    <implementation_note note_attribute="minOccurs">ChapterTimeEnd **MUST** be set (minOccurs=1) the Edition is an ordered edition; see (#editionflagordered)</implementation_note>
+    <implementation_note note_attribute="minOccurs">ChapterTimeEnd **MUST** be set (minOccurs=1) if the Edition is an ordered edition; see (#editionflagordered), unless it's a `Parent Chapter`; see (#nested-chapters)</implementation_note>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">

--- a/notes.md
+++ b/notes.md
@@ -682,7 +682,7 @@ A `Matroska Player` **MUST** play the whole linked `Edition` of the linked Segme
 
 `ChapterSegmentEditionUID` represents a valid Edition from the Linked Segment matching the value of `ChapterSegmentUID`.
 
-When using linked-edition chapter linking. `ChapterTimeEnd` **MUST NOT** be set.
+When using linked-edition chapter linking. `ChapterTimeEnd` is **OPTIONAL**.
 
 
 


### PR DESCRIPTION
Given the example in de5e15a73fb4b87171cee0fad6dee1ead8ce3a9d it's clear that when it's set on a Parent Chapter it cannot be used for playback. Even when parts are contiguous.

Remove the example that was there to illustrate the old rule. Simple rules tell the whole story without going through each case.

This is still compatible with how DvdMenuXtractor generates chapter timestamps.