### PR TITLE
Remove tags Status Of This Document section

### DIFF
--- a/index_tags.md
+++ b/index_tags.md
@@ -51,12 +51,6 @@ in a `Matroska Segment`. It can tag a whole `Segment`, separate `Track Elements`
 While the Matroska tagging framework allows anyone to create their own custom tags, it's important to have a common
 set of values for interoperability. This document intends to define a set of common tag names used in Matroska.
 
-# Status of this document
-
-This document is a work-in-progress specification defining the Matroska file format as part
-of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
-It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",


### PR DESCRIPTION
The IETF status doesn't matter. The document is found at the IETF anyway. We already describe the goal of the document in the Introdution.

And the EBML RFC doesn't has a status either. The Matroska document has one because it deals with versions of Matroska.