### PR TITLE
make top-level elements ID 4-octets long

### DIFF
--- a/diagram.md
+++ b/diagram.md
@@ -2,7 +2,7 @@
 
 A Matroska file **MUST** be composed of at least one `EBML Document` using the `Matroska Document Type`.
 Each `EBML Document` **MUST** start with an `EBML Header` and **MUST** be followed by the `EBML Root Element`,
-defined as `Segment` in Matroska. Matroska defines several `Top Level Elements`
+defined as `Segment` in Matroska. Matroska defines several `Top-Level Elements`
 which **MAY** occur within the `Segment`.
 
 As an example, a simple Matroska file consisting of a single `EBML Document` could be represented like this:
@@ -19,7 +19,7 @@ A more complex Matroska file consisting of an `EBML Stream` (consisting of two `
 
 The following diagram represents a simple Matroska file, comprised of an `EBML Document`
 with an `EBML Header`, a `Segment Element` (the `Root Element`), and all eight Matroska
-`Top Level Elements`. In the following diagrams of this section, horizontal spacing expresses
+`Top-Level Elements`. In the following diagrams of this section, horizontal spacing expresses
 a parent-child relationship between Matroska Elements (e.g., the `Info Element` is contained within
 the `Segment Element`) whereas vertical alignment represents the storage order within the file.
 
@@ -46,7 +46,7 @@ the `Segment Element`) whereas vertical alignment represents the storage order w
 ```
 Figure: Basic layout of a Matroska file.
 
-The Matroska `EBML Schema` defines eight `Top Level Elements`:
+The Matroska `EBML Schema` defines eight `Top-Level Elements`:
 
 - `SeekHead` ((#seekhead)),
 - `Info` ((#info)),
@@ -57,9 +57,9 @@ The Matroska `EBML Schema` defines eight `Top Level Elements`:
 - `Attachments` ((#attachments-1)),
 - and `Tags` ((#tags)).
 
-The `SeekHead Element` (also known as `MetaSeek`) contains an index of `Top Level Elements`
+The `SeekHead Element` (also known as `MetaSeek`) contains an index of `Top-Level Elements`
 locations within the `Segment`. Use of the `SeekHead Element` is **RECOMMENDED**. Without a `SeekHead Element`,
-a Matroska parser would have to search the entire file to find all of the other `Top Level Elements`.
+a Matroska parser would have to search the entire file to find all of the other `Top-Level Elements`.
 This is due to Matroska's flexible ordering requirements; for instance, it is acceptable for
 the `Chapters Element` to be stored after the `Cluster Elements`.
 

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -14,7 +14,7 @@
     <documentation lang="en" purpose="definition">Contains a single seek entry to an EBML Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="SeekID" path="\Segment\SeekHead\Seek\SeekID" id="0x53AB" type="binary" length="&lt;= 4" minOccurs="1" maxOccurs="1">
+  <element name="SeekID" path="\Segment\SeekHead\Seek\SeekID" id="0x53AB" type="binary" length="4" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary EBML ID of a Top-Level Element.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -118,7 +118,7 @@ As an EBML Document Type, Matroska adds the following constraints to the EBML sp
 
 ## Design Rules
 
-The Root Element and all Top-Levels Elements use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
+The Root Element and all Top-Levels Elements **MUST** use 4 octets for their EBML Element ID -- i.e. Segment and direct children of Segment.
 
 Legacy EBML/Matroska parsers did not handle Empty Elements properly, elements present in the file but with a length of zero.
 They always assumed the value was 0 for integers/dates and 0x0p+0 for floats, no matter the default value of the element which should have been used instead.

--- a/ordering.md
+++ b/ordering.md
@@ -13,6 +13,8 @@ To be playable, Matroska **MUST** also contain at least one `Tracks Element` and
 The first `Info Element` and the first `Tracks Element` **MUST** either be stored before the first
 `Cluster Element` or both **SHALL** be referenced by a `SeekHead Element` occurring before the first `Cluster Element`.
 
+All `Top-Level Elements` **MUST** use a 4-octet long EBML Element ID.
+
 When using Medium Linking, chapters are used to reference other Segments to play in a given order (#medium-linking).
 In that case the Segment containing in these Chapters do no required a `Track` Element or a `Cluster` Element.
 


### PR DESCRIPTION
cc @mbunkus as it will change the libmatroska code (unlikely to have any effect in the real world)