### PR TITLE
put the COUNTRY code value in line with other country values in tags

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -31,9 +31,11 @@ targeted item taken from another work of art. All tags in this list can be used
 "under" the SAMPLE tag like TITLE, ARTIST, DATE_RELEASED, etc.</description>
     </tag>
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
-      <description lang="en">The name of the country (bibliographic ISO-639-2 form [@!ISO639-2])
+      <description lang="en">The name of the country
 that is meant to have other tags inside (using nested tags) to country specific information about the item.
-All tags in this list can be used "under" the COUNTRY_SPECIFIC tag like LABEL, PUBLISH_RATING, etc.</description>
+All tags in this list can be used "under" the COUNTRY_SPECIFIC tag like LABEL, PUBLISH_RATING, etc.
+The country code uses the same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
+</description>
     </tag>
     <tag name="TOTAL_PARTS" class="Organization Information" type="UTF-8">
       <description lang="en">Total number of parts defined at the first lower level. (e.g., if TargetType is ALBUM,

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -106,17 +106,6 @@
   </front>
 </reference>
 
-<reference anchor="ISO639-2" target="https://www.loc.gov/standards/iso639-2/php/code_list.php">
-  <front>
-    <title>Codes for the Representation of Names of Languages</title>
-    <author>
-      <organization>United States Library Of Congress</organization>
-    </author>
-    <date day="21" month="December" year="2017"/>
-  </front>
-  <seriesInfo name="ISO" value="639-2:1998" />
-</reference>
-
 <reference anchor="RIFF.tags" target="https://exiftool.org/TagNames/RIFF.html">
   <front>
     <title>RIFF Tags</title>


### PR DESCRIPTION
This is the same text as ChapCountry or RECORDING_LOCATION, COMPOSITION_LOCATION and COMPOSER_NATIONALITY.

Fixes #519