### PR TITLE
Make OldeStereoMode more visible

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -607,7 +607,7 @@ Undefined values **SHOULD NOT** be used as the behavior of known implementations
     <extension type="libmatroska" cppname="VideoAlphaMode"/>
     <extension type="stream copy" keep="1"/>
   </element>
-  <element name="OldStereoMode" path="\Segment\Tracks\TrackEntry\Video\OldStereoMode" id="0x53B9" type="uinteger" maxver="0" maxOccurs="1">
+  <element name="OldStereoMode" path="\Segment\Tracks\TrackEntry\Video\OldStereoMode" id="0x53B9" type="uinteger" minver="1" maxver="2" maxOccurs="1">
     <documentation lang="en" purpose="definition">Bogus StereoMode value used in old versions of libmatroska.</documentation>
     <restriction>
       <enum value="0" label="mono"/>

--- a/notes.md
+++ b/notes.md
@@ -926,8 +926,10 @@ The 3D support is still in infancy and may evolve to support more features.
 
 The StereoMode used to be part of Matroska v2 but it didn't meet the requirement
 for multiple tracks. There was also a bug in libmatroska prior to 0.9.0 that would save/read
-it as 0x53B9 instead of 0x53B8. `Matroska Readers` may support these legacy files by checking
-Matroska v2 or 0x53B9. The older values were 0: mono, 1: right eye, 2: left eye, 3: both eyes.
+it as 0x53B9 instead of 0x53B8; see OldStereoMode ((#oldstereomode-element)). `Matroska Readers` may support these legacy files by checking
+Matroska v2 or 0x53B9.
+The older values of StereoMode were 0: mono, 1: right eye, 2: left eye, 3: both eyes, the only values that can be found in OldStereoMode.
+They are not compatible with the StereoMode values found in Matroska v3 and above.
 
 
 # Default track selection


### PR DESCRIPTION
We need to know the values that were in there. They are also the same values found in StereoMode in the past and they are *incompatible* with the current ones.