### PR TITLE
Rework the element formatting for more consistency

### DIFF
--- a/iana.md
+++ b/iana.md
@@ -27,10 +27,10 @@ Subtype name:
 : matroska
 
 Required parameters:
-: none
+: N/A
 
 Optional parameters:
-: none
+: N/A
 
 Encoding considerations:
 : as per this document and RFC8794
@@ -48,7 +48,7 @@ Applications that use this media type:
 : ffmpeg, vlc, ...
 
 Fragment identifier considerations:
-: none
+: N/A
 
 Additional information:
 
@@ -58,7 +58,7 @@ Additional information:
 
   - File extension(s): mkv
 
-  - Macintosh file type code(s): none
+  - Macintosh file type code(s): N/A
 
 Person & email address to contact for further information:
 : IETF CELLAR WG
@@ -67,7 +67,7 @@ Intended usage:
 : COMMON
 
 Restrictions on usage:
-: N/A
+: None
 
 Author:
 : IETF CELLAR WG
@@ -87,10 +87,10 @@ Subtype name:
 : matroska
 
 Required parameters:
-: none
+: N/A
 
 Optional parameters:
-: none
+: N/A
 
 Encoding considerations:
 : as per this document and RFC8794
@@ -108,7 +108,7 @@ Applications that use this media type:
 : ffmpeg, vlc, ...
 
 Fragment identifier considerations:
-: none
+: N/A
 
 Additional information:
 
@@ -118,7 +118,7 @@ Additional information:
 
   - File extension(s): mka
 
-  - Macintosh file type code(s): none
+  - Macintosh file type code(s): N/A
 
 Person & email address to contact for further information:
 : IETF CELLAR WG
@@ -127,7 +127,7 @@ Intended usage:
 : COMMON
 
 Restrictions on usage:
-: N/A
+: None
 
 Author:
 : IETF CELLAR WG
@@ -147,10 +147,10 @@ Subtype name:
 : matroska-3d
 
 Required parameters:
-: none
+: N/A
 
 Optional parameters:
-: none
+: N/A
 
 Encoding considerations:
 : as per this document and RFC8794
@@ -168,7 +168,7 @@ Applications that use this media type:
 : ffmpeg, vlc, ...
 
 Fragment identifier considerations:
-: none
+: N/A
 
 Additional information:
 
@@ -178,7 +178,7 @@ Additional information:
 
   - File extension(s): mk3d
 
-  - Macintosh file type code(s): none
+  - Macintosh file type code(s): N/A
 
 Person & email address to contact for further information:
 : IETF CELLAR WG
@@ -187,7 +187,7 @@ Intended usage:
 : COMMON
 
 Restrictions on usage:
-: N/A
+: None
 
 Author:
 : IETF CELLAR WG

--- a/iana.md
+++ b/iana.md
@@ -76,7 +76,7 @@ Change controller:
 : IESG
 
 Provisional registration? (standards tree only):
-: NO
+: No
 
 ### For files containing audio tracks with no video tracks
 
@@ -136,7 +136,7 @@ Change controller:
 : IESG
 
 Provisional registration? (standards tree only):
-: NO
+: No
 
 ### For files containing audio tracks with no video tracks
 
@@ -196,7 +196,7 @@ Change controller:
 : IESG
 
 Provisional registration? (standards tree only):
-: NO
+: No
 
 # Annex A: Historic Deprecated Elements
 

--- a/iana.md
+++ b/iana.md
@@ -36,7 +36,7 @@ Encoding considerations:
 : as per this document and RFC8794
 
 Security considerations:
-: See Section 25.
+: See (#security-considerations).
 
 Interoperability considerations:
 : The format is designed to be broadly interoperable.
@@ -96,7 +96,7 @@ Encoding considerations:
 : as per this document and RFC8794
 
 Security considerations:
-: See Section 25.
+: See (#security-considerations).
 
 Interoperability considerations:
 : The format is designed to be broadly interoperable.
@@ -156,7 +156,7 @@ Encoding considerations:
 : as per this document and RFC8794
 
 Security considerations:
-: See Section 25.
+: See (#security-considerations).
 
 Interoperability considerations:
 : The format is designed to be broadly interoperable.

--- a/iana.md
+++ b/iana.md
@@ -45,7 +45,7 @@ Published specification:
 : THISRFC
 
 Applications that use this media type:
-: ffmpeg, vlc, ...
+: FFMpeg, vlc, ...
 
 Fragment identifier considerations:
 : N/A
@@ -105,7 +105,7 @@ Published specification:
 : THISRFC
 
 Applications that use this media type:
-: ffmpeg, vlc, ...
+: FFMpeg, vlc, ...
 
 Fragment identifier considerations:
 : N/A
@@ -165,7 +165,7 @@ Published specification:
 : THISRFC
 
 Applications that use this media type:
-: ffmpeg, vlc, ...
+: FFMpeg, vlc, ...
 
 Fragment identifier considerations:
 : N/A

--- a/iana.md
+++ b/iana.md
@@ -54,7 +54,7 @@ Additional information:
 
   - Deprecated alias names for this type: video/x-matroska
 
-  - Magic number(s): not sure
+  - Magic number(s): N/A
 
   - File extension(s): mkv
 
@@ -114,7 +114,7 @@ Additional information:
 
   - Deprecated alias names for this type: audio/x-matroska
 
-  - Magic number(s): not sure
+  - Magic number(s): N/A
 
   - File extension(s): mka
 
@@ -174,7 +174,7 @@ Additional information:
 
   - Deprecated alias names for this type: video/matroska-3d
 
-  - Magic number(s): not sure
+  - Magic number(s): N/A
 
   - File extension(s): mk3d
 

--- a/iana.md
+++ b/iana.md
@@ -20,81 +20,183 @@ Please register three media types, the [@!RFC6838] templates are below:
 
 ### For files containing video tracks
 
-~~~~
-   Type name: video
-   Subtype name: matroska
-   Required parameters: none
-   Optional parameters: none
-   Encoding considerations: as per this document and RFC8794
-   Security considerations: See Section 25.
-   Interoperability considerations: The format is designed to be broadly interoperable.
-   Published specification: THISRFC
-   Applications that use this media type: ffmpeg, vlc, ...
-   Fragment identifier considerations: none
-   Additional information:
-     Deprecated alias names for this type: video/x-matroska
-     Magic number(s): not sure
-     File extension(s): mkv
-     Macintosh file type code(s): none
-   Person & email address to contact for further information: IETF CELLAR WG
-   Intended usage: COMMON
-   Restrictions on usage: N/A
-   Author: IETF CELLAR WG
-   Change controller: IESG
-   Provisional registration? (standards tree only): NO
-~~~~
+Type name:
+: video
+
+Subtype name:
+: matroska
+
+Required parameters:
+: none
+
+Optional parameters:
+: none
+
+Encoding considerations:
+: as per this document and RFC8794
+
+Security considerations:
+: See Section 25.
+
+Interoperability considerations:
+: The format is designed to be broadly interoperable.
+
+Published specification:
+: THISRFC
+
+Applications that use this media type:
+: ffmpeg, vlc, ...
+
+Fragment identifier considerations:
+: none
+
+Additional information:
+
+  - Deprecated alias names for this type: video/x-matroska
+
+  - Magic number(s): not sure
+
+  - File extension(s): mkv
+
+  - Macintosh file type code(s): none
+
+Person & email address to contact for further information:
+: IETF CELLAR WG
+
+Intended usage:
+: COMMON
+
+Restrictions on usage:
+: N/A
+
+Author:
+: IETF CELLAR WG
+
+Change controller:
+: IESG
+
+Provisional registration? (standards tree only):
+: NO
 
 ### For files containing audio tracks with no video tracks
 
-~~~~
-   Type name: audio
-   Subtype name: matroska
-   Required parameters: none
-   Optional parameters: none
-   Encoding considerations: as per this document and RFC8794
-   Security considerations: See Section 25.
-   Interoperability considerations: The format is designed to be broadly interoperable.
-   Published specification: THISRFC
-   Applications that use this media type: ffmpeg, vlc, ...
-   Fragment identifier considerations: none
-   Additional information:
-     Deprecated alias names for this type: audio/x-matroska
-     Magic number(s): not sure
-     File extension(s): mka
-     Macintosh file type code(s): none
-   Person & email address to contact for further information: IETF CELLAR WG
-   Intended usage: COMMON
-   Restrictions on usage: N/A
-   Author: IETF CELLAR WG
-   Change controller: IESG
-   Provisional registration? (standards tree only): NO
-~~~~
+Type name:
+: audio
+
+Subtype name:
+: matroska
+
+Required parameters:
+: none
+
+Optional parameters:
+: none
+
+Encoding considerations:
+: as per this document and RFC8794
+
+Security considerations:
+: See Section 25.
+
+Interoperability considerations:
+: The format is designed to be broadly interoperable.
+
+Published specification:
+: THISRFC
+
+Applications that use this media type:
+: ffmpeg, vlc, ...
+
+Fragment identifier considerations:
+: none
+
+Additional information:
+
+  - Deprecated alias names for this type: audio/x-matroska
+
+  - Magic number(s): not sure
+
+  - File extension(s): mka
+
+  - Macintosh file type code(s): none
+
+Person & email address to contact for further information:
+: IETF CELLAR WG
+
+Intended usage:
+: COMMON
+
+Restrictions on usage:
+: N/A
+
+Author:
+: IETF CELLAR WG
+
+Change controller:
+: IESG
+
+Provisional registration? (standards tree only):
+: NO
 
 ### For files containing audio tracks with no video tracks
 
-~~~~
-   Type name: video
-   Subtype name: matroska-3d
-   Required parameters: none
-   Optional parameters: none
-   Encoding considerations: as per this document and RFC8794
-   Security considerations: See Section 25.
-   Interoperability considerations: The format is designed to be broadly interoperable.
-   Published specification: THISRFC
-   Applications that use this media type: ffmpeg, vlc, ...
-   Fragment identifier considerations: none
-   Additional information:
-     Deprecated alias names for this type: video/matroska-3d
-     Magic number(s): not sure
-     File extension(s): mk3d
-     Macintosh file type code(s): none
-   Person & email address to contact for further information: IETF CELLAR WG
-   Intended usage: COMMON
-   Restrictions on usage: N/A
-   Author: IETF CELLAR WG
-   Change controller: IESG
-   Provisional registration? (standards tree only): NO
-~~~~
+Type name:
+: video
+
+Subtype name:
+: matroska-3d
+
+Required parameters:
+: none
+
+Optional parameters:
+: none
+
+Encoding considerations:
+: as per this document and RFC8794
+
+Security considerations:
+: See Section 25.
+
+Interoperability considerations:
+: The format is designed to be broadly interoperable.
+
+Published specification:
+: THISRFC
+
+Applications that use this media type:
+: ffmpeg, vlc, ...
+
+Fragment identifier considerations:
+: none
+
+Additional information:
+
+  - Deprecated alias names for this type: video/matroska-3d
+
+  - Magic number(s): not sure
+
+  - File extension(s): mk3d
+
+  - Macintosh file type code(s): none
+
+Person & email address to contact for further information:
+: IETF CELLAR WG
+
+Intended usage:
+: COMMON
+
+Restrictions on usage:
+: N/A
+
+Author:
+: IETF CELLAR WG
+
+Change controller:
+: IESG
+
+Provisional registration? (standards tree only):
+: NO
 
 # Annex A: Historic Deprecated Elements
 

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -53,7 +53,7 @@
     <xsl:if test="@minOccurs | ebml:implementation_note[@note_attribute='minOccurs']">
       <xsl:text>minOccurs</xsl:text>
       <xsl:if test="@maxOccurs">
-        <xsl:text> - maxOccurs</xsl:text>
+        <xsl:text> / maxOccurs</xsl:text>
       </xsl:if>
       <xsl:text>:&#xa;: </xsl:text>
       <xsl:choose>
@@ -65,7 +65,7 @@
         </xsl:otherwise>
       </xsl:choose>
       <xsl:if test="@maxOccurs">
-        <xsl:text> - </xsl:text>
+        <xsl:text> / </xsl:text>
         <xsl:value-of select="@maxOccurs"/>
       </xsl:if>
       <xsl:text>&#xa;&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -81,16 +81,27 @@
     <xsl:if test="@recurring=1">
       <xsl:text>recurring: True&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@minver">
-      <xsl:text>minver:&#xa;: </xsl:text>
-      <xsl:value-of select="@minver"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@maxver">
-      <xsl:text>maxver:&#xa;: </xsl:text>
-      <xsl:value-of select="@maxver"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
+
+    <!-- found in version -->
+    <xsl:choose>
+      <xsl:when test="@minver and @maxver">
+        <xsl:text>minver / maxver:&#xa;: </xsl:text>
+        <xsl:value-of select="@minver"/>
+        <xsl:text> / </xsl:text>
+        <xsl:value-of select="@maxver"/>
+        <xsl:text>&#xa;&#xa;</xsl:text>
+      </xsl:when>
+      <xsl:when test="@minver">
+        <xsl:text>minver:&#xa;: </xsl:text>
+        <xsl:value-of select="@minver"/>
+        <xsl:text>&#xa;&#xa;</xsl:text>
+      </xsl:when>
+      <xsl:when test="@maxver">
+        <xsl:text>maxver:&#xa;: </xsl:text>
+        <xsl:value-of select="@maxver"/>
+        <xsl:text>&#xa;&#xa;</xsl:text>
+      </xsl:when>
+    </xsl:choose>
 
     <xsl:for-each select="ebml:documentation[@purpose='definition']">
       <xsl:text>definition:&#xa;: </xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -30,11 +30,26 @@
        <xsl:text>&#xa;&#xa;</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
+    <xsl:if test="@length">
+      <xsl:text>length:&#xa;: </xsl:text>
+      <xsl:value-of select="@length"/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@range">
+      <xsl:text>range:&#xa;: </xsl:text>
+      <xsl:value-of select="@range"/>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
+    <xsl:if test="@unknownsizeallowed=1">
+      <xsl:text>unknownsizeallowed: True&#xa;&#xa;</xsl:text>
+    </xsl:if>
     <xsl:if test="@path">
       <xsl:text>path:&#xa;: `</xsl:text>
       <xsl:value-of select="@path"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
+
+    <!-- occurence -->
     <xsl:if test="@minOccurs | ebml:implementation_note[@note_attribute='minOccurs']">
       <xsl:text>minOccurs</xsl:text>
       <xsl:if test="@maxOccurs">
@@ -59,19 +74,6 @@
       <xsl:text>maxOccurs:&#xa;: </xsl:text>
       <xsl:value-of select="@maxOccurs"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@range">
-      <xsl:text>range:&#xa;: </xsl:text>
-      <xsl:value-of select="@range"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@length">
-      <xsl:text>length:&#xa;: </xsl:text>
-      <xsl:value-of select="@length"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@unknownsizeallowed=1">
-      <xsl:text>unknownsizeallowed: True&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@recursive=1">
       <xsl:text>recursive: True&#xa;&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -12,13 +12,24 @@
     <xsl:text> </xsl:text>
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
-    <xsl:if test="@name">
-      <xsl:text>id / type:&#xa;: </xsl:text>
-      <xsl:value-of select="@id"/>
-      <xsl:text> / </xsl:text>
-      <xsl:value-of select="@type"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="@default">
+       <xsl:text>id / type / default:&#xa;: </xsl:text>
+       <xsl:value-of select="@id"/>
+       <xsl:text> / </xsl:text>
+       <xsl:value-of select="@type"/>
+       <xsl:text> / </xsl:text>
+       <xsl:value-of select="@default"/>
+       <xsl:text>&#xa;&#xa;</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+       <xsl:text>id / type:&#xa;: </xsl:text>
+       <xsl:value-of select="@id"/>
+       <xsl:text> / </xsl:text>
+       <xsl:value-of select="@type"/>
+       <xsl:text>&#xa;&#xa;</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:if test="@path">
       <xsl:text>path:&#xa;: `</xsl:text>
       <xsl:value-of select="@path"/>
@@ -58,18 +69,6 @@
       <xsl:text>length:&#xa;: </xsl:text>
       <xsl:value-of select="@length"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
-    </xsl:if>
-    <xsl:if test="@default | ebml:implementation_note[@note_attribute='default']">
-      <xsl:choose>
-        <xsl:when test="ebml:implementation_note[@note_attribute='default']">
-          <xsl:text>default: see implementation notes&#xa;&#xa;</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:text>default:&#xa;: </xsl:text>
-          <xsl:value-of select="@default"/>
-          <xsl:text>&#xa;&#xa;</xsl:text>
-        </xsl:otherwise>
-      </xsl:choose>
     </xsl:if>
     <xsl:if test="@unknownsizeallowed=1">
       <xsl:text>unknownsizeallowed: True&#xa;&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -81,9 +81,6 @@
     <xsl:if test="@recurring=1">
       <xsl:text>recurring: True&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:for-each select="ebml:extension[@type='stream copy']">
-      <xsl:text>stream copy: True ((#stream-copy))&#xa;&#xa;</xsl:text>
-    </xsl:for-each>
     <xsl:if test="@minver">
       <xsl:text>minver:&#xa;: </xsl:text>
       <xsl:value-of select="@minver"/>
@@ -176,6 +173,10 @@
       <xsl:text>references:&#xa;: </xsl:text>
       <xsl:value-of select="."/>
       <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:for-each>
+
+    <xsl:for-each select="ebml:extension[@type='stream copy']">
+      <xsl:text>stream copy: True ((#stream-copy))&#xa;&#xa;</xsl:text>
     </xsl:for-each>
 
     <xsl:text>&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -13,10 +13,10 @@
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
     <xsl:if test="@name">
-      <xsl:text>type / id:&#xa;: </xsl:text>
-      <xsl:value-of select="@type"/>
-      <xsl:text> / </xsl:text>
+      <xsl:text>id / type:&#xa;: </xsl:text>
       <xsl:value-of select="@id"/>
+      <xsl:text> / </xsl:text>
+      <xsl:value-of select="@type"/>
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@path">

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -13,9 +13,7 @@
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
     <xsl:if test="@name">
-      <xsl:text>name / type / id:&#xa;: </xsl:text>
-      <xsl:value-of select="@name"/>
-      <xsl:text> / </xsl:text>
+      <xsl:text>type / id:&#xa;: </xsl:text>
       <xsl:value-of select="@type"/>
       <xsl:text> / </xsl:text>
       <xsl:value-of select="@id"/>


### PR DESCRIPTION
Remove redundant information, regroup some information.

This saves 2 pages on the TXT output.

It turns
```
5.1.4.1.21.  Language Element

   name / type / id:  Language / string / 0x22B59C

   path:  "\Segment\Tracks\TrackEntry\Language"

   minOccurs - maxOccurs:  1 - 1

   default:  eng

   definition:  Specifies the language of the track in the Matroska
      languages form; see Section 12 on language codes.  This Element
      MUST be ignored if the LanguageBCP47 Element is used in the same
      TrackEntry.
```

into

```
5.1.4.1.21.  Language Element

   id / type / default:  0x22B59C / string / eng

   path:  "\Segment\Tracks\TrackEntry\Language"

   minOccurs / maxOccurs:  1 / 1

   definition:  Specifies the language of the track in the Matroska
      languages form; see Section 12 on language codes.  This Element
      MUST be ignored if the LanguageBCP47 Element is used in the same
      TrackEntry.
```