### PR TITLE
exclude Matroska v5 elements from the v4 document

### DIFF
--- a/transforms/ebml_schema2markdown4iana_ids.xsl
+++ b/transforms/ebml_schema2markdown4iana_ids.xsl
@@ -6,7 +6,7 @@
   <xsl:template match="ebml:EBMLSchema">
     <xsl:text>Element ID | Element Name            | Reference&#xa;</xsl:text>
     <xsl:text>----------:|:------------------------|:-------------------------------------------&#xa;</xsl:text>
-    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment')]">
+    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and (not(@minver) or @minver&lt;5)]">
       <xsl:sort select="@id" order="descending" />
     </xsl:apply-templates>
     <xsl:text>Table: IDs and Names for Matroska Element IDs assigned by this document&#xa;&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -4,7 +4,7 @@
   <xsl:variable name="smallcase" select="'abcdefghijklmnopqrstuvwxyz'"/>
   <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
   <xsl:template match="ebml:EBMLSchema">
-    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and not(@maxver='0')]"/>
+    <xsl:apply-templates select="//ebml:element[contains(@path,'\Segment') and not(@maxver='0') and (not(@minver) or @minver&lt;5)]"/>
   </xsl:template>
   <xsl:template match="ebml:element">
     <xsl:text>#</xsl:text>


### PR DESCRIPTION
So we can start merging v5 elements and they won't affect the v4 document.

v5 elements will likely be part of a new document that may not include elements
from v1 to v4.