### PR TITLE
add c608 mapping

### DIFF
--- a/block_additional_mappings/c608-captions.md
+++ b/block_additional_mappings/c608-captions.md
@@ -1,0 +1,26 @@
+## c608 Captions
+
+### c608 Captions Description
+
+CEA-608 captions can be stored in `BlockMore Element` to associate the content of a Matroska Block (typically a video frame) with closed captioning data. Storing CEA-608 caption data requires that the corresponding Block SHALL NOT use Lacing.
+
+The `BlockAdditional Element` stores the c608 data as a array of one or more octet pairs from one data channel of a CEA-608 data stream with each octet pair corresponding to a video frame. For more information about the content see [@!ANSI-CTA-608-E-S-2019].
+
+### BlockAddIDType
+
+The BlockAddIDType value reserved for CEA-608 captions is "608".
+
+### BlockAddIDName
+
+The BlockAddIDName value reserved for CEA-608 captions is "CEA-608 captions".
+
+### BlockAddIDExtraData
+
+BlockAddIDExtraData MAY contain a value as defined by Section 6.4.3.3 of [!@DASH-IF-IOP] that describes the caption services and language. An ABNF from [!@DASH-IF-IOP] for this value is restated here for convenience:
+
+```
+@value = (channel *3 [";" channel]) / (language *3[";" language])
+2 channel = channel-number "=" language
+3 channel-number = CC1 | CC2 | CC3 | CC4
+4 language = 3ALPHA ; language code per ISO 639.2/B
+```

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -141,3 +141,23 @@
     <date year="2022" month="October" day="6"/>
   </front>
 </reference>
+
+<reference anchor="ANSI-CTA-608-E-S-2019" target="https://shop.cta.tech/products/line-21-data-services">
+  <front>
+    <title>Line 21 Data Services ANSI/CTA-608-E S-2019</title>
+    <author>
+      <organization>ANSI/CTA</organization>
+    </author>
+    <date year="2019" month="December"/>
+  </front>
+</reference>
+
+<reference anchor="DASH-IF-IOP" target="https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf">
+  <front>
+    <title>Guidelines for Implementation: DASH-IF Interoperability Points</title>
+    <author>
+      <organization>DASH Industry Forum</organization>
+    </author>
+    <date year="2018" month="November" day="18"/>
+  </front>
+</reference>


### PR DESCRIPTION
For discussion, here is a pull request to add storage of EIA-608 data to Matroska. It's defined in a manner similar to (QuickTime)[https://developer.apple.com/documentation/quicktime-file-format/closed_captioning_sample_data/]. The QuickTime version is a bit vague so I added something to the extra data based on DASH to define the name of the caption channel and its language.