### PR TITLE
Encryption clarification

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1197,14 +1197,14 @@ The value "0" means that the contents have not been encrypted.</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ContentEncAESSettings" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAESSettings" id="0x47E7" type="master" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Settings describing the encryption algorithm used.
-It **MUST** be ignored if `ContentEncAlgo` is not AES (5).</documentation>
+    <documentation lang="en" purpose="definition">Settings describing the encryption algorithm used.</documentation>
+    <implementation_note note_attribute="maxOccurs">ContentEncAESSettings **MUST NOT** be set (maxOccurs=0) if ContentEncAlgo is not AES (5).</implementation_note>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="AESSettingsCipherMode" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAESSettings\AESSettingsCipherMode" id="0x47E8" type="uinteger" minver="4" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The AES cipher mode used in the encryption.
-It **MUST** be ignored if `ContentEncAlgo` is not AES (5).</documentation>
+    <documentation lang="en" purpose="definition">The AES cipher mode used in the encryption.</documentation>
+    <implementation_note note_attribute="maxOccurs">AESSettingsCipherMode **MUST NOT** be set (maxOccurs=0) if ContentEncAlgo is not AES (5).</implementation_note>
     <restriction>
       <enum value="1" label="AES-CTR">
         <documentation lang="en" purpose="definition">Counter [@!SP.800-38A].</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1168,10 +1168,11 @@ This Element **MUST** be present if the value of `ContentEncodingType` is 1 (enc
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ContentEncAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAlgo" id="0x47E1" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The encryption algorithm used.
-The value "0" means that the contents have not been encrypted.</documentation>
+    <documentation lang="en" purpose="definition">The encryption algorithm used.</documentation>
     <restriction>
-      <enum value="0" label="Not encrypted"/>
+      <enum value="0" label="Not encrypted">
+        <documentation lang="en" purpose="definition">The data are not encrypted.</documentation>
+      </enum>
       <enum value="1" label="DES">
         <documentation lang="en" purpose="definition">Data Encryption Standard (DES) [@!FIPS.46-3].</documentation>
       </enum>

--- a/notes.md
+++ b/notes.md
@@ -447,6 +447,13 @@ Encryption information is stored in the `ContentEncodings Element` under the `Co
 For encryption systems sharing public/private keys, the creation of the keys and the exchange of keys
 are not covered by this document. They have to be handled by the system using Matroska.
 
+The `ContentEncodingScope Element` gives an idea of which part of the track are encrypted.
+But each `ContentEncAlgo Element` and its sub elements like `AESSettingsCipherMode` really
+define how the encrypted should be exactly interpreted.
+
+The AES-CTR system, which corresponds to `ContentEncAlgo` = 5 ((#contentencalgo-element)) and `AESSettingsCipherMode` = 1 ((#aessettingsciphermode-element)),
+is defined in the [@!WebM-Enc] document.
+
 # Image Presentation
 
 ## Cropping

--- a/notes.md
+++ b/notes.md
@@ -444,6 +444,9 @@ types of encryption can be used, requiring two separate keys to be able to decry
 
 Encryption information is stored in the `ContentEncodings Element` under the `ContentEncryption Element`.
 
+For encryption systems sharing public/private keys, the creation of the keys and the exchange of keys
+are not covered by this document. They have to be handled by the system using Matroska.
+
 # Image Presentation
 
 ## Cropping

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -181,6 +181,14 @@
   </front>
 </reference>
 
+<reference anchor="WebM-Enc" target="https://www.webmproject.org/docs/webm-encryption/">
+  <front>
+    <title>WebM Encryption</title>
+    <author fullname='Frank Galligan'><organization>Google</organization></author>
+    <date day="19" month="September" year="2016" />
+  </front>
+</reference>
+
 <reference anchor="WebVTT" target="https://www.w3.org/TR/webvtt1/#webvtt-cue-identifier">
   <front>
     <title>WebVTT Cue Identifier</title>


### PR DESCRIPTION
* do not use AES parameter if AES is not used
* add some text explaining how key exchange is not covered here
* use a proper enum documentation for "Not encrypted"
* add text saying ContentEncodingScope+ContentEncAlgo may not be enough to handle encrypted data