### PR TITLE
Clarify PES header presence in ARIB caption packets

### DIFF
--- a/subtitles.md
+++ b/subtitles.md
@@ -701,7 +701,9 @@ The semantics of the data component ID are the same as those described in [@!ARI
 
 #### Storage of ARIB subtitles in Matroska Blocks
 
-Each Matroska Block consists of one or more ISDB Caption Data Groups as described
+Each Matroska Block consists of a single synchronized PES data structure as described in
+chapter 5 "Independent PES transmission protocol" of [@!ARIB.STD-B24], volume 3, with a
+Synchronized_PES_data_byte block containing one or more ISDB Caption Data Groups as described
 in chapter 9 "Transmission of caption and superimpose" of [@!ARIB.STD-B24], volume 1, part 3.
 All of the Caption Statement Data Groups in a given Matroska Track **MUST** use the same language index.
 


### PR DESCRIPTION
I'd missed that this header was described in the ARIB B-24 spec. It contains data used to indicate whether the contents are normal captions or "superimpose" captions (used for emergency messaging and the like). All existing software decoders expect it to be present in the packets they're fed, and my implementations of ARIB B-24 in ffmpeg and mpv (both on the mux and demux end) expect it to be present.