### PR TITLE
Add ATRAC1 codec mapping

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -823,7 +823,7 @@ Codec ID: A_ATRAC/AT1
 
 Codec Name: Sony ATRAC1 Codec
 
-Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms. The core technical details on ATRAC1 can be found in [@!AtracAES]. An example encoder/decoder can be found at [@!atracdenc].
+Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms. The core technical details on ATRAC1 can be found in [@?AtracAES]. An example encoder/decoder can be found at [@?atracdenc].
 
 Initialization: None
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -817,6 +817,16 @@ The `BlockAddId` of the `BlockMore` containing these data **MUST** be 1.
 
 Initialization: none
 
+### A_ATRAC/AT1
+
+Codec ID: A_ATRAC/AT1
+
+Codec Name: Sony ATRAC1 Codec
+
+Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms.
+
+Initialization: If the encoded audio track has a channel count other than `2` (STEREO), the `Private Data` contains a single unsigned byte that specifies the number of channels. If the channel count is `0` or the `Initialization` is set to `None`, the channel count will default to `2` (STEREO).
+
 ## Subtitle Codec Mappings
 
 ### S_TEXT/UTF8

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -823,7 +823,7 @@ Codec ID: A_ATRAC/AT1
 
 Codec Name: Sony ATRAC1 Codec
 
-Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms. The core technical details on ATRAC1 can be found at https://www.minidisc.wiki/technology/atrac/aes. An example encoder can be found at https://github.com/dcherednik/atracdenc.
+Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms. The core technical details on ATRAC1 can be found in [@!AtracAES]. An example encoder/decoder can be found at [@!atracdenc].
 
 Initialization: None
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -825,7 +825,7 @@ Codec Name: Sony ATRAC1 Codec
 
 Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms.
 
-Initialization: If the encoded audio track has a channel count other than `2` (STEREO), the `Private Data` contains a single unsigned byte that specifies the number of channels. If the channel count is `0` or the `Initialization` is set to `None`, the channel count will default to `2` (STEREO).
+Initialization: None
 
 ## Subtitle Codec Mappings
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -823,7 +823,7 @@ Codec ID: A_ATRAC/AT1
 
 Codec Name: Sony ATRAC1 Codec
 
-Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms.
+Description: The original ATRAC codec by Sony, mainly used in MiniDisc platforms. The core technical details on ATRAC1 can be found at https://www.minidisc.wiki/technology/atrac/aes. An example encoder can be found at https://github.com/dcherednik/atracdenc.
 
 Initialization: None
 

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -93,3 +93,21 @@
     <date day="04" month="April" year="2021" />
   </front>
 </reference>
+
+<reference anchor="AtracAES" target="https://www.minidisc.wiki/technology/atrac/aes">
+  <front>
+    <title>ATRAC: Adaptive Transform Acoustic Coding for MiniDisc</title>
+    <author>
+      <organization>Sony Corporate Research Laboratories</organization>
+    </author>
+    <date year="1992" month="October" day="1"/>
+  </front>
+</reference>
+
+<reference anchor="atracdenc" target="https://github.com/dcherednik/atracdenc">
+  <front>
+    <title>atracdenc - ATRAC1 and ATRAC3 Decoder/Encoder</title> 
+    <author initials="D." surname="Cherednik" fullname="Daniil Cherednik"></author>
+    <date year="2022" month="October" day="12"/>
+  </front>
+</reference>


### PR DESCRIPTION
This PR adds a mapping for ATRAC1 audio data. 

Related communication in the Celler mailing list: https://mailarchive.ietf.org/arch/msg/cellar/YWKreGPHFltjtps0Yz2JOILdWA4/.