### PR TITLE
Add ARIB B-24 subtitle codec mapping

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -925,6 +925,15 @@ Description: A subtitle format developed for ogg. The mapping for Matroska is de
 on the [Xiph wiki](http://wiki.xiph.org/index.php/OggKate#Matroska_mapping).
 As for Theora and Vorbis, Kate headers are stored in the private data as xiph-laced packets.
 
+### S_ARIBSUB
+
+Codec ID: S_ARIBSUB
+
+Codec Name: ARIB STD-B24 subtitles
+
+Description: This is the textual subtitle format used in the ISDB/ARIB broadcasting standard.
+For more information, see (#arib-isdb-subtitles) on ARIB (ISDB) subtitles.
+
 ## Button Codec Mappings
 
 ### B_VOBBTN

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -106,8 +106,38 @@
 
 <reference anchor="atracdenc" target="https://github.com/dcherednik/atracdenc">
   <front>
-    <title>atracdenc - ATRAC1 and ATRAC3 Decoder/Encoder</title> 
+    <title>atracdenc - ATRAC1 and ATRAC3 Decoder/Encoder</title>
     <author initials="D." surname="Cherednik" fullname="Daniil Cherednik"></author>
     <date year="2022" month="October" day="12"/>
+  </front>
+</reference>
+
+<reference anchor="ARIB.STD-B24" target="https://www.arib.or.jp/english/std_tr/broadcasting/desc/std-b24.html">
+  <front>
+    <title>Data Coding and Transmission Specification for Digital Broadcasting</title>
+    <author>
+      <organization>ARIB</organization>
+    </author>
+    <date year="2022" month="October" day="6"/>
+  </front>
+</reference>
+
+<reference anchor="ARIB.STD-B10" target="https://www.arib.or.jp/english/std_tr/broadcasting/desc/std-b10.html">
+  <front>
+    <title>Service Information for Digital Broadcasting System</title>
+    <author>
+      <organization>ARIB</organization>
+    </author>
+    <date year="2019" month="December" day="5"/>
+  </front>
+</reference>
+
+<reference anchor="ARIB.TR-B14" target="https://www.arib.or.jp/english/std_tr/broadcasting/desc/tr-b14.html">
+  <front>
+    <title>Operational Guidelines for Digital Terrestrial Television Broadcasting</title>
+    <author>
+      <organization>ARIB</organization>
+    </author>
+    <date year="2022" month="October" day="6"/>
   </front>
 </reference>

--- a/subtitles.md
+++ b/subtitles.md
@@ -677,3 +677,35 @@ in segment 7.2 "Syntax and semantics of the subtitling segment" of ETSI EN 300 7
 Each Matroska Block **SHOULD** have a Duration indicating how long the DVB Subtitle Segments
 in that Block **SHOULD** be displayed.
 
+## ARIB (ISDB) subtitles
+
+The specifications for the ARIB B-24 subtitle bitstream format (short: ARIB subtitles)
+and its storage in MPEG transport streams can be found in the documents
+[@!ARIB.STD-B24], [@!ARIB.STD-B10], and [@!ARIB.TR-B14].
+
+### Storage of ARIB subtitles
+
+#### CodecID
+
+The CodecID to use is `S_ARIBSUB`.
+
+#### CodecPrivate
+
+The CodecPrivate element is three bytes long and has the following structure:
+
+*    1 byte: component tag (bit string, left bit first)
+*    2 bytes: data component ID (bit string, left bit first)
+
+The semantics of the component tag are the same as those described in [@!ARIB.STD-B10], part 2, Annex J.
+The semantics of the data component ID are the same as those described in [@!ARIB.TR-B14], fascicle 2, Vol. 3, Section 2, 4.2.8.1.
+
+#### Storage of ARIB subtitles in Matroska Blocks
+
+Each Matroska Block consists of one or more ISDB Caption Data Groups as described
+in chapter 9 "Transmission of caption and superimpose" of [@!ARIB.STD-B24], volume 1, part 3.
+All of the Caption Statement Data Groups in a given Matroska Track **MUST** use the same language index.
+
+A Data Group is normally shown until a subsequent Group provides instructions to clear it.
+Therefore the Matroska Block **SHOULD NOT** have a Duration.
+A player **SHOULD** display a Data Group within a Matroska Block until its internal duration elapses,
+or until a subsequent Data Group removes it.


### PR DESCRIPTION
This adds a mapping for ISDB/ARIB STD-B24 caption data.