### PR TITLE
add a list of tracks to group them together

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1295,6 +1295,16 @@ A Matroska Player **MAY** support encryption.</documentation>
     <documentation lang="en" purpose="definition">A unique ID to identify the TrackSet.</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
+  <element name="TrackSetDisplay" path="\Segment\Tracks\TrackSets\TrackSetDisplay" id="0x7420" type="master" minver="5">
+    <documentation lang="en" purpose="definition">Contains a possible string to use for the TrackSet display for the given languages.</documentation>
+  </element>
+  <element name="TrackSetString" path="\Segment\Tracks\TrackSets\TrackSetDisplay\TrackSetString" id="0x743A" type="utf-8" minver="5" minOccurs="1" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Contains the string to use as the TrackSet name for the TrackSetLanguageBCP47 language(s).</documentation>
+  </element>
+  <element name="TrackSetLanguageBCP47" path="\Segment\Tracks\TrackSets\TrackSetDisplay\TrackSetLanguageBCP47" id="0x74E4" type="string" minver="5" minOccurs="1" >
+    <documentation lang="en" purpose="definition">One language corresponding to the TrackSetString,
+in the [@!BCP47]] form; see (#language-codes) on language codes.</documentation>
+  </element>
   <element name="TrackSetTrackUID" path="\Segment\Tracks\TrackSets\TrackSet\TrackSetTrackUID" id="0x7421" type="uinteger" minver="5" range="not 0" minOccurs="1">
     <documentation lang="en" purpose="definition">A UID that **MUST** match the `TrackUID` value of an track found in this Segment.</documentation>
     <extension type="stream copy" keep="1"/>


### PR DESCRIPTION
For now this Pull Request just adds the bare minimum that we agree on.

I think we also need

- [x] TrackSetUUID so it can be addressed in tags (this time we can use a proper UUID)
- [x] TagsTrackSetUUID to address a track set (give names in multiple languages)
- [x] TrackSetDisplay to set a quick name for a TrackSet (in addition to tags) 
- [ ] Set which group is the default one to use
- [ ] Set if the group is exclusive or not (other tracks hidden when selected)
- [ ] TrackSetType (default, commentary, channel) not sure about the type, the Commentary might be a flag, but the channel might need more info

Fixes #717 