### PR TITLE
Use RFC9559 to reference the main Matroska document

### DIFF
--- a/chapter_codecs_iana.md
+++ b/chapter_codecs_iana.md
@@ -1,7 +1,7 @@
 # IANA Considerations
 
 The Chapter Codec ID values set in `ChapProcessCodecID` use the Matroska Chapter Codec IDs Registry
-defined in [@!Matroska].
+defined in [@!RFC9559].
 
 The initial values 0 and 1 are defined in (#matroska-script) and (#dvd-menu) respectively.
 

--- a/chapter_codecs_security.md
+++ b/chapter_codecs_security.md
@@ -1,5 +1,5 @@
 # Security Considerations
 
 `Tag` values can be either strings or binary blobs. This document inherits security
-considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+considerations from the EBML [@!RFC8794] and Matroska [@!RFC9559] documents.
 

--- a/codec_security.md
+++ b/codec_security.md
@@ -1,4 +1,4 @@
 # Security Considerations
 
-This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!RFC9559] documents.
 

--- a/control_security.md
+++ b/control_security.md
@@ -1,4 +1,4 @@
 # Security Considerations
 
-This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+This document inherits security considerations from the EBML [@!RFC8794] and Matroska [@!RFC9559] documents.
 

--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -44,7 +44,7 @@ This document defines common Matroska Chapter Codecs, the basic Matroska Script 
 
 # Introduction
 
-The [@!Matroska] container can be expanded with Matroska Chapter Codecs. They define a set of instructions
+The [@!RFC9559] container can be expanded with Matroska Chapter Codecs. They define a set of instructions
 that the `Matroska Player` should execute when entering, leaving or during playback of a Chapter.
 This allows extra features not provided by the classical linear playback of files.
 
@@ -55,7 +55,7 @@ and support added in players.
 
 This document is a work-in-progress specification defining the Matroska file format as part
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
-It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
+It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!RFC9559].
 
 # Notation and Conventions
 

--- a/index_codec.md
+++ b/index_codec.md
@@ -56,7 +56,7 @@ This document intends to define this mapping for many commonly used codecs in Ma
 
 This document is a work-in-progress specification defining the Matroska file format as part
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
-It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
+It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!RFC9559].
 
 # Notation and Conventions
 

--- a/index_control.md
+++ b/index_control.md
@@ -48,7 +48,7 @@ This document defines the Control Track usage found in the Matroska container.
 
 This document is a work-in-progress specification defining the Matroska file format as part
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
-It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
+It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!RFC9559].
 
 # Notation and Conventions
 

--- a/index_tags.md
+++ b/index_tags.md
@@ -44,7 +44,7 @@ This document defines the Matroska tags, namely the tag names and their respecti
 
 # Introduction
 
-Matroska is a multimedia container format defined in [@!Matroska]. It can store timestamped multimedia data
+Matroska is a multimedia container format defined in [@!RFC9559]. It can store timestamped multimedia data
 but also chapters and tags. The `Tag` elements add important metadata to identify and classify the information found
 in a Matroska `Segment`. It can tag a whole `Segment`, separate `Tracks` elements, individual `Chapter` elements or `Attachments` elements.
 
@@ -55,7 +55,7 @@ set of values for interoperability. This document intends to define a set of com
 
 This document is a work-in-progress specification defining the Matroska file format as part
 of the [IETF Cellar working group](https://datatracker.ietf.org/wg/cellar/charter/).
-It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!Matroska].
+It uses basic elements and concept already defined in the Matroska specifications defined by this workgroup [@!RFC9559].
 
 # Notation and Conventions
 

--- a/rfc_backmatter_chapter_codecs.md
+++ b/rfc_backmatter_chapter_codecs.md
@@ -46,13 +46,13 @@
   </front>
 </reference>
 
-<reference anchor="Matroska">
+<reference anchor="RFC9559">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="April" day="24" year="2024"/>
+    <date month="October" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
+  <seriesInfo name="RFC" value="9559"></seriesInfo>
 </reference>

--- a/rfc_backmatter_chapter_codecs.md
+++ b/rfc_backmatter_chapter_codecs.md
@@ -45,14 +45,3 @@
     <date month="November" year="1995" />
   </front>
 </reference>
-
-<reference anchor="RFC9559">
-  <front>
-    <title>Media Container Specifications</title>
-    <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
-    <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
-    <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="October" year="2024"/>
-  </front>
-  <seriesInfo name="RFC" value="9559"></seriesInfo>
-</reference>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -62,17 +62,6 @@
   <seriesInfo name="ISO" value="Standard 14496" />
 </reference>
 
-<reference anchor="RFC9559">
-  <front>
-    <title>Media Container Specifications</title>
-    <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
-    <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
-    <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="October" year="2024"/>
-  </front>
-  <seriesInfo name="RFC" value="9559"></seriesInfo>
-</reference>
-
 <reference anchor="ST12" target="http://ieeexplore.ieee.org/document/7291029/">
   <front>
     <title>Time and Control Code</title>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -62,15 +62,15 @@
   <seriesInfo name="ISO" value="Standard 14496" />
 </reference>
 
-<reference anchor="Matroska">
+<reference anchor="RFC9559">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="April" day="24" year="2024"/>
+    <date month="October" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
+  <seriesInfo name="RFC" value="9559"></seriesInfo>
 </reference>
 
 <reference anchor="ST12" target="http://ieeexplore.ieee.org/document/7291029/">

--- a/rfc_backmatter_control.md
+++ b/rfc_backmatter_control.md
@@ -11,13 +11,13 @@
   </front>
 </reference>
 
-<reference anchor="Matroska">
+<reference anchor="RFC9559">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="April" day="24" year="2024"/>
+    <date month="October" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
+  <seriesInfo name="RFC" value="9559"></seriesInfo>
 </reference>

--- a/rfc_backmatter_control.md
+++ b/rfc_backmatter_control.md
@@ -10,14 +10,3 @@
     <date month="November" year="1995" />
   </front>
 </reference>
-
-<reference anchor="RFC9559">
-  <front>
-    <title>Media Container Specifications</title>
-    <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
-    <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
-    <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="October" year="2024"/>
-  </front>
-  <seriesInfo name="RFC" value="9559"></seriesInfo>
-</reference>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -71,15 +71,15 @@
   </front>
 </reference>
 
-<reference anchor="Matroska">
+<reference anchor="RFC9559">
   <front>
     <title>Media Container Specifications</title>
     <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
     <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
     <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="April" day="24" year="2024"/>
+    <date month="October" year="2024"/>
   </front>
-  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-21"/>
+  <seriesInfo name="RFC" value="9559"></seriesInfo>
 </reference>
 
 <reference anchor="MovieDB" target="https://developers.themoviedb.org/3/movies/get-movie-details">

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -71,17 +71,6 @@
   </front>
 </reference>
 
-<reference anchor="RFC9559">
-  <front>
-    <title>Media Container Specifications</title>
-    <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
-    <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
-    <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
-    <date month="October" year="2024"/>
-  </front>
-  <seriesInfo name="RFC" value="9559"></seriesInfo>
-</reference>
-
 <reference anchor="MovieDB" target="https://developers.themoviedb.org/3/movies/get-movie-details">
   <front>
     <title>The Movie Database API</title>

--- a/tags_security.md
+++ b/tags_security.md
@@ -1,5 +1,5 @@
 # Security Considerations
 
 `Tag` values can be either strings or binary blobs. This document inherits security
-considerations from the EBML [@!RFC8794] and Matroska [@!Matroska] documents.
+considerations from the EBML [@!RFC8794] and Matroska [@!RFC9559] documents.
 


### PR DESCRIPTION
It's a draft for now until it's published and we can pull the XML reference from the IETF website.

We can merge when https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9559.xml is available.