### PR TITLE
fix CueRefTime type

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1341,7 +1341,7 @@ If missing, the track's DefaultDuration does not apply and no duration informati
     <documentation lang="en" purpose="definition">The Clusters containing the referenced Blocks.</documentation>
   </element>
   <element name="CueRefTime" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefTime" id="0x96" type="uinteger" minver="2" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Timestamp of the referenced Block, expressed in Matroska Ticks -- i.e., in nanoseconds; see (#timestamp-ticks).</documentation>
+    <documentation lang="en" purpose="definition">Timestamp of the referenced Block, expressed in Segment Ticks which is based on TimestampScale; see (#timestamp-ticks).</documentation>
   </element>
   <element name="CueRefCluster" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference\CueRefCluster" id="0x97" type="uinteger" minver="0" maxver="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The Segment Position of the Cluster containing the referenced Block.</documentation>

--- a/notes.md
+++ b/notes.md
@@ -593,8 +593,6 @@ The elements storing values in Matroska Ticks/nanoseconds are:
 
 * `ChapterAtom\ChapterTimeEnd`; defined in (#chaptertimeend-element)
 
-* `CueReference\CueRefTime`; defined in (#cuetime-element)
-
 ### Segment Ticks
 
 Elements in Segment Ticks involve the use of the `TimestampScale Element` of the Segment to get the timestamp
@@ -615,6 +613,8 @@ The elements storing values in Segment Ticks are:
 * `CuePoint\CueTime`; defined in (#cuetime-element)
 
 * `CuePoint\CueTrackPositions\CueDuration`; defined in (#cueduration-element)
+
+* `CueReference\CueRefTime`; defined in (#cuetime-element)
 
 ### Track Ticks
 


### PR DESCRIPTION
It's in Segment Ticks, using the TimestampScale.
That's how it's used in libmatroska: https://github.com/Matroska-Org/libmatroska/blob/44aefa8ff53562367100619cb79c949b2bb6b87e/src/KaxCuesData.cpp#L138