### PR TITLE
Add an audio emphasis element (v5) to mark some tracks

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1041,6 +1041,47 @@ Setting `ProjectionPoseRoll` to 180 or -180 degrees, with the `ProjectionPoseYaw
     <extension type="stream copy" keep="1"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
+  <element name="Emphasis" path="\Segment\Tracks\TrackEntry\Audio\Emphasis" id="0x92F1" type="uinteger" minver="5" default="0" minOccurs="1" maxOccurs="1" >
+    <documentation lang="en" purpose="definition">Audio emphasis applied on audio samples. The player **MUST** apply the inverse emphasis to get the proper audio samples.</documentation>
+    <restriction>
+      <enum value="0" label="No emphasis"/>
+      <enum value="1" label="CD audio">
+        <documentation lang="en" purpose="definition">First order filter with zero point at 50 microseconds and a pole at 15 microseconds. Also found on DVD Audio and MPEG audio.</documentation>
+      </enum>
+      <enum value="2" label="reserved"/>
+      <enum value="3" label="CCIT J.17">
+        <documentation lang="en" purpose="definition">Defined in [@!ITU-J.17].</documentation>
+      </enum>
+      <enum value="4" label="FM 50">
+        <documentation lang="en" purpose="definition">FM Radio in Europe. RC Filter with a time constant of 50 microseconds.</documentation>
+      </enum>
+      <enum value="5" label="FM 75">
+        <documentation lang="en" purpose="definition">FM Radio in the USA. RC Filter with a time constant of 75 microseconds.</documentation>
+      </enum>
+      <enum value="10" label="Phono RIAA">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=3180, t2=318 and t3=75 microseconds. [@!NAB1964]</documentation>
+      </enum>
+      <enum value="11" label="Phono IEC N78">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=3180, t2=450 and t3=50 microseconds.</documentation>
+      </enum>
+      <enum value="12" label="Phono TELDEC">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=3180, t2=318 and t3=50 microseconds.</documentation>
+      </enum>
+      <enum value="13" label="Phono EMI">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=2500, t2=500 and t3=70 microseconds.</documentation>
+      </enum>
+      <enum value="14" label="Phono Columbia LP">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=1590, t2=318 and t3=100 microseconds.</documentation>
+      </enum>
+      <enum value="15" label="Phono LONDON">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=1590, t2=318 and t3=50 microseconds.</documentation>
+      </enum>
+      <enum value="16" label="Phono NARTB">
+        <documentation lang="en" purpose="definition">Phono filter with time constants of t1=3180, t2=318 and t3=100 microseconds.</documentation>
+      </enum>
+    </restriction>
+    <extension type="stream copy" keep="1"/>
+  </element>
   <element name="TrackOperation" path="\Segment\Tracks\TrackEntry\TrackOperation" id="0xE2" type="master" minver="3" maxOccurs="1">
     <documentation lang="en" purpose="definition">Operation that needs to be applied on tracks to create this virtual track.
 For more details look at (#track-operation).</documentation>

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -154,6 +154,17 @@
   <seriesInfo name="ISO" value="639-2:1998" />
 </reference>
 
+<reference anchor="ITU-J.17" target="https://www.itu.int/rec/T-REC-J.17/en">
+  <front>
+    <title>Pre-emphasis used on sound-programme circuits</title>
+    <author>
+      <organization>International Telecommunication Union</organization>
+    </author>
+    <date day="25" month="November" year="1988"/>
+  </front>
+  <seriesInfo name="ITU" value="J.17" />
+</reference>
+
 <reference anchor="MatroskaCodec">
   <front>
     <title>Media Container Codec Specifications</title>
@@ -175,6 +186,18 @@
   </front>
   <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-tags-09"/>
 </reference>
+
+<reference anchor="NAB1964" target="https://www.richardhess.com/tape/history/NAB/NAB_Disc_Standard_1964_searchable.pdf">
+  <front>
+    <title>NAB Audio Recording And Reproducing Standards For Disc Recording And Reproducing</title>
+    <author>
+      <organization>National Association of Broadcaster</organization>
+    </author>
+    <date day="1" month="February" year="1964"/>
+  </front>
+</reference>
+
+
 
 <reference anchor="LZO" target="https://www.kernel.org/doc/Documentation/lzo.txt">
   <front>


### PR DESCRIPTION
Fixes #582 

* The reserved values is added so that the first 4 values match the [MPEG Audio header](http://www.mpgedit.org/mpgedit/mpeg_format/mpeghdr.htm).
* The phono values are taken from this detailed [document](https://wiki.audacityteam.org/wiki/78rpm_playback_curves). Only the curves using 3 time constants (as the RIAA) ones are kept (1950 and up, before it's too messy)
* I couldn't find a proper RIAA document with the equation but there's a NAB document with the same values and the equation available.
* The CCITT J.17 is actually T-REC-J.17
* I could not find a proper spec for the FM time constants, even [Wikipedia](https://en.wikipedia.org/wiki/FM_broadcasting#Pre-emphasis_and_de-emphasis) doesn't mention any.