### PR TITLE
CueTime in Segment Ticks instead of Matroska Ticks

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1299,7 +1299,7 @@ All entries are local to the Segment.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="CueTime" path="\Segment\Cues\CuePoint\CueTime" id="0xB3" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Absolute timestamp of the seek point, expressed in Matroska Ticks -- i.e., in nanoseconds; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Absolute timestamp of the seek point, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="CueTrackPositions" path="\Segment\Cues\CuePoint\CueTrackPositions" id="0xB7" type="master" minOccurs="1">

--- a/notes.md
+++ b/notes.md
@@ -572,7 +572,6 @@ The elements storing values in Matroska Ticks/nanoseconds are:
 * `BlockGroup\DiscardPadding`; defined in (#discardpadding-element)
 * `ChapterAtom\ChapterTimeStart`; defined in (#chaptertimestart-element)
 * `ChapterAtom\ChapterTimeEnd`; defined in (#chaptertimeend-element)
-* `CuePoint\CueTime`; defined in (#cuetime-element)
 * `CueReference\CueRefTime`; defined in (#cuetime-element)
 
 ### Segment Ticks
@@ -590,6 +589,7 @@ The elements storing values in Segment Ticks are:
 
 * `Cluster\Timestamp`; defined in (#timestamp-element)
 * `Info\Duration` is stored as a floating-point but the same formula applies; defined in (#duration-element)
+* `CuePoint\CueTime`; defined in (#cuetime-element)
 * `CuePoint\CueTrackPositions\CueDuration`; defined in (#cueduration-element)
 
 ### Track Ticks


### PR DESCRIPTION
This aims to align the specification with the usage.
mkvinfo and other tools such as VLC read CueTimes in Segment Ticks (usually milliseconds), not Matroska Ticks (nanoseconds).