### PR TITLE
update the WAVEFORMATEX link to the latest MS link

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -638,8 +638,10 @@ Codec Name: Microsoft(TM) Audio Codec Manager (ACM)
 
 Description: The data are stored in little-endian format (like on IA32 machines).
 
-Initialization: The `Private Data` contains the ACM structure WAVEFORMATEX including the extra private bytes,
-as [defined by Microsoft](http://msdn.microsoft.com/library/default.asp?url=/library/en-us/multimed/mmstr_625u.asp).
+Initialization: The `Private Data` contains the [@!WAVEFORMATEX] structure including the extra format information bytes.
+The structure is stored without packing or padding bytes.
+A `WORD` corresponds to a signed 2 octets integer, `DWORD` corresponds to a signed 4 octets integer.
+The extra format information are appended after the WAVEFORMATEX octets.
 
 ### A_AAC/MPEG2/MAIN
 

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -85,3 +85,12 @@
   <seriesInfo name="ST" value="ST 12-1:2014, DOI 10.5594/SMPTE.ST12-1.2014" />
 </reference>
 
+<reference anchor="WAVEFORMATEX" target="https://docs.microsoft.com/en-us/windows/win32/api/mmeapi/ns-mmeapi-waveformatex">
+  <front>
+    <title>WAVEFORMATEX structure</title>
+    <author>
+      <organization>Microsoft</organization>
+    </author>
+    <date day="04" month="April" year="2021" />
+  </front>
+</reference>


### PR DESCRIPTION
And add more information on how to interpret the bytes as it's not mentioned
in that document. (the format is the same as found in WAV and AVI files)

Fixes #647

All the remaining HTTP links in there also need to be transformed into proper references.