### PR TITLE
Rework the XML Schema to RFC formatting

### DIFF
--- a/transforms/ebml_schema2markdown4deprecated.xsl
+++ b/transforms/ebml_schema2markdown4deprecated.xsl
@@ -10,20 +10,15 @@
      <xsl:text>## </xsl:text>
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
+    <xsl:text>type / id:&#xa;: </xsl:text>
+    <xsl:value-of select="@type"/>
+    <xsl:text> / </xsl:text>
+    <xsl:value-of select="@id"/>
+    <xsl:text>&#xa;&#xa;</xsl:text>
     <xsl:if test="@path">
       <xsl:text>path:&#xa;: `</xsl:text>
       <xsl:value-of select="@path"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@id">
-      <xsl:text>id:&#xa;: </xsl:text>
-      <xsl:value-of select="@id"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@type">
-      <xsl:text>type:&#xa;: </xsl:text>
-      <xsl:value-of select="@type"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:for-each select="ebml:documentation">
       <xsl:if test="@purpose='definition'">

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -71,20 +71,14 @@
       <xsl:value-of select="@type"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@unknownsizeallowed">
-      <xsl:text>unknownsizeallowed:&#xa;: </xsl:text>
-      <xsl:value-of select="@unknownsizeallowed"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:if test="@unknownsizeallowed=1">
+      <xsl:text>unknownsizeallowed: True&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@recursive">
-      <xsl:text>recursive:&#xa;: </xsl:text>
-      <xsl:value-of select="@recursive"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:if test="@recursive=1">
+      <xsl:text>recursive: True&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@recurring">
-      <xsl:text>recurring:&#xa;: </xsl:text>
-      <xsl:value-of select="@recurring"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
+    <xsl:if test="@recurring=1">
+      <xsl:text>recurring: True&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@minver">
       <xsl:text>minver:&#xa;: </xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -13,8 +13,12 @@
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
     <xsl:if test="@name">
-      <xsl:text>name:&#xa;: </xsl:text>
+      <xsl:text>name / type / id:&#xa;: </xsl:text>
       <xsl:value-of select="@name"/>
+      <xsl:text> / </xsl:text>
+      <xsl:value-of select="@type"/>
+      <xsl:text> / </xsl:text>
+      <xsl:value-of select="@id"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@path">
@@ -22,24 +26,27 @@
       <xsl:value-of select="@path"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@id">
-      <xsl:text>id:&#xa;: </xsl:text>
-      <xsl:value-of select="@id"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
     <xsl:if test="@minOccurs | ebml:implementation_note[@note_attribute='minOccurs']">
+      <xsl:text>minOccurs</xsl:text>
+      <xsl:if test="@maxOccurs">
+        <xsl:text> - maxOccurs</xsl:text>
+      </xsl:if>
+      <xsl:text>:&#xa;: </xsl:text>
       <xsl:choose>
         <xsl:when test="ebml:implementation_note[@note_attribute='minOccurs']">
-          <xsl:text>minOccurs: see implementation notes&#xa;&#xa;</xsl:text>
+          <xsl:text>see implementation notes</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:text>minOccurs:&#xa;: </xsl:text>
           <xsl:value-of select="@minOccurs"/>
-          <xsl:text>&#xa;&#xa;</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
+      <xsl:if test="@maxOccurs">
+        <xsl:text> - </xsl:text>
+        <xsl:value-of select="@maxOccurs"/>
+      </xsl:if>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@maxOccurs">
+    <xsl:if test="@maxOccurs and not(@minOccurs | ebml:implementation_note[@note_attribute='minOccurs'])">
       <xsl:text>maxOccurs:&#xa;: </xsl:text>
       <xsl:value-of select="@maxOccurs"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
@@ -65,11 +72,6 @@
           <xsl:text>&#xa;&#xa;</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
-    </xsl:if>
-    <xsl:if test="@type">
-      <xsl:text>type:&#xa;: </xsl:text>
-      <xsl:value-of select="@type"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@unknownsizeallowed=1">
       <xsl:text>unknownsizeallowed: True&#xa;&#xa;</xsl:text>


### PR DESCRIPTION
Compress some elements vertically by grouping the values.

Our current formatting is using the markdown [Definition List](https://www.markdownguide.org/extended-syntax#definition-lists) which doesn't allow a lot of room.

Using a table would likely mean having a title for all 200+ elements. And it wouldn't help with al the optional elements.
Otherwise we need a single giant table and we won't be able to reference elements in there.

This MR reduces the output TXT document by 20 pages.

+ also make boolean attributes output an attribute value