### PR TITLE
tags targets can be omitted

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1590,7 +1590,7 @@ A list of valid tags can be found in [@?MatroskaTags].</documentation>
   </element>
   <element name="Targets" path="\Segment\Tags\Tag\Targets" id="0x63C0" type="master" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specifies which other elements the metadata represented by the Tag applies to.
-If empty or not present, then the Tag describes everything in the Segment.</documentation>
+If empty or omitted, then the Tag describes everything in the Segment.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="TagTargets"/>
   </element>


### PR DESCRIPTION
That's the proper term for mandatory EBML elements not present.