### PR TITLE
extra AUTH48 editorial changes

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -699,7 +699,7 @@ This value is similar in scope to the biCompression value of AVI's `BITMAPINFO` 
     <extension type="libmatroska" cppname="VideoFrameRate"/>
   </element>
   <element name="Colour" path="\Segment\Tracks\TrackEntry\Video\Colour" id="0x55B0" type="master" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Settings describing the colour format.</documentation>
+    <documentation lang="en" purpose="definition">Settings describing the color format.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoColour"/>
     <extension type="stream copy" keep="1"/>
@@ -826,7 +826,7 @@ the value and meanings for TransferCharacteristics are adopted from Table 3 of [
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="Primaries" path="\Segment\Tracks\TrackEntry\Video\Colour\Primaries" id="0x55BB" type="uinteger" minver="4" default="2" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The colour primaries of the video. For clarity,
+    <documentation lang="en" purpose="definition">The color primaries of the video. For clarity,
 the value and meanings for Primaries are adopted from Table 2 of [@!ITU-H.273].</documentation>
     <restriction>
       <enum value="0" label="reserved"/>

--- a/iana.md
+++ b/iana.md
@@ -21,7 +21,7 @@ Matroska files and streams are found in three main forms: audio-video files, aud
 
 Historically, Matroska files and streams have used the following media types with an "x-" prefix.
 For better compatibility, a system **SHOULD** be able to handle both formats.
-Newer systems **SHOULD NOT** use the historic format and use the format that follows the format in [@!RFC6838] instead.
+Newer systems **SHOULD NOT** use the historic format and use the format defined in [@!RFC6838] instead.
 
 IANA has registered three media types per the templates (see [@!RFC6838]) in the following subsections.
 

--- a/index_codec.md
+++ b/index_codec.md
@@ -46,7 +46,7 @@ in a `Block Element` and in an optional `CodecPrivate Element`.
 # Introduction
 
 Matroska is a multimedia container format.
-It stores interleaved and timestamped audio/video/subtitle data using various codecs.
+It stores interleaved and timestamped audiovisual data using various codecs.
 To interpret the codec data, a mapping between the way the data is stored in Matroska and
 how it is understood by such a codec is necessary.
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -52,7 +52,7 @@ but diverges from it significantly because it is based on EBML (Extensible Binar
 a binary derivative of XML. EBML provides significant advantages in terms of future format extensibility,
 without breaking file support in parsers reading the previous versions.
 
-To avoid any misunderstandings, it is essential to clarify exactly what an audio/video container is:
+To avoid any misunderstandings, it is essential to clarify exactly what an audiovisual container is:
 
 - It is NOT a video or audio compression format (codec).
 

--- a/notes.md
+++ b/notes.md
@@ -141,7 +141,7 @@ where:
 
 {newline="false" spacing="normal"}
 Track Number:
-: 8, 16, 24, 32, 40, 48, or 64 bits. An EBML VINT-coded track number.
+: 8, 16, 24, 32, 40, 48, or 56 bits. An EBML VINT-coded track number.
 
 Timestamp:
 : 16 bits. Signed timestamp in Track Ticks.
@@ -210,7 +210,7 @@ where:
 
 {newline="false" spacing="normal"}
 Track Number:
-: 8, 16, 24, 32, 40, 48, or 64 bits. An EBML VINT-coded track number.
+: 8, 16, 24, 32, 40, 48, or 56 bits. An EBML VINT-coded track number.
 
 Timestamp:
 : 16 bits. Signed timestamp in Track Ticks.


### PR DESCRIPTION
On top of #826.

These are changes that need to be pushed in the next AUTH48 cycle. Keeping as draft for now as we may add more changes before the new AUTH48 reply.