### PR TITLE
Misc ContentEncoding text and enum cleaning

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1158,8 +1158,12 @@ If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
   <element name="AESSettingsCipherMode" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAESSettings\AESSettingsCipherMode" id="0x47E8" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The AES cipher mode used in the encryption.</documentation>
     <restriction>
-      <enum value="1" label="AES-CTR / Counter, NIST SP 800-38A"/>
-      <enum value="2" label="AES-CBC / Cipher Block Chaining, NIST SP 800-38A"/>
+      <enum value="1" label="AES-CTR">
+        <documentation lang="en" purpose="definition">Counter [@!SP.800-38A].</documentation>
+      </enum>
+      <enum value="2" label="AES-CBC">
+        <documentation lang="en" purpose="definition">Cipher Block Chaining [@!SP.800-38A].</documentation>
+      </enum>
     </restriction>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1068,6 +1068,7 @@ Values (big-endian) can be OR'ed.</documentation>
       </enum>
       <enum value="4" label="Next">
         <documentation lang="en" purpose="definition">The next ContentEncoding (next `ContentEncodingOrder`. Either the data inside `ContentCompression` and/or `ContentEncryption`).</documentation>
+        <documentation lang="en" purpose="usage notes">This value **SHOULD NOT** be used.</documentation>
       </enum>
     </restriction>
     <extension type="webmproject.org" webm="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1060,9 +1060,15 @@ This value has to be unique over all ContentEncodingOrder Elements in the TrackE
     <documentation lang="en" purpose="definition">A bit field that describes which Elements have been modified in this way.
 Values (big-endian) can be OR'ed.</documentation>
     <restriction>
-      <enum value="1" label="All frame contents, excluding lacing data"/>
-      <enum value="2" label="The track's private data"/>
-      <enum value="4" label="The next ContentEncoding (next `ContentEncodingOrder`. Either the data inside `ContentCompression` and/or `ContentEncryption`)"/>
+      <enum value="1" label="Block">
+        <documentation lang="en" purpose="definition">All frame contents, excluding lacing data.</documentation>
+      </enum>
+      <enum value="2" label="Private">
+        <documentation lang="en" purpose="definition">The track's private data.</documentation>
+      </enum>
+      <enum value="4" label="Next">
+        <documentation lang="en" purpose="definition">The next ContentEncoding (next `ContentEncodingOrder`. Either the data inside `ContentCompression` and/or `ContentEncryption`).</documentation>
+      </enum>
     </restriction>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1050,9 +1050,9 @@ Otherwise, TrickTrackUID and TrickTrackSegUID must be present if this track has 
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ContentEncodingOrder" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncodingOrder" id="0x5031" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Tells when this modification was used during encoding/muxing starting with 0 and counting upwards.
-The decoder/demuxer has to start with the highest order number it finds and work its way down.
-This value has to be unique over all ContentEncodingOrder Elements in the TrackEntry that contains this ContentEncodingOrder element.</documentation>
+    <documentation lang="en" purpose="definition">Tell in which order to apply each `ContentEncoding` of the `ContentEncodings`.
+The decoder/demuxer **MUST** start with the `ContentEncoding` with the highest `ContentEncodingOrder` and work its way down to the `ContentEncoding` with the lowest `ContentEncodingOrder`.
+This value **MUST** be unique over for each `ContentEncoding` found in the `ContentEncodings` of this `TrackEntry`.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1152,12 +1152,13 @@ The value "0" means that the contents have not been encrypted.</documentation>
   </element>
   <element name="ContentEncAESSettings" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAESSettings" id="0x47E7" type="master" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Settings describing the encryption algorithm used.
-If `ContentEncAlgo` != 5 this **MUST** be ignored.</documentation>
+It **MUST** be ignored if `ContentEncAlgo` is not AES (5).</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="AESSettingsCipherMode" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAESSettings\AESSettingsCipherMode" id="0x47E8" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The AES cipher mode used in the encryption.</documentation>
+    <documentation lang="en" purpose="definition">The AES cipher mode used in the encryption.
+It **MUST** be ignored if `ContentEncAlgo` is not AES (5).</documentation>
     <restriction>
       <enum value="1" label="AES-CTR">
         <documentation lang="en" purpose="definition">Counter [@!SP.800-38A].</documentation>

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -61,6 +61,17 @@
   <seriesInfo name='DOI' value='10.6028/NIST.FIPS.197'/>
 </reference>
 
+<reference anchor="SP.800-38A" target="https://csrc.nist.gov/publications/detail/fips/197/final">
+  <front>
+    <title>Recommendation for Block Cipher Modes of Operation: Methods and Techniques</title>
+    <author>
+      <organization>US National Institute of Standards and Technology</organization>
+    </author>
+    <date day="01" month="December" year="2001" />
+  </front>
+  <seriesInfo name='DOI' value='10.6028/NIST.SP.800-38A'/>
+</reference>
+
 <reference anchor="FourCC-RGB" target="https://www.fourcc.org/rgb.php">
   <front>
     <title>RGB Pixel Format FourCCs</title>


### PR DESCRIPTION
* reworked the ContentEncodingOrder text to clarify how to apply cascaded ContentEncoding
* turn enum values into simple name + description
* add AES cipher mode NIST link
* deprecate ContentEncodingScope `next` which doesn't make sense and is not used anywhere

Fixes #580 