### PR TITLE
mention the UncompressedFourCC values don't have an official list

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -692,7 +692,7 @@ PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</i
   </element>
   <element name="UncompressedFourCC" path="\Segment\Tracks\TrackEntry\Video\UncompressedFourCC" id="0x2EB524" type="binary" length="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the uncompressed pixel format used for the Track's data as a FourCC.
-This value is similar in scope to the biCompression value of AVI's `BITMAPINFO` [@?AVIFormat]. See the YUV video formats [@?FourCC-YUV] and RGB video formats [@?FourCC-RGB] for common values.</documentation>
+This value is similar in scope to the biCompression value of AVI's `BITMAPINFO` [@?AVIFormat]. There is no definitive list of FourCC values, nor an official registry. Some common values for YUV pixel formats can be found at [@?MSYUV8], [@?MSYUV16] and [@?FourCC-YUV]. Some common values for uncompressed RGB pixel formats can be found at [@?MSRGB] and [@?FourCC-RGB].</documentation>
     <implementation_note note_attribute="minOccurs">UncompressedFourCC **MUST** be set (minOccurs=1) in TrackEntry, when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
     <extension type="libmatroska" cppname="VideoColourSpace"/>
     <extension type="stream copy" keep="1"/>

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -103,14 +103,14 @@
   <seriesInfo name='DOI' value='10.6028/10.6028/NIST.SP.800-67r2'/>
 </reference>
 
-<reference anchor="FourCC-RGB" target="https://www.fourcc.org/rgb.php">
+<reference anchor="FourCC-RGB" target="http://web.archive.org/web/20160609214806/https://www.fourcc.org/rgb.php">
   <front>
     <title>RGB Pixel Format FourCCs</title>
     <author><organization>Silicon.dk ApS</organization></author>
   </front>
 </reference>
 
-<reference anchor="FourCC-YUV" target="https://www.fourcc.org/yuv.php">
+<reference anchor="FourCC-YUV" target="http://web.archive.org/web/20160609214806/https://www.fourcc.org/yuv.php">
   <front>
     <title>YUV Pixel Format FourCCs</title>
     <author><organization>Silicon.dk ApS</organization></author>

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -117,6 +117,27 @@
   </front>
 </reference>
 
+<reference anchor="MSRGB" target="https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wmf/4e588f70-bd92-4a6f-b77f-35d0feaf7a57">
+  <front>
+    <title>WMF Compression Enumeration</title>
+    <author><organization>Microsoft</organization></author>
+  </front>
+</reference>
+
+<reference anchor="MSYUV8" target="https://learn.microsoft.com/en-us/windows/win32/medfound/recommended-8-bit-yuv-formats-for-video-rendering">
+  <front>
+    <title>Recommended 8-Bit YUV Formats for Video Rendering</title>
+    <author><organization>Microsoft</organization></author>
+  </front>
+</reference>
+
+<reference anchor="MSYUV16" target="https://learn.microsoft.com/en-us/windows/win32/medfound/10-bit-and-16-bit-yuv-video-formats">
+  <front>
+    <title>10-bit and 16-bit YUV Video Formats</title>
+    <author><organization>Microsoft</organization></author>
+  </front>
+</reference>
+
 <reference anchor="ISO639-2" target="https://www.loc.gov/standards/iso639-2/php/code_list.php">
   <front>
     <title>Codes for the Representation of Names of Languages</title>


### PR DESCRIPTION
Link to fourcc.org via web.archive.org as the website is gone. Also add some more official MS values that can be found in AVI, as P010-P016 is missing from all online lists I could find.

Maybe we should start a IANA registry for that in the Codec Spec document. Describing each value might be tricky...