### PR TITLE
deprecate Cluster/Position

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -133,7 +133,7 @@ It is useful when using overlay tracks on seeking or to decide what track to use
 It could change later if not specified as silent in a further Cluster.</documentation>
     <extension type="libmatroska" cppname="ClusterSilentTrackNumber"/>
   </element>
-  <element name="Position" path="\Segment\Cluster\Position" id="0xA7" type="uinteger" maxOccurs="1">
+  <element name="Position" path="\Segment\Cluster\Position" id="0xA7" type="uinteger" maxOccurs="1" minver="0" maxver="0">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster in the Segment (0 in live streams).
 It might help to resynchronise offset on damaged streams.</documentation>
     <extension type="libmatroska" cppname="ClusterPosition"/>


### PR DESCRIPTION
It's not used anywhere and has very little use to fix damaged files.
It can be use spot missing parts between 2 Clusters. But if we know the next
Cluster with that element, we already know there's a missing part...