### PR TITLE
Add codec mapping for VVC

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -258,6 +258,16 @@ Description: Individual pictures (which could be a frame, a field, or 2 fields h
 
 Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure, as defined in [@!ISO.14496-15].
 
+### V_MPEGI/ISO/VVC
+
+Codec ID: V_MPEGI/ISO/VVC
+
+Codec Name: VVC/H.266
+
+Description: Individual pictures (which could be a frame, a field, or 2 fields having the same timestamp) of VVC/H.266 stored as described in [@!ISO.14496-15].
+
+Initialization: The `Private Data` contains a `VVCDecoderConfigurationRecord` structure, as defined in [@!ISO.14496-15].
+
 ### V_AVS2
 
 Codec ID: V_AVS2


### PR DESCRIPTION
The [latest revision](https://www.iso.org/standard/83336.html) of ISO/IEC 14496-15 specifies the carriage of NAL unit structured video in ISO base media file format for [VVC](https://www.itu.int/rec/T-REC-H.266-202309-I/en). The initialization follows the same convention as its predecessors.