### PR TITLE
Replace ISO3166-1 and IANADomains references by BCP47 two-letter region subtag

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -426,15 +426,15 @@ The interpretation of the binary data depends on the BlockAddIDType value and th
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="Language" path="\Segment\Tracks\TrackEntry\Language" id="0x22B59C" type="string" default="eng" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the track in the Matroska languages form;
-see (#language-codes) on language codes.
+    <documentation lang="en" purpose="definition">The language of the track,
+in the Matroska languages form; see (#language-codes) on language codes.
 This Element **MUST** be ignored if the LanguageBCP47 Element is used in the same TrackEntry.</documentation>
     <extension type="libmatroska" cppname="TrackLanguage"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="LanguageBCP47" path="\Segment\Tracks\TrackEntry\LanguageBCP47" id="0x22B59D" type="string" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the track according to [@!BCP47]
-and using the IANA Language Subtag Registry [@!IANALangRegistry].
+    <documentation lang="en" purpose="definition">The language of the track,
+in the [@!BCP47] form; see (#language-codes) on language codes.
 If this Element is used, then any Language Elements used in the same TrackEntry **MUST** be ignored.</documentation>
     <extension type="libmatroska" cppname="LanguageIETF"/>
   </element>
@@ -1420,8 +1420,8 @@ For more detailed information, look at the Chapters explanation in (#chapters).<
     <documentation lang="en" purpose="definition">Contains the string to use as the edition name.</documentation>
   </element>
   <element name="EditionLanguageIETF" path="\Segment\Chapters\EditionEntry\EditionDisplay\EditionLanguageIETF" id="0x45E4" type="string" minver="5">
-    <documentation lang="en" purpose="definition">Specifies one language corresponding to the EditionString in the format defined in [@!BCP47]
-and using the IANA Language Subtag Registry [@!IANALangRegistry].</documentation>
+    <documentation lang="en" purpose="definition">One language corresponding to the EditionString,
+in the [@!BCP47] form; see (#language-codes) on language codes.</documentation>
   </element>
   <element name="ChapterAtom" path="\Segment\Chapters\EditionEntry\+ChapterAtom" id="0xB6" type="master" minOccurs="1" recursive="1">
     <documentation lang="en" purpose="definition">Contains the atom information to use as the chapter atom (apply to all tracks).</documentation>
@@ -1525,19 +1525,20 @@ Absence of this Element indicates that the Chapter **SHOULD** be applied to any 
   </element>
   <element name="ChapLanguage" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapLanguage" id="0x437C" type="string" default="eng" minOccurs="1">
     <documentation lang="en" purpose="definition">A language corresponding to the string,
-in the bibliographic ISO-639-2 form [@!ISO639-2].
+in the Matroska languages form; see (#language-codes) on language codes.
 This Element **MUST** be ignored if a ChapLanguageBCP47 Element is used within the same ChapterDisplay Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="ChapterLanguage"/>
   </element>
   <element name="ChapLanguageBCP47" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapLanguageBCP47" id="0x437D" type="string" minver="4">
-    <documentation lang="en" purpose="definition">Specifies a language corresponding to the ChapString in the format defined in [@!BCP47]
-and using the IANA Language Subtag Registry [@!IANALangRegistry].
+    <documentation lang="en" purpose="definition">A language corresponding to the ChapString,
+in the [@!BCP47] form; see (#language-codes) on language codes.
 If a ChapLanguageBCP47 Element is used, then any ChapLanguage and ChapCountry Elements used in the same ChapterDisplay **MUST** be ignored.</documentation>
     <extension type="libmatroska" cppname="ChapLanguageIETF"/>
   </element>
   <element name="ChapCountry" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterDisplay\ChapCountry" id="0x437E" type="string">
-    <documentation lang="en" purpose="definition">A country corresponding to the string, using the same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
+    <documentation lang="en" purpose="definition">A country corresponding to the string,
+in the Matroska countries form; see (#country-codes) on country codes.
 This Element **MUST** be ignored if a ChapLanguageBCP47 Element is used within the same ChapterDisplay Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="ChapterCountry"/>
@@ -1680,15 +1681,15 @@ If set to any other value, it **MUST** match the `FileUID` value of an attachmen
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="TagLanguage" path="\Segment\Tags\Tag\+SimpleTag\TagLanguage" id="0x447A" type="string" default="und" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the tag specified, in the Matroska languages form;
-see (#language-codes) on language codes.
+    <documentation lang="en" purpose="definition">Specifies the language of the tag specified,
+in the Matroska languages form; see (#language-codes) on language codes.
 This Element **MUST** be ignored if the TagLanguageBCP47 Element is used within the same SimpleTag Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="TagLangue"/>
   </element>
   <element name="TagLanguageBCP47" path="\Segment\Tags\Tag\+SimpleTag\TagLanguageBCP47" id="0x447B" type="string" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language used in the TagString according to [@!BCP47]
-and using the IANA Language Subtag Registry [@!IANALangRegistry].
+    <documentation lang="en" purpose="definition">The language used in the TagString,
+in the [@!BCP47] form; see (#language-codes) on language codes.
 If this Element is used, then any TagLanguage Elements used in the same SimpleTag **MUST** be ignored.</documentation>
     <extension type="libmatroska" cppname="TagLanguageIETF"/>
   </element>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -32,9 +32,9 @@ targeted item taken from another work of art. All tags in this list can be used
     </tag>
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
       <description lang="en">The name of the country
-that is meant to have other tags inside (using nested tags) to country specific information about the item.
+that is meant to have other tags inside (using nested tags) to country specific information about the item,
+in the Matroska countries form, i.e. [@!BCP47] two-letter region subtag, without the UK exception.
 All tags in this list can be used "under" the COUNTRY_SPECIFIC tag like LABEL, PUBLISH_RATING, etc.
-The country code uses the same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
 </description>
     </tag>
     <tag name="TOTAL_PARTS" class="Organization Information" type="UTF-8">
@@ -252,25 +252,24 @@ an age in other countries or a URI defining a logo).</description>
       <description lang="en">Information on when the file was purchased; see also (#commercial) on purchase tags.</description>
     </tag>
     <tag name="RECORDING_LOCATION" class="Spatial Information" type="UTF-8">
-      <description lang="en">The location where the item was recorded. The countries corresponding to the string,
-same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
+      <description lang="en">The location where the item was recorded,
+in the Matroska countries form, i.e. [@!BCP47] two-letter region subtag, without the UK exception.
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example,
 "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state
 is unknown, but you want to store the city, simply leave a space between the two commas. For example, "US, , Austin".</description>
     </tag>
     <tag name="COMPOSITION_LOCATION" class="Spatial Information" type="UTF-8">
-      <description lang="en">Location that the item was originally designed/written. The countries corresponding to the string,
-same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
+      <description lang="en">Location that the item was originally designed/written,
+in the Matroska countries form, i.e. [@!BCP47] two-letter region subtag, without the UK exception.
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city.
 For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown,
 but you want to store the city, simply leave a space between the two commas. For example, "US, , Austin".</description>
     </tag>
     <tag name="COMPOSER_NATIONALITY" class="Spatial Information" type="UTF-8">
-      <description lang="en">Nationality of the main composer of the item, mostly for classical music.
-The countries corresponding to the string,
-same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.</description>
+      <description lang="en">Nationality of the main composer of the item, mostly for classical music,
+in the Matroska countries form, i.e. [@!BCP47] two-letter region subtag, without the UK exception.</description>
     </tag>
     <tag name="COMMENT" class="Personal" type="UTF-8">
       <description lang="en">Any comment related to the content.</description>

--- a/notes.md
+++ b/notes.md
@@ -577,7 +577,9 @@ although `BCP 47` is **RECOMMENDED**. The `BCP 47 Language Elements` are "Langua
 "TagLanguageBCP47 Element", and "ChapLanguageBCP47 Element". If a `BCP 47 Language Element` and an `ISO 639-2 Language Element`
 are used within the same `Parent Element`, then the `ISO 639-2 Language Element` **MUST** be ignored and precedence given to the `BCP 47 Language Element`.
 
-Country codes are the same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
+# Country Codes
+
+Country codes are the [@!BCP47] two-letter region subtag, without the UK exception.
 
 
 # Encryption

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -9,7 +9,7 @@
   </front>
 </reference>
 
-<reference  anchor='BCP47' target='https://www.rfc-editor.org/info/rfc5646'>
+<reference anchor='BCP47' target='https://www.rfc-editor.org/info/rfc5646'>
   <front>
     <title>Tags for Identifying Languages</title>
     <author initials='A.' surname='Phillips' fullname='A. Phillips' role='editor'><organization /></author>
@@ -115,32 +115,6 @@
     <title>YUV Pixel Format FourCCs</title>
     <author><organization>Silicon.dk ApS</organization></author>
   </front>
-</reference>
-
-<reference anchor="IANALangRegistry" target="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">
-  <front>
-    <title>IANA Language Subtag Registry</title>
-    <author/>
-    <date day="28" month="February" year="2013" />
-  </front>
-</reference>
-
-<reference anchor="IANADomains" target="https://www.iana.org/domains/root/db">
-  <front>
-    <title>IANA Root Zone Database</title>
-    <author/>
-  </front>
-</reference>
-
-<reference anchor="ISO3166-1" target="https://www.iso.org/standard/72482.html">
-  <front>
-    <title>Codes for the representation of names of countries and their subdivisions -- Part 1: Country code</title>
-    <author>
-      <organization>International Organization for Standardization</organization>
-    </author>
-    <date month="August" year="2020"/>
-  </front>
-  <seriesInfo name="ISO" value="3166-1:2020" />
 </reference>
 
 <reference anchor="ISO639-2" target="https://www.loc.gov/standards/iso639-2/php/code_list.php">

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -10,13 +10,6 @@
   <seriesInfo name="GS1" value="20.0" />
 </reference>
 
-<reference anchor="IANADomains" target="https://www.iana.org/domains/root/db">
-  <front>
-    <title>IANA Root Zone Database</title>
-    <author/>
-  </front>
-</reference>
-
 <reference anchor="ID3v2" target="https://id3.org/id3v2.3.0">
   <front>
     <title>ID3 tag version 2.3.0</title>
@@ -46,15 +39,17 @@
   </front>
 </reference>
 
-<reference anchor="ISO3166-1" target="https://www.iso.org/standard/72482.html">
+<reference anchor='BCP47' target='https://www.rfc-editor.org/info/rfc5646'>
   <front>
-    <title>Codes for the representation of names of countries and their subdivisions -- Part 1: Country code</title>
-    <author>
-      <organization>International Organization for Standardization</organization>
-    </author>
-    <date month="August" year="2020"/>
+    <title>Tags for Identifying Languages</title>
+    <author initials='A.' surname='Phillips' fullname='A. Phillips' role='editor'><organization /></author>
+    <author initials='M.' surname='Davis' fullname='M. Davis' role='editor'><organization /></author>
+    <date year='2009' month='September' />
+    <abstract><t>This document describes the structure, content, construction, and semantics of language tags for use in cases where it is desirable to indicate the language used in an information object.  It also describes how to register values for use in language tags and the creation of user-defined extensions for private interchange.  This document  specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t></abstract>
   </front>
-  <seriesInfo name="ISO" value="3166-1:2020" />
+  <seriesInfo name='BCP' value='47'/>
+  <seriesInfo name='RFC' value='5646'/>
+  <seriesInfo name='DOI' value='10.17487/RFC5646'/>
 </reference>
 
 <reference anchor="ISO4217" target="https://www.iso.org/iso-4217-currency-codes.html">

--- a/transforms/ebml_schema2spec_common.xsl
+++ b/transforms/ebml_schema2spec_common.xsl
@@ -420,6 +420,9 @@
               <xsl:when test="$link-string = 'block-structure'">
                 <a href="basics.html#block-structure">basics</a>
               </xsl:when>
+              <xsl:when test="$link-string = 'country-codes'">
+                <a href="basics.html#country-codes">basics</a>
+              </xsl:when>
               <xsl:when test="$link-string = 'simpleblock-structure'">
                 <a href="basics.html#simpleblock-structure">basics</a>
               </xsl:when>


### PR DESCRIPTION
Normalize the text about languages and countries, always referencing the notes so definition is at one place only.
ISO3166-1 is replaced by [BCP47 two-letter region subtag](https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.4).
IANADomains is removed because it is actually not (no more?) only about countries (it also trademarks or sponsored words), and items using it are nationalities (so pure ISO3166-1 is needed) or locations (tag may have additional info about state, city...)
IANALangRegistry is removed because [it is referenced by BCP47](https://datatracker.ietf.org/doc/html/rfc5646#section-3).

Note:  we may need to have 2 separate types Nationality and Country, as Country actually lists some regions. For example NC (New Caledonia) is ISO3166-1/IANADomains but is not a nationality (NC inhabitants have FR nationality). But may be too complex and we keep as is for now.