### PR TITLE
Make non-RAP ReferenceBlock usage mandatory in BlockGroup

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -383,8 +383,13 @@ the reference information **SHOULD** be recovered for non-RAP frames.
 </Cluster>
 ```
 
-When a frame in a `BlockGroup` is not a RAP, all references **SHOULD** be listed as a `ReferenceBlock`,
-at least some of them, even if not accurate, or one `ReferenceBlock` with the value "0" corresponding to a self or unknown reference.
+When a frame in a `BlockGroup` is not a RAP, the `BlockGroup` **MUST** contain at least a `ReferenceBlock`.
+The `ReferenceBlock`s **MUST** be used in one of the following ways:
+
+* each reference frame listed as a `ReferenceBlock`,
+* some referenced frame listed as a `ReferenceBlock`, even if the timestamp value is accurate,
+* or one `ReferenceBlock` with the timestamp value "0" corresponding to a self or unknown reference.
+
 The lack of `ReferenceBlock` would mean such a frame is a RAP and seeking on that
 frame that actually depends on other frames **MAY** create bogus output or even crash.
 

--- a/notes.md
+++ b/notes.md
@@ -391,7 +391,7 @@ The `ReferenceBlock`s **MUST** be used in one of the following ways:
 * or one `ReferenceBlock` with the timestamp value "0" corresponding to a self or unknown reference.
 
 The lack of `ReferenceBlock` would mean such a frame is a RAP and seeking on that
-frame that actually depends on other frames **MAY** create bogus output or even crash.
+frame that actually depends on other frames may create bogus output or even crash.
 
 * Same frame that references another frame put inside a BlockGroup but the reference could not be recovered, with the EBML tree shown as XML:
 


### PR DESCRIPTION
If it's not found it would not seek properly.

Fixes #757 and #758 (I should have split the commits)