### PR TITLE
Revert "deprecate Cluster/Position"

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -139,7 +139,7 @@ It is useful when using overlay tracks on seeking or to decide what track to use
 It could change later if not specified as silent in a further Cluster.</documentation>
     <extension type="libmatroska" cppname="ClusterSilentTrackNumber"/>
   </element>
-  <element name="Position" path="\Segment\Cluster\Position" id="0xA7" type="uinteger" minver="0" maxver="0" maxOccurs="1">
+  <element name="Position" path="\Segment\Cluster\Position" id="0xA7" type="uinteger" maxver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster in the Segment (0 in live streams).
 It might help to resynchronise offset on damaged streams.</documentation>
     <extension type="libmatroska" cppname="ClusterPosition"/>


### PR DESCRIPTION
This reverts commit 819e5d7c644423c6d08e42b7786dbb7207f0b790.

It turns out mkclean does produce files with the Cluster\Position so we need to bring back this element.