### PR TITLE
require a specification for Chapter Codec IDs

### DIFF
--- a/iana.md
+++ b/iana.md
@@ -10,6 +10,8 @@ To register a new Chapter Codec ID in this registry, one needs a Chapter Codec I
 a Change Controller (IESG or email of registrant) and
 an optional Reference to a document describing the Chapter Codec ID.
 
+The Chapter Codec IDs are to be allocated according to the "First Come First Served" policy [@!RFC8126].
+
 `ChapProcessCodecID` values of "0" and "1" are RESERVED to the IETF for future use.
 
 ## Media Types


### PR DESCRIPTION
Since the codec IDs influence the playback, it is important that we have a spec to implement it, not necessarily from the IETF.