### PR TITLE
BlockAddIDValue 4 is not recommended

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -88,6 +88,10 @@ The values of `BlockAddID` that are 2 of greater have no semantic meaning, but s
 associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track.
 See (#block-additional-mapping) on Block Additional Mappings for more information.
 
+The value of 4 for `BlockAddID` (so also `BlockAddIDValue`) **SHOULD NOT** be used when `BlockAddIDType` is not 4,
+as some WebM-oriented demuxers consider a block with `BlockAddID` of 4 as ITU T.35 metadata
+without checking `BlockAddIDType`.
+
 The following XML depicts the nested Elements of a `BlockGroup Element` with an example of BlockAdditions:
 
 ```xml
@@ -977,7 +981,8 @@ Block type identifier: 4
 Block type name: ITU T.35 metadata
 
 Description: the `BlockAdditional` data is interpreted as ITU T.35 metadata, as defined by ITU-T T.35
-terminal codes. `BlockAddIDValue` **MUST** be 4.
+terminal codes. `BlockAddIDValue` **MUST** be 4 as some WebM-oriented demuxers may ignore `BlockAddIDType`
+with blocks having a `BlockAddID` of 4.
 
 ### avcE
 


### PR DESCRIPTION
As `BlockAddIDValue` of 4 may be interpreted as ITU T.35 without checking `BlockAddIDType` (reason we mandate  `BlockAddIDValue` when `BlockAddIDType` is 4, right?), I suggest to recommend to avoid `BlockAddIDValue` of 4 when it is not ITU T.35.

Idea is from a comment at https://ffmpeg.org/pipermail/ffmpeg-devel/2023-March/307718.html