### PR TITLE
cleanup Chapter Codec document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ $(OUTPUT_CODEC).md: index_codec.md codec_specs.md subtitles.md block_additional_
 $(OUTPUT_TAGS).md: index_tags.md tagging.md matroska_tagging_registry.md tagging_end.md tags_security.md tags_iana.md tags_iana_names.md rfc_backmatter_tags.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_TAGS)/" > $@
-$(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md rfc_backmatter_chapter_codecs.md
+
+$(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md chapter_codecs_iana.md rfc_backmatter_chapter_codecs.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CHAPTER_CODECS)/" > $@
 
-
-$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.md rfc_backmatter_control.md
+$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.md control_iana.md rfc_backmatter_control.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
 

--- a/Makefile
+++ b/Makefile
@@ -98,11 +98,11 @@ website:
 	jekyll b
 
 clean:
-	$(RM) -f $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).md $(OUTPUT_MATROSKA).xml ebml_matroska_elements4rfc.md matroska_tagging_registry.md
+	$(RM) -f $(OUTPUT_MATROSKA).txt $(OUTPUT_MATROSKA).html $(OUTPUT_MATROSKA).md $(OUTPUT_MATROSKA).xml ebml_matroska_elements4rfc.md matroska_tagging_registry.md  matroska_xsd.xml
 	$(RM) -f $(OUTPUT_CODEC).txt $(OUTPUT_CODEC).html $(OUTPUT_CODEC).md $(OUTPUT_CODEC).xml
 	$(RM) -f $(OUTPUT_TAGS).txt $(OUTPUT_TAGS).html $(OUTPUT_TAGS).md $(OUTPUT_TAGS).xml
 	$(RM) -f $(OUTPUT_CHAPTER_CODECS).txt $(OUTPUT_CHAPTER_CODECS).html $(OUTPUT_CHAPTER_CODECS).md $(OUTPUT_CHAPTER_CODECS).xml
-	$(RM) -f $(OUTPUT_CONTROL).txt $(OUTPUT_CONTROL).html $(OUTPUT_CONTROL).md $(OUTPUT_CONTROL).xml
+	$(RM) -f $(OUTPUT_CONTROL).txt $(OUTPUT_CONTROL).html $(OUTPUT_CONTROL).md $(OUTPUT_CONTROL).xml control_xsd.xml
 	$(RM) -rf _site
 
 .PHONY: clean check website matroska codecs tags all

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,11 @@ $(OUTPUT_TAGS).md: index_tags.md tagging.md matroska_tagging_registry.md tagging
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_TAGS)/" > $@
 
-$(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md chapter_codecs_iana.md rfc_backmatter_chapter_codecs.md
+$(OUTPUT_CHAPTER_CODECS).md: index_chapter_codecs.md chapter_codecs.md chapter_codecs_security.md chapter_codecs_iana.md rfc_backmatter_chapter_codecs.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CHAPTER_CODECS)/" > $@
 
-$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.md control_iana.md rfc_backmatter_control.md
+$(OUTPUT_CONTROL).md: index_control.md control.md control_elements4rfc.md menu.md control_security.md control_iana.md rfc_backmatter_control.md
 	cat $^ | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
 	             -e "s/@BUILD_VERSION@/$(OUTPUT_CONTROL)/" > $@
 

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -54,9 +54,9 @@ until the parent of the chapter is the Edition.
 
 ## Matroska Script (0)
 
-This is the case when `ChapProcessCodecID` = 0\. This is a script language build for
+This is the case when `ChapProcessCodecID` = 0. This is a script language build for
 Matroska purposes. The inspiration comes from [@?ActionScript], [@?ECMAScript] and other similar
-scripting languages. The commands are stored as text commands, in UTF-8\. The syntax is C like,
+scripting languages. The commands are stored as text commands, in UTF-8. The syntax is C like,
 with commands spanned on many lines, each terminating with a ";". You can also include comments
 at the end of lines with "//" or comment many lines using "/* \*/". The scripts are stored
 in ChapProcessData. For the moment ChapProcessPrivate is not used.
@@ -67,7 +67,7 @@ same suggests, it means that, when this command is encountered, the `Matroska Pl
 
 ## DVD menu (1)
 
-This is the case when `ChapProcessCodecID` = 1\. Each level of a chapter corresponds
+This is the case when `ChapProcessCodecID` = 1. Each level of a chapter corresponds
 to a logical level in the DVD system [@?DVD-Video] that is stored in the first octet of the ChapProcessPrivate.
 This DVD hierarchy is as follows:
 

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -18,7 +18,9 @@ For example, if a chapter codec of type "1" in SegmentA needs to link to Segment
 it can store that information as "SegB" in its internal data.
 
 The translation `ChapterTranslate` in SegmentB would use the following elements:
+
 * `ChapterTranslate\ChapterTranslateCodec` = 1
+
 * `ChapterTranslate\ChapterTranslateID` = "SegB"
 
 The `Matroska Player` **MUST** use the `SegmentFamily` to find all Segments that need translation
@@ -42,6 +44,7 @@ When switching from a chapter to another:
 chapter **MUST** be executed, then the leave commands of its parent chapter, etc., until the
 common `Parent Chapter` or `Edition` element. The leave command of that `Parent Chapter` or `Edition` element
 **MUST NOT** be executed.
+
 * the enter commands (`ChapProcessTime`=1) of the `Nested Chapter` of the common `Parent Chapter` or `Edition` element,
 to reach the chapter we switch to, **MUST** be executed, then the enter commands of its `Nested Chapter`
 to reach the chapter we switch to **MUST** be executed, until that chapter is the chapter we switch to.
@@ -107,11 +110,17 @@ If the level specified in `ChapProcessPrivate` is a PGC (0x20), there is an octe
 called the Playback Type, specifying the kind of PGC defined:
 
 *   0x00: entry only/basic PGC
+
 *   0x82: Title+Entry Menu (only found in the Video Manager domain)
+
 *   0x83: Root Menu (only found in the VTSM domain)
+
 *   0x84: Subpicture Menu (only found in the VTSM domain)
+
 *   0x85: Audio Menu (only found in the VTSM domain)
+
 *   0x86: Angle Menu (only found in the VTSM domain)
+
 *   0x87: Chapter Menu (only found in the VTSM domain)
 
 The next 4 following octets correspond to the `User Operation flags`

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -55,7 +55,7 @@ the `Matroska Player` **MUST** execute its leaved commands, then the leave comma
 until the parent of the chapter is the Edition.
 
 
-## Matroska Script (0)
+## Matroska Script
 
 This is the case when `ChapProcessCodecID` = 0. This is a script language build for
 Matroska purposes. The inspiration comes from [@?ActionScript], [@?ECMAScript] and other similar
@@ -68,7 +68,7 @@ The one and only command existing for the moment is `GotoAndPlay( ChapterUID );`
 same suggests, it means that, when this command is encountered, the `Matroska Player`
 **SHOULD** jump to the `Chapter` specified by the UID and play it.
 
-## DVD menu (1)
+## DVD Menu
 
 This is the case when `ChapProcessCodecID` = 1. Each level of a chapter corresponds
 to a logical level in the DVD system [@?DVD-Video] that is stored in the first octet of the `ChapProcessPrivate`.

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -55,7 +55,7 @@ until the parent of the chapter is the Edition.
 ## Matroska Script (0)
 
 This is the case when `ChapProcessCodecID` = 0\. This is a script language build for
-Matroska purposes. The inspiration comes from ActionScript, javascript and other similar
+Matroska purposes. The inspiration comes from [@?ActionScript], [@?ECMAScript] and other similar
 scripting languages. The commands are stored as text commands, in UTF-8\. The syntax is C like,
 with commands spanned on many lines, each terminating with a ";". You can also include comments
 at the end of lines with "//" or comment many lines using "/* \*/". The scripts are stored

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -64,7 +64,7 @@ until the parent of the chapter is the Edition.
 This is the case when `ChapProcessCodecID` = 0. This is a script language build for
 Matroska purposes. The inspiration comes from [@?ActionScript], [@?ECMAScript] and other similar
 scripting languages. The commands are stored as text commands, in UTF-8. The syntax is C like,
-with commands spanned on many lines, each terminating with a ";". You can also include comments
+with commands spanned on many lines, each terminating with a semicolon ";". You can also include comments
 at the end of lines with "//" or comment many lines using "/* \*/". The scripts are stored
 in `ChapProcessData`. For the moment `ChapProcessPrivate` is not used.
 

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -70,7 +70,7 @@ in `ChapProcessData`. For the moment `ChapProcessPrivate` is not used.
 
 The one and only command existing for the moment is `GotoAndPlay( ChapterUID );`. As the
 same suggests, it means that, when this command is encountered, the `Matroska Player`
-**SHOULD** jump to the `Chapter` specified by the UID and play it.
+**SHOULD** jump to the `Chapter` specified by the UID and play it, as long as this `Chapter` exists.
 
 ## DVD Menu
 

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -59,7 +59,7 @@ Matroska purposes. The inspiration comes from [@?ActionScript], [@?ECMAScript] a
 scripting languages. The commands are stored as text commands, in UTF-8. The syntax is C like,
 with commands spanned on many lines, each terminating with a ";". You can also include comments
 at the end of lines with "//" or comment many lines using "/* \*/". The scripts are stored
-in ChapProcessData. For the moment ChapProcessPrivate is not used.
+in `ChapProcessData`. For the moment `ChapProcessPrivate` is not used.
 
 The one and only command existing for the moment is `GotoAndPlay( ChapterUID );`. As the
 same suggests, it means that, when this command is encountered, the `Matroska Player`
@@ -68,7 +68,7 @@ same suggests, it means that, when this command is encountered, the `Matroska Pl
 ## DVD menu (1)
 
 This is the case when `ChapProcessCodecID` = 1. Each level of a chapter corresponds
-to a logical level in the DVD system [@?DVD-Video] that is stored in the first octet of the ChapProcessPrivate.
+to a logical level in the DVD system [@?DVD-Video] that is stored in the first octet of the `ChapProcessPrivate`.
 This DVD hierarchy is as follows:
 
 | ChapProcessPrivate | DVD Name | Hierarchy                                           | Commands Possible | Comment                                   |
@@ -91,7 +91,7 @@ This field uses 2 octets as follows:
 For instance, the menu part from VTS_01_0.VOB would be coded [1,0] and the content
 part from VTS_02_3.VOB would be [2,1]. The VMG is always [0,0]
 
-The following octets of ChapProcessPrivate are as follows:
+The following octets of `ChapProcessPrivate` are as follows:
 
 | Octet 1 | DVD Name | Following Octets                                                                             |
 |---------|----------|----------------------------------------------------------------------------------------------|
@@ -103,7 +103,7 @@ The following octets of ChapProcessPrivate are as follows:
 | 0x10    | PTT      | PTT-chapter number (1)                                                                       |
 | 0x08    | CN       | Cell number [VOB ID(2)][Cell ID(1)][Angle Num(1)]                                            |
 
-If the level specified in ChapProcessPrivate is a PGC (0x20), there is an octet
+If the level specified in `ChapProcessPrivate` is a PGC (0x20), there is an octet
 called the Playback Type, specifying the kind of PGC defined:
 
 *   0x00: entry only/basic PGC
@@ -117,7 +117,7 @@ called the Playback Type, specifying the kind of PGC defined:
 The next 4 following octets correspond to the `User Operation flags`
 in the standard PGC. When a bit is set, the command **SHOULD** be disabled.
 
-ChapProcessData contains the pre/post/cell commands in binary format as there are stored on a DVD.
+`ChapProcessData` contains the pre/post/cell commands in binary format as there are stored on a DVD.
 There is just an octet preceding these data to specify the number of commands in the element.
 As follows: [# of commands(1)][command 1 (8)][command 2 (8)][command 3 (8)].
 

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -6,6 +6,10 @@ Some `ChapProcess` elements hold commands to execute when entering/leaving a cha
 
 When chapter codecs are used the `EditionFlagOrdered` of the edition they belong to **MUST** be set.
 
+Each `ChapProcessCodecID` value in an edition **SHOULD** have a single interpreter for the whole `EditionEntry`,
+if that `ChapProcessCodecID` value is supported by the `Matroska Player`.
+This is necessary to be able to read/write global variables that can be used between chapters.
+
 ## Segment Linking
 
 Chapter Codecs can reference another `Segment` and jump to that `Segment`.

--- a/chapter_codecs.md
+++ b/chapter_codecs.md
@@ -109,19 +109,19 @@ The following octets of `ChapProcessPrivate` are as follows:
 If the level specified in `ChapProcessPrivate` is a PGC (0x20), there is an octet
 called the Playback Type, specifying the kind of PGC defined:
 
-*   0x00: entry only/basic PGC
+*   `0x00`: entry only/basic PGC
 
-*   0x82: Title+Entry Menu (only found in the Video Manager domain)
+*   `0x82`: Title+Entry Menu (only found in the Video Manager domain)
 
-*   0x83: Root Menu (only found in the VTSM domain)
+*   `0x83`: Root Menu (only found in the VTSM domain)
 
-*   0x84: Subpicture Menu (only found in the VTSM domain)
+*   `0x84`: Subpicture Menu (only found in the VTSM domain)
 
-*   0x85: Audio Menu (only found in the VTSM domain)
+*   `0x85`: Audio Menu (only found in the VTSM domain)
 
-*   0x86: Angle Menu (only found in the VTSM domain)
+*   `0x86`: Angle Menu (only found in the VTSM domain)
 
-*   0x87: Chapter Menu (only found in the VTSM domain)
+*   `0x87`: Chapter Menu (only found in the VTSM domain)
 
 The next 4 following octets correspond to the `User Operation flags`
 in the standard PGC. When a bit is set, the command **SHOULD** be disabled.

--- a/chapter_codecs_iana.md
+++ b/chapter_codecs_iana.md
@@ -1,4 +1,7 @@
 # IANA Considerations
 
-To be determined.
+The Chapter Codec ID values set in `ChapProcessCodecID` use the Matroska Chapter Codec IDs Registry
+defined in [@!Matroska].
+
+The initial values 0 and 1 are defined in (#matroska-script) and (#dvd-menu) respectively.
 

--- a/chapter_codecs_iana.md
+++ b/chapter_codecs_iana.md
@@ -1,0 +1,4 @@
+# IANA Considerations
+
+To be determined.
+

--- a/chapter_codecs_security.md
+++ b/chapter_codecs_security.md
@@ -1,0 +1,5 @@
+# Security Considerations
+
+`Tag` values can be either strings or binary blobs. This document inherits security
+considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+

--- a/control_iana.md
+++ b/control_iana.md
@@ -1,0 +1,4 @@
+# IANA Considerations
+
+To be determined.
+

--- a/control_security.md
+++ b/control_security.md
@@ -1,0 +1,4 @@
+# Security Considerations
+
+This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+

--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -44,7 +44,12 @@ This document defines common Matroska Chapter Codecs, the basic Matroska Script 
 
 # Introduction
 
-*TODO*
+The [@!Matroska] container can be expanded with Matroska Chapter Codecs. They define a set of instructions
+that the `Matroska Player` should execute when entering, leaving or during playback of a Chapter.
+This allows extra features not provided by the classical linear playback of files.
+
+The Matroska Chapter Codecs codec is extensible. So any new codec can be created
+and support added in players.
 
 # Status of This Document
 

--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -57,10 +57,6 @@ It uses basic elements and concept already defined in the Matroska specification
 `Tag` values can be either strings or binary blobs. This document inherits security
 considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
 
-# IANA Considerations
-
-To be determined.
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",

--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -52,11 +52,6 @@ This document is a work-in-progress specification defining the Matroska file for
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
 It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
 
-# Security Considerations
-
-`Tag` values can be either strings or binary blobs. This document inherits security
-considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",

--- a/index_control.md
+++ b/index_control.md
@@ -54,10 +54,6 @@ It uses basic elements and concept already defined in the Matroska specification
 
 This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
 
-# IANA Considerations
-
-To be determined.
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",

--- a/index_control.md
+++ b/index_control.md
@@ -50,10 +50,6 @@ This document is a work-in-progress specification defining the Matroska file for
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
 It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
 
-# Security Considerations
-
-This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
-
 # Notation and Conventions
 
 The key words "**MUST**", "**MUST NOT**",

--- a/rfc_backmatter_chapter_codecs.md
+++ b/rfc_backmatter_chapter_codecs.md
@@ -45,13 +45,14 @@
     <date month="November" year="1995" />
   </front>
 </reference>
+
 <reference anchor="Matroska">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="May" day="1" year="2022"/>
+    <date month="April" day="24" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-10"/>
+  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
 </reference>

--- a/rfc_backmatter_chapter_codecs.md
+++ b/rfc_backmatter_chapter_codecs.md
@@ -1,6 +1,25 @@
 
 {backmatter}
 
+<reference anchor="ActionScript" target="https://en.wikipedia.org/wiki/ActionScript">
+  <front>
+    <title>ActionScript</title>
+    <author>
+      <organization>Wikipedia</organization>
+    </author>
+  </front>
+</reference>
+
+<reference anchor="ECMAScript" target="https://262.ecma-international.org/14.0/">
+  <front>
+    <title>ECMA-262 14th Edition, June 2022. ECMAScript 2023 language specification</title>
+    <author>
+      <organization>Ecma International</organization>
+    </author>
+    <date month="June" year="2023" />
+  </front>
+</reference>
+
 <reference anchor="DVD-Info" target="http://dvd.sourceforge.net/dvdinfo/">
   <front>
     <title>DVD-Video Information</title>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -68,9 +68,9 @@
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="May" day="1" year="2022"/>
+    <date month="April" day="24" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-10"/>
+  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
 </reference>
 
 <reference anchor="ST12" target="http://ieeexplore.ieee.org/document/7291029/">

--- a/rfc_backmatter_control.md
+++ b/rfc_backmatter_control.md
@@ -10,13 +10,14 @@
     <date month="November" year="1995" />
   </front>
 </reference>
+
 <reference anchor="Matroska">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="May" day="1" year="2022"/>
+    <date month="April" day="24" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-10"/>
+  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
 </reference>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -77,9 +77,9 @@
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="October" day="8" year="2023"/>
+    <date month="April" day="24" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-20"/>
+  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
 </reference>
 
 <reference anchor="MovieDB" target="https://developers.themoviedb.org/3/movies/get-movie-details">


### PR DESCRIPTION
Some clarifications are also added about the uniqueness of the interpreter for the whole duration of an Edition. That allows internal variables to be shared between chapters. This is already the case in VLC for the DVD Menu (which wouldn't work otherwise).

The control track document is also updated the same way with regards to formatting.