### PR TITLE
rename "old parsers"

### DIFF
--- a/index_matroska.md
+++ b/index_matroska.md
@@ -50,7 +50,7 @@ This document updates [@!RFC8794] to permit the use of a previously reserved EBM
 Matroska is an audiovisual data container format. It was derived from a project called [@?MCF],
 but diverges from it significantly because it is based on EBML (Extensible Binary Meta Language) [@!RFC8794],
 a binary derivative of XML. EBML provides significant advantages in terms of future format extensibility,
-without breaking file support in old parsers.
+without breaking file support in parsers reading the previous versions.
 
 First, it is essential to clarify exactly "What an Audio/Video container is", to avoid any misunderstandings:
 


### PR DESCRIPTION
They are EBML parsers that don't know about new features in EBML.