### PR TITLE
Reword the DefaultDecodedFieldDuration to clarify the progressive value

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -62,11 +62,11 @@ These values are valid at the end of the decoding process before post-processing
 
 Examples:
 
-* Blu-ray movie: 1000000000ns/(48/1.001) = 20854167ns
-* PAL broadcast/DVD: 1000000000ns/(50/1.000) = 20000000ns
-* N/ATSC broadcast: 1000000000ns/(60/1.001) = 16683333ns
-* hard-telecined DVD: 1000000000ns/(60/1.001) = 16683333ns (60 encoded interlaced fields per second)
-* soft-telecined DVD: 1000000000ns/(60/1.001) = 16683333ns (48 encoded interlaced fields per second, with "repeat_first_field = 1")
+* Blu-ray movie:      1000000000 ns/(48/1.001) = 20854167 ns
+* PAL broadcast/DVD:  1000000000 ns/(50/1.000) = 20000000 ns
+* N/ATSC broadcast:   1000000000 ns/(60/1.001) = 16683333 ns
+* hard-telecined DVD: 1000000000 ns/(60/1.001) = 16683333 ns (60 encoded interlaced fields per second)
+* soft-telecined DVD: 1000000000 ns/(60/1.001) = 16683333 ns (48 encoded interlaced fields per second, with "repeat_first_field = 1")
 
 # Block Structure
 

--- a/notes.md
+++ b/notes.md
@@ -50,11 +50,12 @@ If that property is not set, elements may or may not keep the same value between
 
 The `DefaultDecodedFieldDuration Element` can signal to the displaying application how
 often fields of a video sequence will be available for displaying. It can be used for both
-interlaced and progressive content. If the video sequence is signaled as interlaced,
-then the period between two successive fields at the output of the decoding process
-equals `DefaultDecodedFieldDuration`.
+interlaced and progressive content. 
 
-For video sequences signaled as progressive, it is twice the value of `DefaultDecodedFieldDuration`.
+If the video sequence is signaled as interlaced (#flaginterlaced-element), then `DefaultDecodedFieldDuration` equals 
+the period between two successive fields at the output of the decoding process.
+For video sequences signaled as progressive, `DefaultDecodedFieldDuration` is half of 
+the period between two successive frames at the output of the decoding process.
 
 These values are valid at the end of the decoding process before post-processing
 (such as deinterlacing or inverse telecine) is applied.


### PR DESCRIPTION
This is pretty much the fix originally proposed and agreed on: https://matroska-devel.matroska.narkive.com/WIX08bXP/proposal-add-new-element-defaultdeocdedfieldduration 

Fixes #760