### PR TITLE
Remove markdown titles

### DIFF
--- a/attachments.md
+++ b/attachments.md
@@ -1,7 +1,3 @@
----
-title: Attachments
----
-
 # Attachments
 
 Matroska supports storage of related files and data in the `Attachments Element`
@@ -95,4 +91,5 @@ The file extension check **MUST** be case insensitive.
 
 Matroska writers **SHOULD** use a valid font media type from [@!RFC8081] in the `AttachedFile\FileMediaType` of the font attachment.
 They **MAY** use the media types found in older files when compatibility with older players is necessary.
+
 

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -1,6 +1,3 @@
----
-title: Block Additional Mapping
----
 # Block Additional Mapping
 
 Extra data or metadata can be added to each `Block` using `BlockAdditional` data.

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -1,7 +1,3 @@
----
-title: Chapter Codecs
----
-
 # Matroska Chapter Codecs
 
 Chapter codecs are a way to add more complex playback features than the usual linear playback.

--- a/chapters.md
+++ b/chapters.md
@@ -1,7 +1,3 @@
----
-title: Chapters
----
-
 # Chapters
 
 The Matroska Chapters system can have multiple `Editions` and each `Edition` can consist of

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1,7 +1,3 @@
----
-title: Codec Mappings
----
-
 # Codec Mappings
 
 A `Codec Mapping` is a set of attributes to identify, name, and contextualize the format

--- a/control.md
+++ b/control.md
@@ -1,6 +1,3 @@
----
-title: Control Tracks
----
 # Edition Flags
 
 ## EditionFlagHidden

--- a/cues.md
+++ b/cues.md
@@ -1,7 +1,3 @@
----
-title: Cues
----
-
 # Cues
 
 The `Cues Element` provides an index of certain `Cluster Elements` to allow for optimized

--- a/matroska_implement.md
+++ b/matroska_implement.md
@@ -1,7 +1,3 @@
----
-title: Matroska Implementation Recommentations
----
-
 # Implementation Recommendations
 
 ## Cluster

--- a/menu.md
+++ b/menu.md
@@ -1,7 +1,3 @@
----
-title: Menu Specifications
----
-
 # Menu Specifications
 
 This document is a _draft of the Menu system_ that will be the default one in `Matroska`.

--- a/notes.md
+++ b/notes.md
@@ -1,7 +1,3 @@
----
-title: Specification Notes
----
-
 # Matroska versioning
 
 Matroska is based upon the principle that a reading application does not have to support

--- a/ordering.md
+++ b/ordering.md
@@ -1,7 +1,3 @@
----
-title: Matroska Element Ordering
----
-
 # Matroska Element Ordering
 
 Except for the `EBML Header` and the `CRC-32 Element`, the EBML specification does not

--- a/streaming.md
+++ b/streaming.md
@@ -1,7 +1,3 @@
----
-title: Matroska Streaming
----
-
 # Matroska Streaming
 
 In Matroska, there are two kinds of streaming: file access and livestreaming.

--- a/subtitles.md
+++ b/subtitles.md
@@ -1,7 +1,3 @@
----
-title: Subtitles
----
-
 # Subtitles
 
 Because Matroska is a general container format, we try to avoid specifying the formats

--- a/tagging.md
+++ b/tagging.md
@@ -1,7 +1,3 @@
----
-title: Tagging
----
-
 # Tagging
 
 When a Tag is nested within another Tag, the nested Tag becomes an attribute of the base tag.

--- a/tags-precedence.md
+++ b/tags-precedence.md
@@ -1,7 +1,3 @@
----
-title: Tags Precedence
----
-
 # Tags Precedence
 
 Tags allow tagging all kinds of Matroska parts with very detailed metadata in multiple languages.


### PR DESCRIPTION
The latest mmark doesn't handle them properly. And we probably don't need them.