### PR TITLE
Generate the initial IANA registry for Matroska IDs

### DIFF
--- a/.github/workflows/generate-rfcs.yaml
+++ b/.github/workflows/generate-rfcs.yaml
@@ -46,6 +46,7 @@ jobs:
           mv draft-ietf-cellar-tags-??.xml artifacts
           mv draft-ietf-cellar-chapter-codecs-??.xml artifacts
           mv draft-ietf-cellar-control-??.xml artifacts
+          mv matroska_iana.xml artifacts
 
       - name: XML Artifact
         uses: actions/upload-artifact@master

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EBML_SCHEMA_XSD := ../ebml-specification/EBMLSchema.xsd
 XML2RFC := $(XML2RFC_CALL) --v3
 MMARK := $(MMARK_CALL)
 
-all: matroska codecs tags chapter_codecs control
+all: matroska codecs tags chapter_codecs control matroska_iana.xml
 	$(info RFC rendering has been tested with mmark version 2.2.8 and xml2rfc 2.46.0, please ensure these are installed and recent enough.)
 
 matroska: $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).xml
@@ -47,6 +47,9 @@ ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_
 
 matroska_iana_ids.md: transforms/ebml_schema2markdown4iana_ids.xsl matroska_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4iana_ids.xsl matroska_xsd.xml > $@
+
+matroska_iana.xml: transforms/ebml_schema2xml4iana_ids.xsl matroska_xsd.xml
+	xsltproc transforms/ebml_schema2xml4iana_ids.xsl matroska_xsd.xml | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/"  > $@
 
 matroska_deprecated4rfc.md: transforms/ebml_schema2markdown4deprecated.xsl matroska_xsd.xml
 	xsltproc transforms/ebml_schema2markdown4deprecated.xsl matroska_xsd.xml > $@

--- a/transforms/ebml_schema2xml4iana_ids.xsl
+++ b/transforms/ebml_schema2xml4iana_ids.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" xmlns:ebml="urn:ietf:rfc:8794" xmlns="http://www.iana.org/assignments">
+  <xsl:output encoding="UTF-8" version="1.0" indent="yes"/>
+  <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'"/>
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+
+  <xsl:template match="ebml:EBMLSchema">
+    <registry id="matroska">
+      <title>Matroska</title>
+      <created>@BUILD_DATE@</created>
+
+      <!-- Element IDs -->
+      <registry id="matroska-element-ids">
+        <title>Matroska Element IDs</title>
+        <xref type="rfc" data="rfc8794"/>
+        <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and string-length(@id)=4]">
+          <xsl:sort select="@id"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and string-length(@id)=6]">
+          <xsl:sort select="@id"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and string-length(@id)=8]">
+          <xsl:sort select="@id"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and string-length(@id)=10]">
+          <xsl:sort select="@id"/>
+        </xsl:apply-templates>
+      </registry>
+
+    </registry>
+  </xsl:template>
+  <xsl:template match="ebml:element">
+    <record date="@BUILD_DATE@">
+      <value><xsl:value-of select="@id"/></value>
+      <description><xsl:value-of select="@name"/></description>
+      <xref type="draft" data="draft-ietf-cellar-matroska-09">Matroska Media Container Format, (#<xsl:choose>
+          <xsl:when test="maxver='0'">
+            <xsl:value-of select="translate(@name, $uppercase, $smallcase)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="translate(@name, $uppercase, $smallcase)"/>
+          </xsl:otherwise>
+        </xsl:choose>)</xref>
+    </record>
+  </xsl:template>
+</xsl:stylesheet>

--- a/transforms/ebml_schema2xml4iana_ids.xsl
+++ b/transforms/ebml_schema2xml4iana_ids.xsl
@@ -27,6 +27,21 @@
         </xsl:apply-templates>
       </registry>
 
+      <!-- Chapter Codec IDs -->
+      <registry id="matroska-chapter-codec-ids">
+        <title>Matroska Chapter Codec IDs</title>
+        <record date="@BUILD_DATE@">
+          <number>0</number>
+          <description>Reserved</description>
+          <xref type="draft" data="draft-ietf-cellar-matroska-09">Matroska Media Container Format, (#chapprocesscodecid-element)</xref>
+        </record>
+        <record date="@BUILD_DATE@">
+          <number>1</number>
+          <description>Reserved</description>
+          <xref type="draft" data="draft-ietf-cellar-matroska-09">Matroska Media Container Format, (#chapprocesscodecid-element)</xref>
+        </record>
+      </registry>
+
     </registry>
   </xsl:template>
   <xsl:template match="ebml:element">


### PR DESCRIPTION
Similar to the format of https://www.iana.org/assignments/ebml/ebml.xml

The IDs are sorted by length and ID value (like EBML ones).

The links to the actual RFC are temporary (no RFC numbers, section numbers can vary).

Fixes #568