### PR TITLE
make encryption references normative

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1228,19 +1228,19 @@ A Matroska Player **MAY** support encryption.</documentation>
         <documentation lang="en" purpose="definition">The data are not encrypted.</documentation>
       </enum>
       <enum value="1" label="DES">
-        <documentation lang="en" purpose="definition">Data Encryption Standard (DES) [@?FIPS.46-3].</documentation>
+        <documentation lang="en" purpose="definition">Data Encryption Standard (DES) [@!FIPS.46-3].</documentation>
       </enum>
       <enum value="2" label="3DES">
-        <documentation lang="en" purpose="definition">Triple Data Encryption Algorithm [@?SP.800-67].</documentation>
+        <documentation lang="en" purpose="definition">Triple Data Encryption Algorithm [@!SP.800-67].</documentation>
       </enum>
       <enum value="3" label="Twofish">
-        <documentation lang="en" purpose="definition">Twofish Encryption Algorithm [@?Twofish].</documentation>
+        <documentation lang="en" purpose="definition">Twofish Encryption Algorithm [@!Twofish].</documentation>
       </enum>
       <enum value="4" label="Blowfish">
-        <documentation lang="en" purpose="definition">Blowfish Encryption Algorithm [@?Blowfish].</documentation>
+        <documentation lang="en" purpose="definition">Blowfish Encryption Algorithm [@!Blowfish].</documentation>
       </enum>
       <enum value="5" label="AES">
-        <documentation lang="en" purpose="definition">Advanced Encryption Standard (AES) [@?FIPS.197].</documentation>
+        <documentation lang="en" purpose="definition">Advanced Encryption Standard (AES) [@!FIPS.197].</documentation>
       </enum>
     </restriction>
     <extension type="webmproject.org" webm="1"/>


### PR DESCRIPTION
Encryption support is not mandatory. But when it's used, the way to handle each encryption type is normative, given the proper documentation.