### PR TITLE
bring back the CodecDelay default value

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -434,7 +434,7 @@ That means when this track has a gap, see (#silenttracks-element) on SilentTrack
 the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay matters, the first one is the one that **SHOULD** be used.
 If not found it **SHOULD** be the second, etc.</documentation>
   </element>
-  <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
+  <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">CodecDelay is The codec-built-in delay, expressed in Matroska Ticks -- ie in nanoseconds; see (#timestamp-ticks).
 It represents the amount of codec samples that will be discarded by the decoder during playback.
 This timestamp value **MUST** be subtracted from each frame timestamp in order to get the timestamp that will be actually played.


### PR DESCRIPTION
The default value was removed in 743317d06088e8a732a7b7f880386d8b0435142b but then the element was made mandatory in f81cb9d339574ce2b00faa288cd466908e31b797. Now files need to set a value even if they don't use the feature.

So we bring back the default value to fix this.

See issue found in libmatroska because of this https://github.com/Matroska-Org/libmatroska/pull/61.