### PR TITLE
remove normative aspect of track flags

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -327,12 +327,12 @@ The value **SHOULD** be stored on 1 octet.</documentation>
     <extension type="libmatroska" cppname="TrackFlagEnabled"/>
   </element>
   <element name="FlagDefault" path="\Segment\Tracks\TrackEntry\FlagDefault" id="0x88" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) **SHOULD** be eligible for automatic selection by the player; see (#default-track-selection) for more details.</documentation>
+    <documentation lang="en" purpose="definition">Set if that track (audio, video or subs) is eligible for automatic selection by the player; see (#default-track-selection) for more details.</documentation>
     <extension type="libmatroska" cppname="TrackFlagDefault"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="FlagForced" path="\Segment\Tracks\TrackEntry\FlagForced" id="0x55AA" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Applies only to subtitles. Set if that track **SHOULD** be eligible for automatic selection by the player if it matches the user's language preference,
+    <documentation lang="en" purpose="definition">Applies only to subtitles. Set if that track is eligible for automatic selection by the player if it matches the user's language preference,
 even if the user's preferences would normally not enable subtitles with the selected audio track;
 this can be used for tracks containing only translations of foreign-language audio or onscreen text.
 See (#default-track-selection) for more details.</documentation>


### PR DESCRIPTION
The linked section gives a better idea of what should and should not be done.