### PR TITLE
Fix application instead of file reading in Matroska versioning

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -25,8 +25,8 @@ set. For example, if a file contains only `Elements` of version 2 or lower excep
 **SHOULD** still be set to 2 and not 4 because evaluating `CueRelativePosition` is not
 necessary for standard playback -- it makes seeking more precise if used.
 
-A reading application supporting Matroska version `V` **MUST NOT** refuse to read an
-application with `DocReadTypeVersion` equal to or lower than `V` even if `DocTypeVersion`
+A reading application supporting Matroska version `V` **MUST NOT** refuse to read a
+file with `DocReadTypeVersion` equal to or lower than `V` even if `DocTypeVersion`
 is greater than `V`.
 
 A reading application


### PR DESCRIPTION
The next paragraph uses "file" for the same thing.

Fixes #759 