### PR TITLE
make Slices deprecated

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -200,7 +200,7 @@ This information **SHOULD** always be referenced by a seek entry.</documentation
 The duration of DiscardPadding is not calculated in the duration of the TrackEntry and **SHOULD** be discarded during playback.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" maxver="1" maxOccurs="1">
+  <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master"  minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains slices description.</documentation>
   </element>
   <element name="TimeSlice" path="\Segment\Cluster\BlockGroup\Slices\TimeSlice" id="0xE8" type="master" minver="0" maxver="0">


### PR DESCRIPTION
In 7136c753fdecafbd81b11b0f31734ce836ce3ef8 all sub-elements had a maxver of
either 0 or 1 so we had to use 1.

Now all sub-elements have a maxver of 0 so it should be 0 as well. This is true
since 88adb292307bb5ca5df7b141e2df04cb1e16f1be.