### PR TITLE
show the CI status on main page

### DIFF
--- a/.github/workflows/generate-rfcs.yaml
+++ b/.github/workflows/generate-rfcs.yaml
@@ -1,6 +1,9 @@
 name: "Build/Test the Matroska RFCs"
 # Trigger the workflow on push or pull request
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   build_ietf:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/ietf-wg-cellar/matroska-specification/actions/workflows/generate-rfcs.yaml/badge.svg)](https://github.com/ietf-wg-cellar/matroska-specification/actions/workflows/generate-rfcs.yaml)
+
 # Matroska Specification
 
 This repository holds content related to the official Matroska specification and standard. Discussion of the plans for standardization is regulated on the [CELLAR listserv](https://datatracker.ietf.org/wg/cellar/charter/). Approved changes should be submitted to this repository as a pull request. The latest draft published from these specifications can be found at the [IETF Datatracker](https://datatracker.ietf.org/doc/draft-ietf-cellar-matroska/).


### PR DESCRIPTION
And avoid doing the RFCs twice per Pull Request update.