### PR TITLE
fix ChapterSkipType old style EBML Schema path

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1465,8 +1465,8 @@ Like the SegmentUUID, it is a Universally Unique IDentifier stored in binary for
     <implementation_note note_attribute="minOccurs">ChapterSegmentUUID **MUST** be set (minOccurs=1) if ChapterSegmentEditionUID is used; see (#medium-linking) on medium-linking Segments.</implementation_note>
     <extension type="libmatroska" cppname="ChapterSegmentUID"/>
   </element>
-  <element name="ChapterSkipType" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSkipType)" id="0x4588" type="uinteger" maxOccurs="1" minver="5">
-    <documentation lang="en">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
+  <element name="ChapterSkipType" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSkipType" id="0x4588" type="uinteger" maxOccurs="1" minver="5">
+    <documentation lang="en" purpose="definition">Indicate what type of content the ChapterAtom contains and might be skipped. It can be used to automatically skip content based on the type.
 If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it **MUST NOT** have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
 If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
     </documentation>


### PR DESCRIPTION
No impact on the current documents. This is a Matroska v5 element.