### PR TITLE
Adjust FieldOrder enum labels to better match description texts

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -553,10 +553,10 @@ The format depends on the `ChapProcessCodecID` used; see (#chapprocesscodecid-el
       <enum value="6" label="bff">
         <documentation lang="en" purpose="definition">Bottom field displayed first. Bottom field stored first.</documentation>
       </enum>
-      <enum value="9" label="bff(swapped)">
+      <enum value="9" label="tff (interleaved)">
         <documentation lang="en" purpose="definition">Top field displayed first. Fields are interleaved in storage with the top line of the top field stored first.</documentation>
       </enum>
-      <enum value="14" label="tff(swapped)">
+      <enum value="14" label="bff (interleaved)">
         <documentation lang="en" purpose="definition">Bottom field displayed first. Fields are interleaved in storage with the top line of the top field stored first.</documentation>
       </enum>
     </restriction>


### PR DESCRIPTION
In #162 the description for FieldOrder values have been fixed to match current practice. After the change the enum labels for FieldOrder values "9" and "14" do not align with the longer description text anymore, so adjust the labels accordingly.