### PR TITLE
[AUTH48] integrate the remaining changes from RFC9559

### DIFF
--- a/attachments.md
+++ b/attachments.md
@@ -1,34 +1,42 @@
 # Attachments
 
-Matroska supports storage of related files and data in the `Attachments` element
-(a `Top-Level Element`). `Attachments` elements can be used to store related cover art,
-font files, transcripts, reports, error recovery files, pictures, text-based annotations,
-copies of specifications, or other ancillary files related to the `Segment`.
+Matroska supports storage of related files and data in the
+`Attachments` element (a `Top-Level Element`).
+`Attachments` elements can be used to store related
+cover art, font files, transcripts, reports, error recovery files, pictures,
+text-based annotations, copies of specifications, or other ancillary files
+related to the `Segment`.
 
 `Matroska Readers` **MUST NOT** execute files stored as `Attachments` elements.
 
 ## Cover Art
 
-This section defines a set of guidelines for the storage of cover art in Matroska files.
-A `Matroska Reader` **MAY** use embedded cover art to display a representational
-still-image depiction of the multimedia contents of the Matroska file.
+This section defines a set of guidelines for the storage of cover art in
+Matroska files.  A `Matroska Reader` **MAY** use embedded
+cover art to display a representational still-image depiction of the
+multimedia contents of the Matroska file.
 
 Only [@?JPEG] and PNG [@?RFC2083] image formats **SHOULD** be used for cover art pictures.
 
 There can be two different covers for a movie/album: a portrait style (e.g., a DVD case)
 and a landscape style (e.g., a wide banner ad).
 
-There can be two versions of the same cover: the `normal cover` and the `small cover`.
-The dimension of the `normal cover` **SHOULD** be 600 pixels on the smallest side (e.g.,
-960x600 for landscape, 600x800 for portrait, or 600x600 for square). The dimension of
-the `small cover` **SHOULD** be 120 pixels on the smallest side (e.g., 192x120 or 120x160).
+There can be two versions of the same cover: the `normal cover` and
+the `small cover`.  The dimension of the `normal cover`
+**SHOULD** be 600 pixels on the smallest side (e.g., 960x600 for
+landscape, 600x800 for portrait, or 600x600 for square). The dimension of the
+`small cover` **SHOULD** be 120 pixels on the smallest side
+(e.g., 192x120 or 120x160).
 
-Versions of cover art can be differentiated by the filename, which is stored in the
-`FileName` element. The default filename of the `normal cover` in square or portrait mode
-is `cover.(jpg|png)`. When stored, the `normal cover` **SHOULD** be the first `Attachments` element in
-storage order. The `small cover` **SHOULD** be prefixed with "small_", such as
-`small_cover.(jpg|png)`. The landscape variant **SHOULD** be suffixed with "\_land",
-such as `cover_land.(jpg|png)`. The filenames are case-sensitive.
+Versions of cover art can be differentiated by the filename, which is
+stored in the `FileName` element. The default filename of the
+`normal cover` in square or portrait mode is
+`cover.(jpg|png)`. When stored, the `normal cover`
+**SHOULD** be the first `Attachments` element in storage
+order. The `small cover` **SHOULD** be prefixed with
+"small_", such as `small_cover.(jpg|png)`. The landscape variant
+**SHOULD** be suffixed with "\_land", such as
+`cover_land.(jpg|png)`. The filenames are case-sensitive.
 
 The following table provides examples of file names for cover art in `Attachments`.
 
@@ -47,13 +55,12 @@ to display an associated subtitle track. This allows the presentation of a Matro
 consistent in various environments where the needed fonts might not be available on the local system.
 
 Depending on the font format in question, each font file can contain multiple font variants.
-Each font variant has a name that will be referred to as Font Name from now on.
+Each font variant has a name that  will be referred to as Font Name from now on.
 This Font Name can be different from the Attachment's `FileName`, even when disregarding the extension.
 In order to select a font for display, a `Matroska Player` **SHOULD** consider both the Font Name
 and the base name of the Attachment's `FileName`, preferring the former when there are multiple matches.
 
-Subtitle codecs, such as SubStation Alpha (SSA) and Advanced SubStation Alpha (ASS), usually refer to a font by its Font Name, not
-by its filename.
+Subtitle codecs, such as SubStation Alpha (SSA) and Advanced SubStation Alpha (ASS), usually refer to a font by its Font Name, not by its filename.
 If none of the Attachments are a match for the Font Name, the `Matroska Player` **SHOULD**
 attempt to find a system font whose Font Name matches the one used in the subtitle track.
 

--- a/chapters.md
+++ b/chapters.md
@@ -49,22 +49,28 @@ Table: Default Edition, With Default{#defaultEditionWithDefault}
 
 ### EditionFlagOrdered
 
-The `EditionFlagOrdered` flag is a significant feature, as it enables an `Edition`
-of `Ordered Chapters` that defines and arranges a virtual timeline rather than simply
-labeling points within the timeline. For example, with `Editions` of `Ordered Chapters`,
-a single `Matroska file` can present multiple edits of a film without duplicating content.
-Alternatively, if a videotape is digitized in full, one `Ordered Edition` could present
-the full content (including colorbars, countdown, slate, a feature presentation, and
-black frames), while another `Edition` of `Ordered Chapters` can use `Chapters` that only
-mark the intended presentation with the colorbars and other ancillary visual information
-excluded. If an `Edition` of `Ordered Chapters` is enabled, then the `Matroska Player` **MUST**
-play those `Chapters` in their stored order from the timestamp marked in the
-`ChapterTimeStart` element to the timestamp marked in to `ChapterTimeEnd` element.
+The `EditionFlagOrdered` flag is a significant feature, as it
+enables an `Edition` of `Ordered Chapters` that defines and
+arranges a virtual timeline rather than simply labeling points within the
+timeline. For example, with `Editions` of `Ordered Chapters`, a
+single `Matroska file` can present multiple edits of a film without
+duplicating content.  Alternatively, if a videotape is digitized in full, one
+`Ordered Edition` could present the full content (including colorbars,
+countdown, slate, a feature presentation, and black frames), while another
+`Edition` of `Ordered Chapters` can use `Chapters` that
+only mark the intended presentation with the colorbars and other ancillary
+visual information excluded. If an `Edition` of `Ordered Chapters`
+is enabled, then the `Matroska Player`
+**MUST** play those `Chapters` in their stored order from
+the timestamp marked in the `ChapterTimeStart` element to the timestamp
+marked in to `ChapterTimeEnd` element.
 
-If the `EditionFlagOrdered` flag evaluates to "0", `Simple Chapters` are used and
-only the `ChapterTimeStart` of a `Chapter` is used as a chapter mark to jump to the
-predefined point in the timeline. With `Simple Chapters`, a `Matroska Player` **MUST**
-ignore certain elements inside a `Chapters` element. In that case, these elements are informational only.
+If the `EditionFlagOrdered` flag evaluates to "0", `Simple Chapters`
+are used and only the `ChapterTimeStart` of a
+`Chapter` is used as a chapter mark to jump to the predefined point in
+the timeline. With `Simple Chapters`, a `Matroska Player`
+**MUST** ignore certain elements inside a `Chapters`
+element. In that case, these elements are informational only.
 
 The following list shows the different `Chapters` elements only found in `Ordered Chapters`.
 
@@ -103,11 +109,13 @@ The `ChapterAtom` is also called a `Chapter`.
 For `Simple Chapters`, this is the position of the chapter markers in the timeline.
 
 ### ChapterTimeEnd
-`ChapterTimeEnd` is the timestamp of the end of `Chapter` with nanosecond accuracy and is not scaled by `TimestampScale`.
-The timestamp defined by the `ChapterTimeEnd` is not part of the `Chapter`.
-A `Matroska Player` calculates the duration of this `Chapter` using the difference between the
-`ChapterTimeEnd` and `ChapterTimeStart`.
-The end timestamp **MUST** be greater than or equal to the start timestamp.
+`ChapterTimeEnd` is the timestamp of the end of `Chapter`
+with nanosecond accuracy and is not scaled by `TimestampScale`.  The
+timestamp defined by the `ChapterTimeEnd` is not part of the
+`Chapter`.  A `Matroska Player` calculates the duration of this
+`Chapter` using the difference between the `ChapterTimeEnd` and
+`ChapterTimeStart`.  The end timestamp **MUST** be greater
+than or equal to the start timestamp.
 
 When the `ChapterTimeEnd` timestamp is equal to the `ChapterTimeStart` timestamp,
 the timestamp is included in the `Chapter`. It can be useful to put markers in
@@ -145,10 +153,10 @@ The `ChapterTimeEnd` **SHOULD NOT** be set in `Parent Chapters` and **MUST** be 
 
 ### ChapterFlagHidden
 
-Each `Chapter`'s
-`ChapterFlagHidden` flag works independently of `Parent Chapters`.
-A `Nested Chapter` with a `ChapterFlagHidden` flag that evaluates to "0" remains visible in the user interface even if the
-`Parent Chapter`'s `ChapterFlagHidden` flag is set to "1".
+Each `Chapter`'s `ChapterFlagHidden` flag works independently of `Parent Chapters`.
+A `Nested Chapter` with a `ChapterFlagHidden` flag that evaluates to
+"0" remains visible in the user interface even if the `Parent Chapter`'s
+`ChapterFlagHidden` flag is set to "1".
 
 Chapter + Nested Chapter | ChapterFlagHidden | visible
 :------------------------|:------------------|:-------
@@ -165,13 +173,12 @@ Table: ChapterFlagHidden Nested Visibility{#ChapterFlagHiddenNested}
 The menu features are handled like a `chapter codec`. That means each codec has a type,
 some private data, and some data in the chapters.
 
-The type of the menu system is defined by the `ChapProcessCodecID` parameter. For now,
-only two values are supported: 0 (Matroska Script) and 1 (menu borrowed from the DVD [@?DVD-Video]).
+The type of the menu system is defined by the `ChapProcessCodecID` parameter.
+For now, only two values are supported: 0 (Matroska Script) and 1 (menu borrowed from the DVD [@?DVD-Video]).
 The private data stored in `ChapProcessPrivate` and
 `ChapProcessData` depends on the `ChapProcessCodecID` value.
 
-The menu system, as well as Chapter Codecs in general, can perform actions on the `Matroska Player`,
-such as jumping to another `Chapter` or `Edition`, selecting different tracks, and possibly more.
+The menu system, as well as Chapter Codecs in general, can perform actions on the `Matroska Player`, such as jumping to another `Chapter` or `Edition`, selecting different tracks, and possibly more.
 The scope of all the possibilities of Chapter Codecs is not covered in this document, as it
 depends on the Chapter Codec features and its integration in a `Matroska Player`.
 

--- a/cues.md
+++ b/cues.md
@@ -1,13 +1,16 @@
 # Cues
 
-The `Cues` element provides an index of certain `Cluster` elements to allow for optimized
-seeking to absolute timestamps within the `Segment`. The `Cues` element contains one or
-many `CuePoint` elements, each of which **MUST** reference an absolute timestamp (via the
-`CueTime` element), a `Track` (via the `CueTrack` element), and a `Segment Position`
-(via the `CueClusterPosition` element). Additional non-mandated elements are part of
-the `CuePoint` element, such as `CueDuration`, `CueRelativePosition`, `CueCodecState`,
-and others that provide any `Matroska Reader` with additional information to use in
-the optimization of seeking performance.
+The `Cues` element provides an index of certain `Cluster`
+elements to allow for optimized seeking to absolute timestamps within the
+`Segment`. The `Cues` element contains one or many
+`CuePoint` elements, each of which **MUST** reference an
+absolute timestamp (via the `CueTime` element), a `Track` (via
+the `CueTrack` element), and a `Segment Position` (via the
+`CueClusterPosition` element). Additional non-mandated elements are
+part of the `CuePoint` element, such as `CueDuration`,
+`CueRelativePosition`, `CueCodecState`, and others that provide
+any `Matroska Reader` with additional information to use in the
+optimization of seeking performance.
 
 ## Recommendations
 

--- a/diagram.md
+++ b/diagram.md
@@ -68,7 +68,7 @@ The `SeekHead` element (also known as `MetaSeek`) contains an index of `Top-Leve
 locations within the `Segment`. Use of the `SeekHead` element is **RECOMMENDED**. Without a `SeekHead` element,
 a Matroska parser would have to search the entire file to find all of the other `Top-Level Elements`.
 This is due to Matroska's flexible ordering requirements; for instance, it is acceptable for
-the `Chapters` element to be stored after the `Cluster ` element(s).
+the `Chapters` element to be stored after the `Cluster` element(s).
 
 ```
 +--------------------------------+

--- a/diagram.md
+++ b/diagram.md
@@ -64,11 +64,14 @@ The Matroska `EBML Schema` defines eight `Top-Level Elements`:
 
 - `Tags` ((#tags))
 
-The `SeekHead` element (also known as `MetaSeek`) contains an index of `Top-Level Elements`
-locations within the `Segment`. Use of the `SeekHead` element is **RECOMMENDED**. Without a `SeekHead` element,
-a Matroska parser would have to search the entire file to find all of the other `Top-Level Elements`.
-This is due to Matroska's flexible ordering requirements; for instance, it is acceptable for
-the `Chapters` element to be stored after the `Cluster` element(s).
+The `SeekHead` element (also known as `MetaSeek`) contains an
+index of `Top-Level Elements` locations within the
+`Segment`. Use of the `SeekHead` element is
+**RECOMMENDED**. Without a `SeekHead` element, a Matroska
+parser would have to search the entire file to find all of the other
+`Top-Level Elements`.  This is due to Matroska's flexible ordering
+requirements; for instance, it is acceptable for the `Chapters` element
+to be stored after the `Cluster` element(s).
 
 ```
 +--------------------------------+
@@ -258,8 +261,7 @@ Figure: Representation of the `Block` Element Structure
 
 Each `Cluster` **MUST** contain exactly one `Timestamp` element. The `Timestamp` element value **MUST**
 be stored once per `Cluster`. The `Timestamp` element in the `Cluster` is relative to the entire `Segment`.
-The `Timestamp` element **SHOULD** be the first element in the `Cluster` it belongs to
-or the second element if that `Cluster` contains a `CRC-32` element ((#crc-32)).
+The `Timestamp` element **SHOULD** be the first element in the `Cluster` it belongs to or the second element if that `Cluster` contains a `CRC-32` element ((#crc-32)).
 
 Additionally, the `Block` contains an offset that, when added to the `Cluster`'s `Timestamp` element value,
 yields the `Block`'s effective timestamp. Therefore, the timestamp in the `Block` itself is relative to
@@ -273,8 +275,7 @@ the `Timestamp` of the necessary `Block` is used. Because there can be as many `
 as necessary for a `Block`, it allows for some extremely complex referencing.
 
 The `Cues` element is used to seek when playing back a file by providing a temporal index
-for some of the `Tracks`. It is similar to the `SeekHead` element but is used for seeking to
-a specific time when playing back the file. It is possible to seek without this element,
+for some of the `Tracks`. It is similar to the `SeekHead` element but is used for seeking to a specific time when playing back the file. It is possible to seek without this element,
 but it is much more difficult because a `Matroska Reader` would have to "hunt and peck"
 through the file to look for the correct timestamp.
 
@@ -320,7 +321,9 @@ The `Tags` element contains metadata that describes the `Segment` and potentiall
 its `Tracks`, `Chapters`, and `Attachments`. Each `Track` or `Chapter` that those tags
 applies to has its UID listed in the `Tags`. The `Tags` contain all extra information about
 the file: scriptwriters, singers, actors, directors, titles, edition, price, dates, genre, comments,
-etc. `Tags` can contain their values in multiple languages. For example, a movie's "TITLE" tag value might contain both the original English title as well as the German title.
+etc. `Tags` can contain their values in multiple languages.
+For example, a movie's "TITLE" tag value might contain both the original
+English title as well as the German title.
 
 ```
 +-------------------------------------------+

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -39,9 +39,12 @@ The value of the UID **MUST** contain at least one bit set to 1.</documentation>
   <element name="PrevUUID" path="\Segment\Info\PrevUUID" id="0x3CB923" type="binary" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">An ID that identifies the previous `Segment` of a `Linked Segment`.</documentation>
     <documentation lang="en" purpose="usage notes">If the `Segment` is a part of a `Linked Segment` that uses
-Hard Linking ((#hard-linking)),
-then either the `PrevUUID` or the `NextUUID` element is **REQUIRED**. If a `Segment` contains a `PrevUUID` but not a `NextUUID`,
-then it **MAY** be considered as the last `Segment` of the `Linked Segment`. The `PrevUUID` **MUST NOT** be equal to the `SegmentUUID`.</documentation>
+Hard Linking ((#hard-linking)), then either the
+`PrevUUID` or the `NextUUID` element is
+**REQUIRED**. If a `Segment` contains a `PrevUUID`
+but not a `NextUUID`, then it **MAY** be considered as the
+last `Segment` of the `Linked Segment`. The `PrevUUID`
+**MUST NOT** be equal to the `SegmentUUID`.</documentation>
     <extension type="libmatroska" cppname="PrevUID"/>
   </element>
   <element name="PrevFilename" path="\Segment\Info\PrevFilename" id="0x3C83AB" type="utf-8" maxOccurs="1">
@@ -52,8 +55,7 @@ but `PrevUUID` **SHOULD** be considered authoritative for identifying the previo
   <element name="NextUUID" path="\Segment\Info\NextUUID" id="0x3EB923" type="binary" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">An ID that identifies the next `Segment` of a `Linked Segment`.</documentation>
     <documentation lang="en" purpose="usage notes">If the `Segment` is a part of a `Linked Segment` that uses Hard Linking ((#hard-linking)),
-then either the `PrevUUID` or the `NextUUID` element is **REQUIRED**. If a `Segment` contains a `NextUUID` but not a `PrevUUID`,
-then it **MAY** be considered as the first `Segment` of the `Linked Segment`. The `NextUUID` **MUST NOT** be equal to the `SegmentUUID`.</documentation>
+then either the `PrevUUID` or the `NextUUID` element is **REQUIRED**. If a `Segment` contains a `NextUUID` but not a `PrevUUID`, then it **MAY** be considered as the first `Segment` of the `Linked Segment`. The `NextUUID` **MUST NOT** be equal to the `SegmentUUID`.</documentation>
     <extension type="libmatroska" cppname="NextUID"/>
   </element>
   <element name="NextFilename" path="\Segment\Info\NextFilename" id="0x3E83BB" type="utf-8" maxOccurs="1">
@@ -66,7 +68,8 @@ but `NextUUID` **SHOULD** be considered authoritative for identifying the Next `
     <documentation lang="en" purpose="usage notes">If the `Segment` `Info` contains a `ChapterTranslate` element, this element is **REQUIRED**.</documentation>
   </element>
   <element name="ChapterTranslate" path="\Segment\Info\ChapterTranslate" id="0x6924" type="master">
-    <documentation lang="en" purpose="definition">The mapping between this `Segment` and a segment value in the given Chapter Codec.</documentation>
+    <documentation lang="en" purpose="definition">The mapping between this `Segment` and a
+    segment value in the given Chapter Codec.</documentation>
     <documentation lang="en" purpose="rationale">Chapter Codecs may need to address different segments, but they may not know of the way to identify such segments when stored in Matroska.
 This element and its child elements add a way to map the internal segments known to the Chapter Codec to the `SegmentUUID`s in Matroska.
 This allows remuxing a file with Chapter Codec without changing the content of the codec data, just the `Segment` mapping.</documentation>
@@ -174,17 +177,20 @@ An EBML parser that has no knowledge of the `Block` structure could still see an
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="BlockAddID" path="\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAddID" id="0xEE" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">An ID that identifies how to interpret the `BlockAdditional` data; see [@?I-D.ietf-cellar-codec, section 4.1.5] for more information.
-A value of 1 indicates that the `BlockAdditional` data is defined by the codec.
-Any other value indicates that the `BlockAdditional` data should be handled according to the `BlockAddIDType` that is located in the
+    <documentation lang="en" purpose="definition">An ID that identifies how to interpret the `BlockAdditional` data; see [@?I-D.ietf-cellar-codec, section 4.1.5] for
+    more information. A value of 1 indicates that the `BlockAdditional` data is
+    defined by the codec. Any other value indicates that the `BlockAdditional` data
+    should be handled according to the `BlockAddIDType` that is located in the
 `TrackEntry`.</documentation>
     <documentation lang="en" purpose="usage notes">Each `BlockAddID` value **MUST** be unique between all `BlockMore` elements found in a `BlockAdditions` element. To keep `MaxBlockAdditionID` as low as possible, small values **SHOULD** be used.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="BlockDuration" path="\Segment\Cluster\BlockGroup\BlockDuration" id="0x9B" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The duration of the `Block`, expressed in Track Ticks; see (#timestamp-ticks).
-The `BlockDuration` element can be useful at the end of a `Track` to define the duration of the last frame (as there is no subsequent `Block` available)
-or when there is a break in a track like for subtitle tracks.</documentation>
+The `BlockDuration` element can be useful
+at the end of a `Track` to define the duration of the last frame (as
+there is no subsequent `Block` available) or when there is a break in a
+track like for subtitle tracks.</documentation>
     <implementation_note note_attribute="minOccurs">`BlockDuration` **MUST** be set (minOccurs=1) if the associated `TrackEntry` stores a `DefaultDuration` value.</implementation_note>
     <implementation_note note_attribute="default">If a value is not present and no `DefaultDuration` is defined, the value is assumed to be the difference between the timestamp of this `Block` and the timestamp of the next `Block` in "display" order (not coding order).</implementation_note>
     <extension type="webmproject.org" webm="1"/>
@@ -199,9 +205,7 @@ This is used to reference other frames necessary to decode this frame.
 The relative value **SHOULD** correspond to a valid `Block` that this `Block` depends on.
 Historically, `Matroska Writers` didn't write the actual `Block(s)` that this `Block` depends on, but they did write *some* `Block(s)` in the past.
 
-The value "0" **MAY** also be used to signify that this `Block` cannot be decoded on its own, but the necessary reference `Block(s)` is unknown. In this case, other `ReferenceBlock` elements **MUST NOT** be found in the same `BlockGroup`.
-
-If the `BlockGroup` doesn't have a `ReferenceBlock` element, then the `Block` it contains can be decoded without using any other `Block` data.</documentation>
+The value "0" **MAY** also be used to signify that this `Block` cannot be decoded on its own, but the necessary reference `Block(s)` is unknown. In this case, other `ReferenceBlock` elements **MUST NOT** be found in the same `BlockGroup`. If the `BlockGroup` doesn't have a `ReferenceBlock` element, then the `Block` it contains can be decoded without using any other `Block` data.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ReferenceVirtual" path="\Segment\Cluster\BlockGroup\ReferenceVirtual" id="0xFD" type="integer" minver="0" maxver="0" maxOccurs="1">
@@ -212,9 +216,13 @@ If the `BlockGroup` doesn't have a `ReferenceBlock` element, then the `Block` it
 This information **SHOULD** always be referenced by a seek entry.</documentation>
   </element>
   <element name="DiscardPadding" path="\Segment\Cluster\BlockGroup\DiscardPadding" id="0x75A2" type="integer" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Duration of the silent data added to the `Block`, expressed in Matroska Ticks -- i.e., in nanoseconds; see (#timestamp-ticks)
-(padding at the end of the `Block` for positive values and at the beginning of the `Block` for negative values).
-The duration of `DiscardPadding` is not calculated in the duration of the `TrackEntry` and **SHOULD** be discarded during playback.</documentation>
+    <documentation lang="en" purpose="definition">Duration of the silent data added to the `Block`, expressed in
+    Matroska Ticks -- i.e., in nanoseconds; see (#timestamp-ticks)
+(padding at the end of the `Block` for positive values and at the
+beginning of the `Block` for negative values).  The duration of
+`DiscardPadding` is not calculated in the duration of the
+`TrackEntry` and **SHOULD** be discarded during
+playback.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="Slices" path="\Segment\Cluster\BlockGroup\Slices" id="0x8E" type="master" minver="0" maxver="0" maxOccurs="1">
@@ -347,7 +355,8 @@ See (#default-track-selection) for more details.</documentation>
     <documentation lang="en" purpose="definition">Set to 1 if and only if the track contains commentary.</documentation>
   </element>
   <element name="FlagLacing" path="\Segment\Tracks\TrackEntry\FlagLacing" id="0x9C" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if the track **MAY** contain blocks that use lacing. When set to 0, all blocks **MUST** have their lacing flags set to "no lacing"; see (#block-lacing) on 'Block' Lacing.</documentation>
+    <documentation lang="en" purpose="definition">Set to 1 if the track **MAY** contain blocks that use lacing.
+    When set to 0, all blocks **MUST** have their lacing flags set to "no lacing"; see (#block-lacing) on 'Block' Lacing.</documentation>
     <extension type="libmatroska" cppname="TrackFlagLacing"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
@@ -464,8 +473,7 @@ see [@?I-D.ietf-cellar-codec] for more info.</documentation>
   </element>
   <element name="TrackOverlay" path="\Segment\Tracks\TrackEntry\TrackOverlay" id="0x6FAB" type="uinteger" maxver="0">
     <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the `Track` specified (in the u-integer).
-This means that when this track has a gap on `SilentTracks`,
-the overlay track should be used instead. The order of multiple `TrackOverlay` matters; the first one is the one that should be used.
+This means that when this track has a gap on `SilentTracks`, the overlay track should be used instead. The order of multiple `TrackOverlay` matters; the first one is the one that should be used.
 If the first one is not found, it should be the second, etc.</documentation>
   </element>
   <element name="CodecDelay" path="\Segment\Tracks\TrackEntry\CodecDelay" id="0x56AA" type="uinteger" minver="4" default="0" minOccurs="1" maxOccurs="1">
@@ -576,8 +584,10 @@ The format depends on the `ChapProcessCodecID` used; see (#chapprocesscodecid-el
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="AlphaMode" path="\Segment\Tracks\TrackEntry\Video\AlphaMode" id="0x53C0" type="uinteger" minver="3" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Indicates whether the `BlockAdditional` element with `BlockAddID` of "1" contains Alpha data as defined by the Codec Mapping for the `CodecID`.
- Undefined values (i.e., values other than 0 or 1) **SHOULD NOT** be used, as the behavior of known implementations is different.</documentation>
+    <documentation lang="en" purpose="definition">Indicates whether the `BlockAdditional` element with `BlockAddID` of "1"
+    contains Alpha data as defined by the Codec Mapping for the `CodecID`.
+ Undefined values (i.e., values other than 0 or 1) **SHOULD NOT** be used, as the
+ behavior of known implementations is different.</documentation>
     <extension type="enum source" registry="Alpha Mode" policy="First Come First Served"/>
     <restriction>
       <enum value="0" label="none">
@@ -686,7 +696,8 @@ This value is similar in scope to the biCompression value of AVI's `BITMAPINFO` 
     <extension type="libmatroska" cppname="VideoGamma"/>
   </element>
   <element name="FrameRate" path="\Segment\Tracks\TrackEntry\Video\FrameRate" id="0x2383E3" type="float" minver="0" maxver="0" range="&gt; 0x0p+0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Number of frames per second. This value is informational only. It is intended for constant frame rate streams and should not be used for a variable frame rate `TrackEntry`.</documentation>
+    <documentation lang="en" purpose="definition">Number of frames per second. This value is informational only. It is intended for constant frame rate streams and should not be
+    used for a variable frame rate `TrackEntry`.</documentation>
     <extension type="libmatroska" cppname="VideoFrameRate"/>
   </element>
   <element name="Colour" path="\Segment\Tracks\TrackEntry\Video\Colour" id="0x55B0" type="master" minver="4" maxOccurs="1">
@@ -726,23 +737,25 @@ For clarity, the value and meanings for `MatrixCoefficients` are adopted from Ta
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ChromaSubsamplingHorz" path="\Segment\Tracks\TrackEntry\Video\Colour\ChromaSubsamplingHorz" id="0x55B3" type="uinteger" minver="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The number of pixels to remove in the Cr and Cb channels for every pixel not removed horizontally.
-Example: For video with 4:2:0 chroma subsampling, the `ChromaSubsamplingHorz` **SHOULD** be set to 1.</documentation>
+    <documentation lang="en" purpose="definition">The number of pixels to remove in the Cr and Cb channels for every pixel not removed horizontally. Example: For video with 4:2:0 chroma subsampling, the `ChromaSubsamplingHorz`
+    **SHOULD** be set to 1.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoChromaSubsampHorz"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ChromaSubsamplingVert" path="\Segment\Tracks\TrackEntry\Video\Colour\ChromaSubsamplingVert" id="0x55B4" type="uinteger" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">The number of pixels to remove in the Cr and Cb channels for every pixel not removed vertically.
-Example: For video with 4:2:0 chroma subsampling, the `ChromaSubsamplingVert` **SHOULD** be set to 1.</documentation>
+Example: For video with 4:2:0 chroma subsampling, the `ChromaSubsamplingVert`
+**SHOULD** be set to 1.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoChromaSubsampVert"/>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="CbSubsamplingHorz" path="\Segment\Tracks\TrackEntry\Video\Colour\CbSubsamplingHorz" id="0x55B5" type="uinteger" minver="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">The number of pixels to remove in the Cb channel for every pixel not removed horizontally.
-This is additive with `ChromaSubsamplingHorz`. Example: For video with 4:2:1 chroma subsampling,
-the `ChromaSubsamplingHorz` **SHOULD** be set to 1, and `CbSubsamplingHorz` **SHOULD** be set to 1.</documentation>
+This is additive with `ChromaSubsamplingHorz`.
+Example: For video with 4:2:1 chroma
+subsampling, the `ChromaSubsamplingHorz` **SHOULD** be set to 1, and `CbSubsamplingHorz` **SHOULD** be set to 1.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoCbSubsampHorz"/>
     <extension type="stream copy" keep="1"/>
@@ -959,9 +972,7 @@ redundant framing information while preserving versioning and semantics between 
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ProjectionPoseYaw" path="\Segment\Tracks\TrackEntry\Video\Projection\ProjectionPoseYaw" id="0x7673" type="float" minver="4" range="&gt;= -0xB4p+0, &lt;= 0xB4p+0" default="0x0p+0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies a yaw rotation to the projection.
-
-Value represents a clockwise rotation, in degrees, around the up vector. This rotation must be applied
+    <documentation lang="en" purpose="definition">Specifies a yaw rotation to the projection. Value represents a clockwise rotation, in degrees, around the up vector. This rotation must be applied
 before any `ProjectionPosePitch` or `ProjectionPoseRoll` rotations.
 The value of this element **MUST** be in the -180 to 180 degree range, both inclusive.
 
@@ -971,9 +982,7 @@ Setting `ProjectionPoseYaw` to 180 or -180 degrees with `ProjectionPoseRoll` and
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ProjectionPosePitch" path="\Segment\Tracks\TrackEntry\Video\Projection\ProjectionPosePitch" id="0x7674" type="float" minver="4" range="&gt;= -0x5Ap+0, &lt;= 0x5Ap+0" default="0x0p+0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies a pitch rotation to the projection.
-
-Value represents a counter-clockwise rotation, in degrees, around the right vector. This rotation must be applied
+    <documentation lang="en" purpose="definition">Specifies a pitch rotation to the projection. Value represents a counter-clockwise rotation, in degrees, around the right vector. This rotation must be applied
 after the `ProjectionPoseYaw` rotation and before the `ProjectionPoseRoll` rotation.
 The value of this element **MUST** be in the -90 to 90 degree range, both inclusive.</documentation>
     <extension type="webmproject.org" webm="1"/>
@@ -981,15 +990,16 @@ The value of this element **MUST** be in the -90 to 90 degree range, both inclus
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ProjectionPoseRoll" path="\Segment\Tracks\TrackEntry\Video\Projection\ProjectionPoseRoll" id="0x7675" type="float" minver="4" range="&gt;= -0xB4p+0, &lt;= 0xB4p+0" default="0x0p+0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies a roll rotation to the projection.
-
-Value represents a counter-clockwise rotation, in degrees, around the forward vector. This rotation must be applied
-after the `ProjectionPoseYaw` and `ProjectionPosePitch` rotations.
-The value of this element **MUST** be in the -180 to 180 degree range, both inclusive.
-
-Setting `ProjectionPoseRoll` to 180 or -180 degrees and `ProjectionPoseYaw` to 180 or -180 degrees with `ProjectionPosePitch` set to 0 degrees flips the image vertically.
-
-Setting `ProjectionPoseRoll` to 180 or -180 degrees with `ProjectionPoseYaw` and `ProjectionPosePitch` set to 0 degrees flips the image horizontally and vertically.</documentation>
+    <documentation lang="en" purpose="definition">Specifies a roll rotation to the projection. Value represents a
+    counter-clockwise rotation, in degrees, around the forward vector. This
+    rotation must be applied after the `ProjectionPoseYaw` and
+    `ProjectionPosePitch` rotations.  The value of this element
+    **MUST** be in the -180 to 180 degree range, both inclusive. Setting `ProjectionPoseRoll` to 180 or -180 degrees and
+    `ProjectionPoseYaw` to 180 or -180 degrees with
+    `ProjectionPosePitch` set to 0 degrees flips the image vertically.
+    Setting `ProjectionPoseRoll` to 180 or -180 degrees with
+    `ProjectionPoseYaw` and `ProjectionPosePitch` set to 0 degrees
+    flips the image horizontally and vertically.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="VideoProjectionPoseRoll"/>
     <extension type="stream copy" keep="1"/>
@@ -1069,8 +1079,7 @@ Setting `ProjectionPoseRoll` to 180 or -180 degrees with `ProjectionPoseYaw` and
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackOperation" path="\Segment\Tracks\TrackEntry\TrackOperation" id="0xE2" type="master" minver="3" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Operation that needs to be applied on tracks to create this virtual track.
-For more details, see (#track-operation).</documentation>
+    <documentation lang="en" purpose="definition">Operation that needs to be applied on tracks to create this virtual track. For more details, see (#track-operation).</documentation>
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="TrackCombinePlanes" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes" id="0xE3" type="master" minver="3" maxOccurs="1">
@@ -1112,7 +1121,8 @@ For more details, see (#track-operation).</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="TrickTrackFlag" path="\Segment\Tracks\TrackEntry\TrickTrackFlag" id="0xC6" type="uinteger" minver="0" maxver="0" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if this video track is a Smooth FF/RW track. If set to 1, `MasterTrackUID` and `MasterTrackSegUID` should be present, and `BlockGroups` for this track must contain ReferenceFrame structures.
+    <documentation lang="en" purpose="definition">Set to 1 if this video track is a Smooth FF/RW track. If set to 1, `MasterTrackUID` and `MasterTrackSegUID` should be present, and
+    `BlockGroups` for this track must contain ReferenceFrame structures.
 Otherwise, TrickTrackUID and TrickTrackSegUID must be present if this track has a corresponding Smooth FF/RW track. See [@?DivXTrickTrack].</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
@@ -1142,8 +1152,7 @@ This value **MUST** be unique for each `ContentEncoding` found in the `ContentEn
     <extension type="stream copy" keep="1"/>
   </element>
   <element name="ContentEncodingScope" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncodingScope" id="0x5032" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A bit field that describes which elements have been modified in this way.
-Values (big-endian) can be OR'ed.</documentation>
+    <documentation lang="en" purpose="definition">A bit field that describes which elements have been modified in this way. Values (big-endian) can be OR'ed.</documentation>
     <extension type="enum source" registry="Content Encoding Scope" policy="Specification Required" bitfield="1"/>
     <restriction>
       <enum value="0x1" label="Block">
@@ -1178,10 +1187,7 @@ Each block **MUST** be decompressable, even if no previous block is available in
   </element>
   <element name="ContentCompAlgo" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentCompression\ContentCompAlgo" id="0x4254" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The compression algorithm used.</documentation>
-    <documentation lang="en" purpose="usage notes">Compression method "1" (bzlib) and "2" (lzo1x) lack proper documentation on the format, which limits implementation possibilities.
-Due to licensing conflicts on commonly available libraries' compression methods, "2" (lzo1x) does not offer widespread interoperability.
-A `Matroska Writer` **SHOULD NOT** use these compression methods by default.
-A `Matroska Reader` **MAY** support methods "1" and "2" and **SHOULD** support other methods.</documentation>
+    <documentation lang="en" purpose="usage notes">Compression method "1" (bzlib) and "2" (lzo1x) lack proper documentation on the format, which limits implementation possibilities. Due to licensing conflicts on commonly available libraries' compression methods, "2" (lzo1x) does not offer widespread interoperability. A `Matroska Writer` **SHOULD NOT** use these compression methods by default. A `Matroska Reader` **MAY** support methods "1" and "2" and **SHOULD** support other methods.</documentation>
     <extension type="enum source" registry="Compression Algorithm" policy="Specification Required"/>
     <restriction>
       <enum value="0" label="zlib">
@@ -1288,8 +1294,8 @@ A `Matroska Player` **MAY** support encryption.</documentation>
     </restriction>
   </element>
   <element name="Cues" path="\Segment\Cues" id="0x1C53BB6B" type="master" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A `Top-Level Element` to speed seeking access.
-All entries are local to the `Segment`.</documentation>
+    <documentation lang="en" purpose="definition">A `Top-Level Element` to speed seeking access.  All entries are
+    local to the `Segment`.</documentation>
     <implementation_note note_attribute="minOccurs">This element **SHOULD** be set when the `Segment` is not transmitted as a live stream; see (#livestreaming).</implementation_note>
     <extension type="webmproject.org" webm="1"/>
   </element>
@@ -1328,8 +1334,9 @@ If missing, the track's `DefaultDuration` does not apply and no duration informa
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="CueCodecState" path="\Segment\Cues\CuePoint\CueTrackPositions\CueCodecState" id="0xEA" type="uinteger" minver="2" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The `Segment Position` ((#segment-position)) of the Codec State corresponding to this `Cues` element.
-0 means that the data is taken from the initial `TrackEntry`.</documentation>
+    <documentation lang="en" purpose="definition">The `Segment Position` ((#segment-position)) of the
+    Codec State corresponding to this `Cues` element. 0 means that the
+    data is taken from the initial `TrackEntry`.</documentation>
   </element>
   <element name="CueReference" path="\Segment\Cues\CuePoint\CueTrackPositions\CueReference" id="0xDB" type="master" minver="2">
     <documentation lang="en" purpose="definition">The `Clusters` containing the referenced `Blocks`.</documentation>
@@ -1377,12 +1384,14 @@ If missing, the track's `DefaultDuration` does not apply and no duration informa
     <documentation lang="en" purpose="definition">A binary value that a track/codec can refer to when the attachment is needed.</documentation>
   </element>
   <element name="FileUsedStartTime" path="\Segment\Attachments\AttachedFile\FileUsedStartTime" id="0x4661" type="uinteger" minver="0" maxver="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment comes into context, expressed in Segment Ticks, which are based on `TimestampScale`. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment comes into context, expressed in Segment Ticks, which are based on
+    `TimestampScale`. See [@?DivXWorldFonts].</documentation>
     <documentation lang="en" purpose="usage notes">This element is reserved for future use and if written **MUST** be the segment start timestamp.</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
   <element name="FileUsedEndTime" path="\Segment\Attachments\AttachedFile\FileUsedEndTime" id="0x4662" type="uinteger" minver="0" maxver="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment goes out of context, expressed in Segment Ticks, which are based on `TimestampScale`. See [@?DivXWorldFonts].</documentation>
+    <documentation lang="en" purpose="definition">The timestamp at which this optimized font attachment goes out of context, expressed in Segment Ticks, which are based on
+    `TimestampScale`. See [@?DivXWorldFonts].</documentation>
     <documentation lang="en" purpose="usage notes">This element is reserved for future use and if written **MUST** be the segment end timestamp.</documentation>
     <extension type="divx.com" divx="1"/>
   </element>
@@ -1447,7 +1456,8 @@ the last frame it includes, especially for the `ChapterAtom` using the last fram
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Set to 1 if a chapter is hidden. Hidden chapters **SHOULD NOT** be available to the user interface
+    <documentation lang="en" purpose="definition">Set to 1 if a chapter is hidden.
+    Hidden chapters **SHOULD NOT** be available to the user interface
 (but still be available to Control Tracks; see (#chapterflaghidden) on `Chapter` flags).</documentation>
   </element>
   <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
@@ -1672,8 +1682,9 @@ If set to any other value, it **MUST** match the `ChapterUID` value of a chapter
   </element>
   <element name="TagAttachmentUID" path="\Segment\Tags\Tag\Targets\TagAttachmentUID" id="0x63C6" type="uinteger" default="0">
     <documentation lang="en" purpose="definition">A UID that identifies the Attachment(s) that the tags belong to.</documentation>
-    <documentation lang="en" purpose="usage notes">If the value is 0 at this level, the tags apply to all the attachments in the `Segment`.
-If set to any other value, it **MUST** match the `FileUID` value of an attachment found in this `Segment`.</documentation>
+    <documentation lang="en" purpose="usage notes">If the value is 0 at this level, the tags apply to all the attachments in
+    the `Segment`.  If set to any other value, it **MUST** match
+    the `FileUID` value of an attachment found in this `Segment`.</documentation>
   </element>
   <element name="SimpleTag" path="\Segment\Tags\Tag\+SimpleTag" id="0x67C8" type="master" minOccurs="1" recursive="1">
     <documentation lang="en" purpose="definition">Contains general information about the target.</documentation>
@@ -1685,8 +1696,7 @@ If set to any other value, it **MUST** match the `FileUID` value of an attachmen
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="TagLanguage" path="\Segment\Tags\Tag\+SimpleTag\TagLanguage" id="0x447A" type="string" default="und" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the specified tag
-in the Matroska languages form; see (#language-codes) on language codes.
+    <documentation lang="en" purpose="definition">Specifies the language of the specified tag in the Matroska languages form; see (#language-codes) on language codes.
 This element **MUST** be ignored if the `TagLanguageBCP47` element is used within the same `SimpleTag` element.</documentation>
     <extension type="webmproject.org" webm="1"/>
     <extension type="libmatroska" cppname="TagLangue"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -28,7 +28,7 @@
     <extension type="webmproject.org" webm="1"/>
   </element>
   <element name="SegmentUUID" path="\Segment\Info\SegmentUUID" id="0x73A4" type="binary" length="16" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A randomly generated UID that identifies the `Segment` amongst many others (128 bits). It is equivalent to a Universally Unique Identifier (UUID) v4 [@!RFC4122] with all bits randomly (or pseudorandomly) chosen.  An actual UUID v4 value, where some bits are not random, **MAY** also be used.</documentation>
+    <documentation lang="en" purpose="definition">A randomly generated UID that identifies the `Segment` amongst many others (128 bits). It is equivalent to a Universally Unique Identifier (UUID) v4 [@!RFC9562] with all bits randomly (or pseudorandomly) chosen.  An actual UUID v4 value, where some bits are not random, **MAY** also be used.</documentation>
     <documentation lang="en" purpose="usage notes">If the `Segment` is a part of a `Linked Segment`, then this element is **REQUIRED**.
 The value of the UID **MUST** contain at least one bit set to 1.</documentation>
     <extension type="libmatroska" cppname="SegmentUID"/>
@@ -62,7 +62,7 @@ then it **MAY** be considered as the first `Segment` of the `Linked Segment`. Th
 but `NextUUID` **SHOULD** be considered authoritative for identifying the Next `Segment`.</documentation>
   </element>
   <element name="SegmentFamily" path="\Segment\Info\SegmentFamily" id="0x4444" type="binary" length="16">
-    <documentation lang="en" purpose="definition">A UID that all `Segments` of a `Linked Segment` **MUST** share (128 bits). It is equivalent to a UUID v4 [@!RFC4122] with all bits randomly (or pseudorandomly) chosen. An actual UUID v4 value, where some bits are not random, **MAY** also be used.</documentation>
+    <documentation lang="en" purpose="definition">A UID that all `Segments` of a `Linked Segment` **MUST** share (128 bits). It is equivalent to a UUID v4 [@!RFC9562] with all bits randomly (or pseudorandomly) chosen. An actual UUID v4 value, where some bits are not random, **MAY** also be used.</documentation>
     <documentation lang="en" purpose="usage notes">If the `Segment` `Info` contains a `ChapterTranslate` element, this element is **REQUIRED**.</documentation>
   </element>
   <element name="ChapterTranslate" path="\Segment\Info\ChapterTranslate" id="0x6924" type="master">

--- a/iana.md
+++ b/iana.md
@@ -2,7 +2,8 @@
 
 ## Media Types
 
-Matroska files and streams are found in three main forms: audio-video, audio-only, and (occasionally) stereoscopic video.
+Matroska files and streams are found in three main forms: audio-video,
+audio-only, and (occasionally) stereoscopic video.
 
 Historically, Matroska files and streams have used the following media types with an "x-" prefix.
 For better compatibility, a system **SHOULD** be able to handle both formats.

--- a/iana_matroska_ids.md
+++ b/iana_matroska_ids.md
@@ -5,10 +5,9 @@
 IANA has created a new registry called the "Matroska Element IDs"
 registry.
 
-To register a new Element ID in this registry, one needs
-an Element ID, an Element Name,
-a Change Controller, and
-an optional Reference to a document describing the Element ID.
+To register a new Element ID in this registry, one needs an Element ID, an
+Element Name, a Change Controller, and an
+optional Reference to a document describing the Element ID.
 
 Element IDs are encoded
 using the VINT mechanism described in [@!RFC8794, section 4] and can be between
@@ -21,7 +20,8 @@ One-octet Matroska Element IDs (range 0x80-0xFE) are to be allocated according t
 
 Two-octet Matroska Element IDs (range 0x407F-0x7FFE) are to be allocated according to the "Specification Required" policy [@!RFC8126].
 
-Two-octet Matroska Element IDs between 0x0100 and 0x407E are not valid for use as an Element ID.
+Two-octet Matroska Element IDs between 0x0100 and 0x407E are not valid for
+use as an Element ID.
 
 Three-octet (range 0x203FFF-0x3FFFFE) and four-octet Matroska Element IDs (range 0x101FFFFF-0x1FFFFFFE) are to be allocated according to the "First Come First Served" policy [@!RFC8126].
 
@@ -32,18 +32,20 @@ Four-octet Matroska Element IDs between 0x01000000 and 0x101FFFFE are not valid 
 The allowed values in the "Matroska Element IDs" registry are similar to the ones found
 in the "EBML Element IDs" registry defined in [@!RFC8794, section 17.1].
 
-EBML Element IDs defined for the EBML Header -- as defined in [@!RFC8794, section 17.1] --
-**MUST NOT** be used as Matroska Element IDs.
+EBML Element IDs defined for the EBML Header -- as defined in [@!RFC8794, section 17.1] -- **MUST NOT** be used as Matroska Element IDs.
 
-Given the scarcity of one-octet Element IDs, they should only be created to save space for elements found many times in a file
-(for example, `BlockGroup` or `Chapters`). The four-octet Element IDs are mostly for synchronization of large elements.
-They should only be used for such high-level elements.
-Elements that are not expected to be used often should use three-octet Element IDs.
+Given the scarcity of one-octet Element IDs, they should only be created
+to save space for elements found many times in a file (for example, `BlockGroup`
+or `Chapters`). The four-octet Element IDs are mostly for synchronization of
+large elements.  They should only be used for such high-level elements.
+Elements that are not expected to be used often should use three-octet Element
+IDs.
 
 Elements found in (#historic-deprecated-elements) have an assigned Matroska Element ID for historical reasons.
 These elements are not in use and **SHOULD NOT** be reused unless there are no other IDs available with the desired size.
 Such IDs are marked as "Reclaimed" in the "Matroska Element IDs" registry, as they could be used for other things in the future.
 
-(#iana-table) shows the initial contents of the "Matroska Element IDs" registry.
-The Change Controller for the initial entries is the IETF.
+(#iana-table) shows the initial contents of the
+"Matroska Element IDs" registry. The Change Controller for the initial
+entries is the IETF.
 

--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -63,7 +63,8 @@ The key words "**MUST**", "**MUST NOT**",
 "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174]
-when, and only when, they appear in all capitals, as shown here.
+"**MAY**", and "**OPTIONAL**" in this document are
+to be interpreted as described in BCP 14 [@!RFC2119]
+[@!RFC8174] when, and only when, they appear in all capitals,
+as shown here.
 

--- a/index_codec.md
+++ b/index_codec.md
@@ -64,7 +64,8 @@ The key words "**MUST**", "**MUST NOT**",
 "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174]
-when, and only when, they appear in all capitals, as shown here.
+"**MAY**", and "**OPTIONAL**" in this document are
+to be interpreted as described in BCP 14 [@!RFC2119]
+[@!RFC8174] when, and only when, they appear in all capitals,
+as shown here.
 

--- a/index_control.md
+++ b/index_control.md
@@ -56,7 +56,8 @@ The key words "**MUST**", "**MUST NOT**",
 "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174]
-when, and only when, they appear in all capitals, as shown here.
+"**MAY**", and "**OPTIONAL**" in this document are
+to be interpreted as described in BCP 14 [@!RFC2119]
+[@!RFC8174] when, and only when, they appear in all capitals,
+as shown here.
 

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -5,14 +5,15 @@ ipr= "trust200902"
 area = "art"
 submissiontype = "IETF"
 workgroup = "cellar"
-date = @BUILD_DATE@
+date = 2024-10-01
 keyword = ["binary","storage","matroska","ebml","webm"]
+updates = [8794]
+obsoletes = []
 
 [seriesInfo]
-name = "Internet-Draft"
-stream = "IETF"
+name = "RFC"
+value = "9559"
 status = "standard"
-value = "@BUILD_VERSION@"
 
 [[author]]
 initials="S."

--- a/index_matroska.md
+++ b/index_matroska.md
@@ -38,8 +38,9 @@ fullname="Dave Rice"
 
 .# Abstract
 
-This document defines the Matroska audiovisual data container structure, including definitions of its structural elements,
-terminology, vocabulary, and application.
+This document defines the Matroska audiovisual data container structure,
+including definitions of its structural elements, terminology,
+vocabulary, and application.
 
 This document updates RFC 8794 to permit the use of a previously reserved Extensible Binary Meta Language (EBML) Element ID.
 
@@ -47,12 +48,15 @@ This document updates RFC 8794 to permit the use of a previously reserved Extens
 
 # Introduction
 
-Matroska is an audiovisual data container format. It was derived from a project called [@?MCF]
-but diverges from it significantly because it is based on EBML (Extensible Binary Meta Language) [@!RFC8794],
-a binary derivative of XML. EBML provides significant advantages in terms of future format extensibility,
+Matroska is an audiovisual data container format. It was derived from a
+project called [@?MCF] but diverges from it
+significantly because it is based on EBML (Extensible Binary Meta Language)
+[@!RFC8794], a binary derivative of XML. EBML
+provides significant advantages in terms of future format extensibility,
 without breaking file support in parsers reading the previous versions.
 
-To avoid any misunderstandings, it is essential to clarify exactly what an audio/video container is:
+To avoid any misunderstandings, it is essential to clarify exactly
+what an audio/video container is:
 
 - It is NOT a video or audio compression format (codec).
 
@@ -88,11 +92,13 @@ The key words "**MUST**", "**MUST NOT**",
 "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174]
-when, and only when, they appear in all capitals, as shown here.
+"**MAY**", and "**OPTIONAL**" in this document are
+to be interpreted as described in BCP 14 [@!RFC2119]
+[@!RFC8174] when, and only when, they appear in all capitals,
+as shown here.
 
-This document defines the following terms in order to define the format and application of Matroska:
+This document defines the following terms in order to
+define the format and application of Matroska:
 
 Matroska:
 
@@ -124,25 +130,24 @@ and EBML Structure (Section [@RFC8794, 3]).
 ## Updates to RFC 8794
 
 Because of an oversight, [@!RFC8794] reserved EBML ID 0x80, which is used by deployed Matroska implementations.
-For this reason, this specification updates [@!RFC8794] to make 0x80 a legal EBML ID.
-Additionally, this specification makes the following updates:
+For this reason, this specification updates [@!RFC8794] to make 0x80 a legal EBML ID. Additionally, this specification makes the following updates:
 
 - [@!RFC8794, section 17.1] (per Erratum ID #7189 [@Err7189])
 
 OLD:
 
->   One-octet Element IDs **MUST** be between 0x81 and 0xFE.  These items are
->   valuable because they are short, and they need to be used for
->   commonly repeated elements.  Element IDs are to be allocated within
+>   One-octet Element IDs **MUST** be between 0x81 and
+>   0xFE.  These items are valuable because they are short, and they need to be
+>   used for commonly repeated elements.  Element IDs are to be allocated within
 >   this range according to the "RFC Required" policy [@!RFC8126].
 >
 >   The following one-octet Element IDs are RESERVED: 0xFF and 0x80.
 
 NEW:
 
->   One-octet Element IDs **MUST** be between 0x80 and 0xFE.  These items are
->   valuable because they are short, and they need to be used for
->   commonly repeated elements.  Element IDs are to be allocated within
+>   One-octet Element IDs **MUST** be between 0x80 and
+>   0xFE.  These items are valuable because they are short, and they need to be
+>   used for commonly repeated elements.  Element IDs are to be allocated within
 >   this range according to the "RFC Required" policy [@!RFC8126].
 >
 >   The following one-octet Element ID is RESERVED: 0xFF.

--- a/index_tags.md
+++ b/index_tags.md
@@ -63,7 +63,8 @@ The key words "**MUST**", "**MUST NOT**",
 "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
-"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174]
-when, and only when, they appear in all capitals, as shown here.
+"**MAY**", and "**OPTIONAL**" in this document are
+to be interpreted as described in BCP 14 [@!RFC2119]
+[@!RFC8174] when, and only when, they appear in all capitals,
+as shown here.
 

--- a/matroska_implement.md
+++ b/matroska_implement.md
@@ -11,8 +11,8 @@ It is **RECOMMENDED** that the first `SeekHead` element be followed by a `Void` 
 allow for the `SeekHead` element to be expanded to cover new `Top-Level Elements`
 that could be added to the Matroska file, such as `Tags`, `Chapters`, and `Attachments` elements.
 
-The size of this `Void` element should be adjusted depending on the
-`Tags`, `Chapters`, and `Attachments` elements in the Matroska file.
+The size of this `Void` element should be adjusted depending on the `Tags`,
+`Chapters`, and `Attachments` elements in the Matroska file.
 
 ## Optimum Layouts
 

--- a/matroska_security.md
+++ b/matroska_security.md
@@ -16,13 +16,15 @@ Attacks on a `Matroska Reader` could include:
 * Chapter Codecs running unwanted commands on the host system.
 
 The same error handling done for EBML applies to Matroska files.
-Particular error handling is not covered in this specification, as this is depends on the goal of the `Matroska Readers`.
-`Matroska Readers` decide how to handle the errors whether or not they are recoverable in their code.
-For example, if the checksum of the `\Segment\Tracks` is invalid, some could decide to try to read the data anyway,
-some will just reject the file, and most will not even check it.
+Particular error handling is not covered in this specification, as this is
+depends on the goal of the `Matroska Readers`.
+`Matroska Readers` decide how to handle the errors whether or not they are
+recoverable in their code.
+For example, if the checksum of the `\Segment\Tracks` is invalid, some
+could decide to try to read the data anyway, some will just reject the file,
+and most will not even check it.
 
-`Matroska Reader` implementations need to be robust against malicious payloads.
-Those related to denial of service are outlined in [@RFC4732, section 2.1].
+`Matroska Reader` implementations need to be robust against malicious payloads. Those related to denial of service are outlined in [@RFC4732, section 2.1].
 
 Although rarer, the same may apply to a `Matroska Writer`.  Malicious stream data
 must not cause the `Matroska Writer` to misbehave, as this might allow an attacker access

--- a/notes.md
+++ b/notes.md
@@ -40,8 +40,8 @@ by the current `Parent Element`.
 It is sometimes necessary to create a Matroska file from another Matroska file, for example, to add subtitles in a language
 or to edit out a portion of the content.
 Some values from the original Matroska file need to be kept the same in the destination file.
-For example, the SamplingFrequency of an audio track wouldn't change between the two files.
-Some other values may change between the two files, for example, the TrackNumber of an audio track when another track has been added.
+For example, the `SamplingFrequency` of an audio track wouldn't change between the two files.
+Some other values may change between the two files, for example, the `TrackNumber` of an audio track when another track has been added.
 
 An element is marked with a property "`stream copy: True`" when the values of that element need to be kept identical between the source and destination files.
 If that property is not set, elements may or may not keep the same value between the source and destination files.

--- a/notes.md
+++ b/notes.md
@@ -1,39 +1,41 @@
 # Matroska Versioning
 
 Matroska is based on the principle that a reading application does not have to support
-100% of the specifications in order to be able to play the file. Therefore, a Matroska file
-contains version indicators that tell a reading application what to expect.
+100% of the specifications in order to be able to play the file. Therefore, a Matroska file contains version indicators that tell a reading application what to expect.
 
-It is possible and valid to have the version fields indicate that the file contains
-Matroska elements from a higher specification version number while signaling that a
-reading application **MUST** only support a lower version number properly in order to play
-it back (possibly with a reduced feature set).
+It is possible and valid to have the version fields indicate that the file
+contains Matroska elements from a higher specification version number while
+signaling that a reading application **MUST** only support a lower
+version number properly in order to play it back (possibly with a reduced
+feature set).
 
-The `EBML Header` of each Matroska document informs the reading application on what
-version of Matroska to expect. The elements within the `EBML Header` with jurisdiction
-over this information are `DocTypeVersion` and `DocTypeReadVersion`.
+The `EBML Header` of each Matroska document informs the reading
+application on what version of Matroska to expect. The elements within the
+`EBML Header` with jurisdiction over this information are
+`DocTypeVersion` and `DocTypeReadVersion`.
 
 `DocTypeVersion` **MUST** be equal to or greater than the highest Matroska version number of
-any element present in the Matroska file. For example, a file using the `SimpleBlock` element ((#simpleblock-element))
-**MUST** have a `DocTypeVersion` equal to or greater than 2. A file containing `CueRelativePosition`
+any element present in the Matroska file. For example, a file using the `SimpleBlock` element ((#simpleblock-element)) **MUST** have a `DocTypeVersion` equal to or greater than 2. A file containing `CueRelativePosition`
 elements  ((#cuerelativeposition-element)) **MUST** have a `DocTypeVersion` equal to or greater than 4.
 
-The `DocTypeReadVersion` **MUST** contain the minimum version number that a reading application
-can minimally support in order to play the file back -- optionally with a reduced feature
-set. For example, if a file contains only elements of version 2 or lower except for
-`CueRelativePosition` (which is a version 4 Matroska element), then `DocTypeReadVersion`
-**SHOULD** still be set to 2 and not 4 because evaluating `CueRelativePosition` is not
-necessary for standard playback -- it makes seeking more precise if used.
+The `DocTypeReadVersion` **MUST** contain the minimum
+version number that a reading application can minimally support in order to
+play the file back -- optionally with a reduced feature set. For example, if a
+file contains only elements of version 2 or lower except for
+`CueRelativePosition` (which is a version 4 Matroska element), then
+`DocTypeReadVersion` **SHOULD** still be set to 2 and not 4
+because evaluating `CueRelativePosition` is not necessary for standard
+playback -- it makes seeking more precise if used.
 
 A reading application supporting Matroska version `V` **MUST NOT** refuse to read a
 file with `DocReadTypeVersion` equal to or lower than `V`, even if `DocTypeVersion`
 is greater than `V`.
 
-A reading application
-supporting at least Matroska version `V` and reading a file whose `DocTypeReadVersion`
-field is equal to or lower than `V` **MUST** skip Matroska/EBML elements it encounters
-but does not know about if that unknown element fits into the size constraints set
-by the current `Parent Element`.
+A reading application supporting at least Matroska version `V` and
+reading a file whose `DocTypeReadVersion` field is equal to or lower
+than `V` **MUST** skip Matroska/EBML elements it encounters
+but does not know about if that unknown element fits into the size constraints
+set by the current `Parent Element`.
 
 # Stream Copy
 
@@ -48,9 +50,10 @@ If that property is not set, elements may or may not keep the same value between
 
 # DefaultDecodedFieldDuration
 
-The `DefaultDecodedFieldDuration` element can signal to the displaying application how
-often fields of a video sequence will be available for displaying. It can be used for both
-interlaced and progressive content.
+The `DefaultDecodedFieldDuration` element can signal to the
+displaying application how often fields of a video sequence will be available
+for displaying. It can be used for both interlaced and progressive
+content.
 
 If the video sequence is signaled as interlaced ((#flaginterlaced-element)), then `DefaultDecodedFieldDuration` equals
 the period between two successive fields at the output of the decoding process.
@@ -110,8 +113,7 @@ The value is stored as a signed value on 16 bits.
 This section describes the binary data contained in the `Block` element ((#block-element)). Bit 0 is the most significant bit.
 
 As the `TrackNumber` size can vary between 1 and 8 octets, there are 8 different sizes for the `Block` header.
-The definitions for `TrackNumber` sizes of 1 and 2 are provided;
-the other variants can be deduced by extending the size of the `TrackNumber` by multiples of 8 bits.
+The definitions for `TrackNumber` sizes of 1 and 2 are provided; the other variants can be deduced by extending the size of the `TrackNumber` by multiples of 8 bits.
 
 ```
   0                   1                   2                   3
@@ -179,8 +181,9 @@ The `SimpleBlock` structure is inspired by the `Block` structure; see (#block-st
 The main differences are the added Keyframe flag and Discardable flag. Otherwise, everything is the same.
 
 As the `TrackNumber` size can vary between 1 and 8 octets, there are 8 different sizes for the `SimpleBlock` header.
-The definitions for `TrackNumber` sizes of 1 and 2 are provided;
-the other variants can be deduced by extending the size of the `TrackNumber` by multiples of 8 bits.
+The definitions for `TrackNumber` sizes of 1 and 2 are provided; the
+other variants can be deduced by extending the size of the
+`TrackNumber` by multiples of 8 bits.
 
 ```
   0                   1                   2                   3
@@ -270,8 +273,7 @@ When the `FlagLacing` ((#flaglacing-element)) is set to 0, all blocks of that tr
 
 ### No Lacing
 
-When no lacing is used, the number of frames in the lace is omitted, and only one frame can be stored in the `Block`.
-The LACING bits of the `Block` Header flags are set to `00b`.
+When no lacing is used, the number of frames in the lace is omitted, and only one frame can be stored in the `Block`. The LACING bits of the `Block` Header flags are set to `00b`.
 
 The `Block` for an 800-octet frame is as follows:
 
@@ -383,8 +385,7 @@ For example, for three frames that are 800 octets each:
 | 1605-2404    | <frame3> | Third frame data  |
 Table: Fixed-Size Lacing Example{#blockFixedSizeLacing}
 
-This gives a `Block` of 2405 octets. When reading the `Block`, we find that there are three frames (Octet 4).
-The data start at Octet 5, so the size of each frame is (2405 - 5) / 3 = 800.
+This gives a `Block` of 2405 octets. When reading the `Block`, we find that there are three frames (Octet 4). The data start at Octet 5, so the size of each frame is (2405 - 5) / 3 = 800.
 
 
 ### Laced Frames Timestamp
@@ -408,21 +409,23 @@ For subtitles, this is usually not the case, so lacing **SHOULD NOT** be used.
 
 ## Random Access Points
 
-Random Access Points (RAPs) are positions where the parser can seek to and start playback without decoding
-what was before. In Matroska, `BlockGroups` and `SimpleBlocks` can be RAPs.
-To seek to these elements, it is still necessary to seek to the `Cluster` containing them,
-read the `Cluster` Timestamp,
-and start playback from the `BlockGroup` or `SimpleBlock` that is a RAP.
+Random Access Points (RAPs) are positions where the parser can seek to and
+start playback without decoding what was before. In Matroska,
+`BlockGroups` and `SimpleBlocks` can be RAPs.  To seek to these
+elements, it is still necessary to seek to the `Cluster` containing
+them, read the `Cluster` Timestamp, and start playback from the
+`BlockGroup` or `SimpleBlock` that is a RAP.
 
 Because a Matroska File is usually composed of multiple tracks playing at the same time
 -- video, audio, and subtitles -- to seek properly to a RAP, each selected track must be
 taken into account. Usually, all audio and subtitle `BlockGroups` or `SimpleBlocks` are RAPs.
 They are independent of each other and can be played randomly.
 
-On the other hand, video tracks often use references to previous and future frames for better
-coding efficiency. Frames with such references **MUST** either contain one or more
-`ReferenceBlock` elements in their `BlockGroup` or **MUST** be marked
-as non-keyframe in a `SimpleBlock`; see (#simpleblock-structure).
+On the other hand, video tracks often use references to previous and future
+frames for better coding efficiency. Frames with such references
+**MUST** either contain one or more `ReferenceBlock`
+elements in their `BlockGroup` or **MUST** be marked as
+non-keyframe in a `SimpleBlock`; see (#simpleblock-structure).
 
 ```xml
 &lt;Cluster&gt;
@@ -602,8 +605,7 @@ The elements storing values in Matroska Ticks/nanoseconds are:
 
 ### Segment Ticks
 
-Elements in Segment Ticks involve the use of the `TimestampScale` element of the `Segment` to get the timestamp
-in nanoseconds of the element, with the following formula:
+Elements in Segment Ticks involve the use of the `TimestampScale` element of the `Segment` to get the timestamp in nanoseconds of the element, with the following formula:
 
     timestamp in nanosecond = element value * TimestampScale
 
@@ -625,8 +627,10 @@ The elements storing values in Segment Ticks are:
 
 ### Track Ticks
 
-Elements in Track Ticks involve the use of the `TimestampScale` element of the `Segment` and the `TrackTimestampScale` element of the `Track`
-to get the timestamp in nanoseconds of the element, with the following formula:
+Elements in Track Ticks involve the use of the `TimestampScale`
+element of the `Segment` and the `TrackTimestampScale` element
+of the `Track` to get the timestamp in nanoseconds of the element, with
+the following formula:
 
     timestamp in nanoseconds =
         element value * TrackTimestampScale * TimestampScale
@@ -647,20 +651,25 @@ The elements storing values in Track Ticks are:
 When the `TrackTimestampScale` is interpreted as "1.0", Track Ticks are equivalent to Segment Ticks
 and give an integer value in nanoseconds. This is the most common case as `TrackTimestampScale` is usually omitted.
 
-A value of `TrackTimestampScale` other than "1.0" **MAY** be used
-to scale the timestamps more in tune with each `Track` sampling frequency.
-For historical reasons, a lot of `Matroska Readers` don't take the `TrackTimestampScale` value into account.
-Thus, using a value other than "1.0" might not work in many places.
+A value of `TrackTimestampScale` other than "1.0" **MAY**
+be used to scale the timestamps more in tune with each `Track` sampling
+frequency. For historical reasons, a lot of `Matroska Readers` don't
+take the `TrackTimestampScale` value into account. Thus, using a value
+other than "1.0" might not work in many places.
 
 ## Block Timestamps
 
-A `Block` element and `SimpleBlock` element timestamp is the time when the decoded data of the first
-frame in the `Block`/`SimpleBlock` **MUST** be presented if the track of that `Block`/`SimpleBlock` is selected for playback.
+A `Block` element and `SimpleBlock` element timestamp is the
+time when the decoded data of the first frame in the
+`Block`/`SimpleBlock` **MUST** be presented if the
+track of that `Block`/`SimpleBlock` is selected for playback.
 This is also known as the Presentation Timestamp (PTS).
 
-The `Block` element and `SimpleBlock` element store their timestamps as signed integers, relative
-to the `Cluster\Timestamp` value of the `Cluster` they are stored in.
-To get the timestamp of a `Block` or `SimpleBlock` in nanoseconds, the following formula is used:
+The `Block` element and `SimpleBlock` element store their
+timestamps as signed integers, relative to the `Cluster\Timestamp`
+value of the `Cluster` they are stored in.  To get the timestamp of a
+`Block` or `SimpleBlock` in nanoseconds, the following formula
+is used:
 
     ( Cluster\Timestamp + ( block timestamp * TrackTimestampScale ) ) *
     TimestampScale
@@ -683,11 +692,13 @@ During playback, when a frame has a negative timestamp, the content **MUST** be 
 
 The default Track Tick duration is one millisecond.
 
-The `TimestampScale` is a floating-point value that is usually "1.0". But when it's not, the multiplied
-`Block` Timestamp is a floating-point value in nanoseconds.
-The `Matroska Reader` **SHOULD** use the nearest rounding value in nanoseconds to get
-the proper nanosecond timestamp of a `Block`. This allows some clever `TimestampScale` values
-to have a more refined timestamp precision per frame.
+The `TimestampScale` is a floating-point value that is usually
+"1.0". But when it's not, the multiplied `Block` Timestamp is a
+floating-point value in nanoseconds.  The `Matroska Reader`
+**SHOULD** use the nearest rounding value in nanoseconds to get the
+proper nanosecond timestamp of a `Block`. This allows some clever
+`TimestampScale` values to have a more refined timestamp precision per
+frame.
 
 # Language Codes
 
@@ -696,10 +707,12 @@ bibliographic ISO 639-2 form [@!ISO639-2] (like "fre" for French)
 or such a language code followed by a dash and a country code for specialities in languages (like "fre-ca" for Canadian French).
 The `ISO 639-2 Language` elements are `Language` element, `TagLanguage` element, and `ChapLanguage` element.
 
-Starting in Matroska version 4, the forms defined in either [@!ISO639-2] or [@!RFC5646] **MAY** be used,
-although the form in [@!RFC5646] is **RECOMMENDED**. The `Language` elements in the [@!RFC5646] form are `LanguageBCP47` element,
-`TagLanguageBCP47` element, and `ChapLanguageBCP47` element. If both an [@!ISO639-2] Language element and an [@!RFC5646] Language element
-are used within the same `Parent Element`, then the `Language` element in the [@!ISO639-2] form **MUST** be ignored and precedence given to the `Language` element in the [@!RFC5646] form.
+Starting in Matroska version 4, the forms defined in either [@!ISO639-2] or
+[@!RFC5646] **MAY** be used, although the form in [@!RFC5646] is **RECOMMENDED**. The `Language` elements in the [@!RFC5646] form
+are `LanguageBCP47` element, `TagLanguageBCP47` element, and
+`ChapLanguageBCP47` element. If both an [@!ISO639-2] Language element and an [@!RFC5646] Language element are used within the same
+`Parent Element`, then the `Language` element in the [@!ISO639-2] form **MUST**
+be ignored and precedence given to the `Language` element in the [@!RFC5646] form.
 
 In this document, "BCP47" in element names refers specifically to
 [@!RFC5646], which is part of BCP 47.
@@ -711,22 +724,26 @@ Country codes are the [@!RFC5646] two-letter region subtags, without the UK exce
 
 # Encryption
 
-This Matroska specification provides no interoperable solution for securing the
-data container with any assurances of confidentiality, integrity, authenticity,
-or authorization. The `ContentEncryption` element ((#contentencryption-element))
-and associated sub-fields ((#contentencalgo-element) to (#aessettingsciphermode-element)) are defined
-only for the benefit of implementers to construct their own proprietary solution
-or as the basis for further standardization activities.  How to use these
-fields to secure a Matroska data container is out of scope, as are any related
-issues such as key management and distribution.
+This Matroska specification provides no interoperable solution for securing
+the data container with any assurances of confidentiality, integrity,
+authenticity, or authorization. The `ContentEncryption` element
+((#contentencryption-element)) and associated sub-fields
+((#contentencalgo-element) to
+(#aessettingsciphermode-element)) are defined only for the benefit of
+implementers to construct their own proprietary solution or as the basis for
+further standardization activities.  How to use these fields to secure a
+Matroska data container is out of scope, as are any related issues such as key
+management and distribution.
 
-A `Matroska Reader` who encounters containers that use the fields defined in this
-section **MUST** rely on out-of-scope guidance to decode the associated content.
+A `Matroska Reader` who encounters containers that use the fields
+defined in this section **MUST** rely on out-of-scope guidance to
+decode the associated content.
 
-Because encryption occurs within the `Block` element, it is possible to manipulate
-encrypted streams without decrypting them. The streams could potentially be copied,
-deleted, cut, appended, or any number of other possible editing techniques without
-decryption. The data can be used without having to expose it or go through the decrypting process.
+Because encryption occurs within the `Block` element, it is possible
+to manipulate encrypted streams without decrypting them. The streams could
+potentially be copied, deleted, cut, appended, or any number of other possible
+editing techniques without decryption. The data can be used without having to
+expose it or go through the decrypting process.
 
 Encryption can also be layered within Matroska. This means that two completely different
 types of encryption can be used, requiring two separate keys to be able to decrypt a stream.
@@ -742,45 +759,56 @@ parameters is required for a complete solution but is out of scope of this
 document and left to the proprietary implementations using them or subsequent
 profiles of this document.
 
-The `ContentEncodingScope` element gives an idea of which part of the track is encrypted,
-but each `ContentEncAlgo` element and its sub-elements (like `AESSettingsCipherMode`)
-define exactly how the encrypted track should be interpreted.
+The `ContentEncodingScope` element gives an idea of which part of
+the track is encrypted, but each `ContentEncAlgo` element and its
+sub-elements (like `AESSettingsCipherMode`) define exactly how the
+encrypted track should be interpreted.
 
 An example of an extension that builds upon these security-related fields in this specification is [@?WebM-Enc].
 It uses AES-CTR, `ContentEncAlgo` = 5 ((#contentencalgo-element)), and `AESSettingsCipherMode` = 1 ((#aessettingsciphermode-element)).
 
-A `Matroska Writer` **MUST NOT** use insecure cryptographic algorithms to create new
-archives or streams, but a `Matroska Reader` **MAY** support these algorithms to read
-previously made archives or streams.
+A `Matroska Writer` **MUST NOT** use insecure
+cryptographic algorithms to create new archives or streams, but a `Matroska Reader`
+**MAY** support these algorithms to read previously
+made archives or streams.
 
 # Image Presentation
 
 ## Cropping
 
-The `PixelCrop` elements (`PixelCropTop`, `PixelCropBottom`, `PixelCropRight`, and `PixelCropLeft`)
-indicate when, and by how much, encoded video frames **SHOULD** be cropped for display.
-These elements allow edges of the frame that are not intended for display (such as the
-sprockets of a full-frame film scan or the Video ANCillary (VANC) area of a digitized analog videotape) to be stored but hidden. `PixelCropTop` and `PixelCropBottom` store an integer of how many
-rows of pixels **SHOULD** be cropped from the top and bottom of the image, respectively.
- `PixelCropLeft` and `PixelCropRight` store an integer of how many columns of pixels
- **SHOULD** be cropped from the left and right of the image, respectively.
+The `PixelCrop` elements (`PixelCropTop`,
+`PixelCropBottom`, `PixelCropRight`, and `PixelCropLeft`)
+indicate when, and by how much, encoded video frames **SHOULD** be
+cropped for display.  These elements allow edges of the frame that are not
+intended for display (such as the sprockets of a full-frame film scan or the
+Video ANCillary (VANC) area of a digitized analog videotape) to be stored but
+hidden.  `PixelCropTop` and `PixelCropBottom` store an integer
+of how many rows of pixels **SHOULD** be cropped from the top and
+bottom of the image, respectively.  `PixelCropLeft` and
+`PixelCropRight` store an integer of how many columns of pixels
+**SHOULD** be cropped from the left and right of the image,
+respectively.
 
- For example,
- a pillar-boxed video that stores a 1440x1080 visual image within the center of a padded
- 1920x1080 encoded image may set both `PixelCropLeft` and `PixelCropRight` to "240",
- so a `Matroska Player` should crop off 240 columns of pixels from the left and
- right of the encoded image to present the image with the pillar-boxes hidden.
+For example, a pillar-boxed video that stores a 1440x1080 visual image
+within the center of a padded 1920x1080 encoded image may set both
+`PixelCropLeft` and `PixelCropRight` to "240", so a `Matroska Player`
+should crop off 240 columns of pixels from the left and right of
+the encoded image to present the image with the pillar-boxes hidden.
 
-Cropping has to be performed before resizing and the display dimensions given by
- `DisplayWidth`, `DisplayHeight`, and `DisplayUnit` apply to the already-cropped image.
+Cropping has to be performed before resizing and the display dimensions
+given by `DisplayWidth`, `DisplayHeight`, and
+`DisplayUnit` apply to the already-cropped image.
 
 ## Rotation
 
-The `ProjectionPoseRoll` element ((#projectionposeroll-element)) can be used to indicate
-that the image from the associated video track **SHOULD** be rotated for presentation.
-For instance, the following example of the `Projection` element ((#projection-element))
-and the `ProjectionPoseRoll` element represents a video track where the image **SHOULD** be
-presented with a 90-degree counter-clockwise rotation, with the EBML tree shown as XML:
+The `ProjectionPoseRoll` element
+((#projectionposeroll-element)) can be used to indicate that the image
+from the associated video track **SHOULD** be rotated for
+presentation.  For instance, the following example of the `Projection`
+element ((#projection-element)) and the
+`ProjectionPoseRoll` element represents a video track where the image
+**SHOULD** be presented with a 90-degree counter-clockwise
+rotation, with the EBML tree shown as XML:
 
 ```xml
 &lt;Projection&gt;
@@ -791,14 +819,17 @@ Figure: Rotation Example
 
 # Segment Position
 
-The `Segment Position` of an element refers to the position of the first octet of the
-`Element ID` of that element, measured in octets, from the beginning of the `Element Data`
-section of the containing `Segment` element. In other words, the `Segment Position` of an
-element is the distance in octets from the beginning of its containing `Segment` element
-minus the size of the `Element ID` and `Element Data Size` of that `Segment` element.
-The `Segment Position` of the first `Child Element` of the `Segment` element is 0.
-An element that is not stored within a `Segment` element, such as the elements of
-the `EBML Header`, do not have a `Segment Position`.
+The `Segment Position` of an element refers to the position of the
+first octet of the `Element ID` of that element, measured in octets,
+from the beginning of the `Element Data` section of the containing
+`Segment` element. In other words, the `Segment Position` of an
+element is the distance in octets from the beginning of its containing
+`Segment` element minus the size of the `Element ID` and
+`Element Data Size` of that `Segment` element.  The
+`Segment Position` of the first `Child Element` of the `Segment`
+element is 0.  An element that is not stored within a `Segment`
+element, such as the elements of the `EBML Header`, do not have a
+`Segment Position`.
 
 ## Segment Position Exception
 
@@ -838,9 +869,10 @@ of the `MuxingApp` element in the above example is "26 - 21" or "5".
 
 # Linked Segments
 
-Matroska provides several methods to link two or more `Segment` elements together to create
-a `Linked Segment`. A `Linked Segment` is a set of multiple `Segments` linked together into
-a single presentation by using Hard Linking or Medium Linking.
+Matroska provides several methods to link two or more `Segment`
+elements together to create a `Linked Segment`. A
+`Linked Segment` is a set of multiple `Segments` linked together into a
+single presentation by using Hard Linking or Medium Linking.
 
 All `Segments` within a `Linked Segment` **MUST** have a `SegmentUUID`.
 
@@ -918,22 +950,30 @@ Table: Hard Linking with Mixed UID Links{#hardLinkingMixedUIDs}
 
 ## Medium Linking
 
-Medium Linking creates relationships between `Segments` using `Ordered Chapters` ((#editionflagordered)) and the
-`ChapterSegmentUUID` element. A `Chapter Edition` with `Ordered Chapters` **MAY** contain
-`Chapters` elements that reference timestamp ranges from other `Segments`. The `Segment`
-referenced by the `Ordered Chapter` via the `ChapterSegmentUUID` element **SHOULD** be played as
-part of a `Linked Segment`.
+Medium Linking creates relationships between `Segments` using
+`Ordered Chapters` ((#editionflagordered)) and the
+`ChapterSegmentUUID` element. A `Chapter Edition` with
+`Ordered Chapters` **MAY** contain `Chapters`
+elements that reference timestamp ranges from other `Segments`. The
+`Segment` referenced by the `Ordered Chapter` via the
+`ChapterSegmentUUID` element **SHOULD** be played as part of
+a `Linked Segment`.
 
 The timestamps of `Segment` content referenced by `Ordered Chapters`
 **MUST** be adjusted according to the cumulative duration of the previous `Ordered Chapters`.
 
-As an example, a file named `intro.mkv` could have a `SegmentUUID` of "0xb16a58609fc7e60653a60c984fc11ead".
-Another file called `program.mkv` could use a `Chapter Edition` that contains two `Ordered Chapters`.
-The first chapter references the `Segment` of `intro.mkv` with the use of a `ChapterSegmentUUID`,
-`ChapterSegmentEditionUID`, `ChapterTimeStart`, and an optional `ChapterTimeEnd` element.
-The second chapter references content within the `Segment` of `program.mkv`. A `Matroska Player`
-**SHOULD** recognize the `Linked Segment` created by the use of `ChapterSegmentUUID` in an enabled
-`Edition` and present the reference content of the two `Segments` as a single presentation.
+As an example, a file named `intro.mkv` could have a
+`SegmentUUID` of "0xb16a58609fc7e60653a60c984fc11ead".  Another file
+called `program.mkv` could use a `Chapter Edition` that contains
+two `Ordered Chapters`.  The first chapter references the
+`Segment` of `intro.mkv` with the use of a
+`ChapterSegmentUUID`, `ChapterSegmentEditionUID`,
+`ChapterTimeStart`, and an optional `ChapterTimeEnd` element.
+The second chapter references content within the `Segment` of
+`program.mkv`. A `Matroska Player` **SHOULD**
+recognize the `Linked Segment` created by the use of
+`ChapterSegmentUUID` in an enabled `Edition` and present the
+reference content of the two `Segments` as a single presentation.
 
 The `ChapterSegmentUUID` represents the `Segment` that holds the content to play in place of the `Linked Chapter`.
 The `ChapterSegmentUUID` **MUST NOT** be the `SegmentUUID` of its own `Segment`.
@@ -946,8 +986,9 @@ There are two ways to use a chapter link:
 
 ### Linked-Duration
 
-A `Matroska Player` **MUST** play the content of the `Linked Segment`
-from the `ChapterTimeStart` until the `ChapterTimeEnd` timestamp in place of the `Linked Chapter`.
+A `Matroska Player` **MUST** play the content of the
+`Linked Segment` from the `ChapterTimeStart` until the
+`ChapterTimeEnd` timestamp in place of the `Linked Chapter`.
 
 `ChapterTimeStart` and `ChapterTimeEnd` represent timestamps in the `Linked Segment` matching the value of `ChapterSegmentUUID`.
 Their values **MUST** be in the range of the `Linked Segment` duration.
@@ -969,51 +1010,62 @@ When using Linked-Edition chapter linking, `ChapterTimeEnd` is **OPTIONAL**.
 
 ## Default Flag
 
-The Default flag is a hint for a `Matroska Player` indicating that a given track
-**SHOULD** be eligible to be automatically selected as the default track for a given
-language. If no tracks in a given language have the Default flag set, then all tracks
-in that language are eligible for automatic selection. This can be used to indicate that
-a track provides "regular service" that is suitable for users with default settings, as opposed to
-specialized services, such as commentary, captions for users with hearing impairments, or descriptive audio.
+The Default flag is a hint for a `Matroska Player` indicating that a
+given track **SHOULD** be eligible to be automatically selected as
+the default track for a given language. If no tracks in a given language have
+the Default flag set, then all tracks in that language are eligible for
+automatic selection. This can be used to indicate that a track provides
+"regular service" that is suitable for users with default settings, as opposed
+to specialized services, such as commentary, captions for users with hearing
+impairments, or descriptive audio.
 
-The `Matroska Player` **MAY** override the Default flag for any reason, including
-user preferences to prefer tracks providing accessibility services.
+The `Matroska Player` **MAY** override the Default flag
+for any reason, including user preferences to prefer tracks providing
+accessibility services.
 
 ## Forced Flag
 
-The Forced flag tells the `Matroska Player` that it **SHOULD** display this subtitle track,
-even if user preferences usually would not call for any subtitles to be displayed alongside
-the audio track that is currently selected. This can be used to indicate that a track contains translations
-of on-screen text or dialogue spoken in a different language than the track's primary language.
+The Forced flag tells the `Matroska Player` that it
+**SHOULD** display this subtitle track, even if user preferences
+usually would not call for any subtitles to be displayed alongside the audio
+track that is currently selected. This can be used to indicate that a track
+contains translations of on-screen text or dialogue spoken in a different
+language than the track's primary language.
 
 ## Hearing-Impaired Flag
 
-The Hearing-Impaired flag tells the `Matroska Player` that it **SHOULD** prefer this track
-when selecting a default track for a user with a hearing impairment and that it **MAY** prefer to select
-a different track when selecting a default track for a user that is not hearing impaired.
+The Hearing-Impaired flag tells the `Matroska Player` that it
+**SHOULD** prefer this track when selecting a default track for a
+user with a hearing impairment and that it **MAY** prefer to select
+a different track when selecting a default track for a user that is not
+hearing impaired.
 
 ## Visual-Impaired Flag
 
-The Visual-Impaired flag tells the `Matroska Player` that it **SHOULD** prefer this track
-when selecting a default track for a user with a visual impairment and that it **MAY** prefer to select
-a different track when selecting a default track for a user that is not visually impaired.
+The Visual-Impaired flag tells the `Matroska Player` that it
+**SHOULD** prefer this track when selecting a default track for a
+user with a visual impairment and that it **MAY** prefer to select
+a different track when selecting a default track for a user that is not
+visually impaired.
 
 ## Descriptions Flag
 
-The Descriptions flag tells the `Matroska Player` that this track is suitable to play via
-a text-to-speech system for a user with a visual impairment and that it **SHOULD NOT** automatically
-select this track when selecting a default track for a user that is not visually impaired.
+The Descriptions flag tells the `Matroska Player` that this track is
+suitable to play via a text-to-speech system for a user with a visual
+impairment and that it **SHOULD NOT** automatically select this
+track when selecting a default track for a user that is not visually
+impaired.
 
 ## Original Flag
 
-The Original flag tells the `Matroska Player` that this track is in the original language
-and that it **SHOULD** prefer this track if configured to prefer original-language tracks of this
-track's type.
+The Original flag tells the `Matroska Player` that this track is in
+the original language and that it **SHOULD** prefer this track if
+configured to prefer original-language tracks of this track's type.
 
 ## Commentary Flag
 
-The Commentary flag tells the `Matroska Player` that this track contains commentary on
-the content.
+The Commentary flag tells the `Matroska Player` that this track
+contains commentary on the content.
 
 ## Track Operation
 
@@ -1026,12 +1078,14 @@ However, the codec ID is meaningless because each "sub" track needs to be decode
 own decoder before the "operation" is applied. The `Cues` elements corresponding to such
 a virtual track **SHOULD** be the union of the `Cues` elements for each of the tracks it's composed of (when the `Cues` are defined per track).
 
-In the case of `TrackJoinBlocks`, the `Block` elements (from `BlockGroup` and `SimpleBlock`)
-of all the tracks **SHOULD** be used as if they were defined for this new virtual `Track`.
-When two `Block` elements have overlapping start or end timestamps, it's up to the underlying
-system to either drop some of these frames or render them the way they overlap.
-This situation **SHOULD** be avoided when creating such tracks, as you can never be sure
-of the end result on different platforms.
+In the case of `TrackJoinBlocks`, the `Block` elements (from
+`BlockGroup` and `SimpleBlock`) of all the tracks
+**SHOULD** be used as if they were defined for this new virtual
+`Track`.  When two `Block` elements have overlapping start or
+end timestamps, it's up to the underlying system to either drop some of these
+frames or render them the way they overlap.  This situation
+**SHOULD** be avoided when creating such tracks, as you can never
+be sure of the end result on different platforms.
 
 ## Overlay Track
 
@@ -1045,14 +1099,17 @@ There are two different ways to compress 3D videos: have each eye track in a sep
 and have one track have both eyes combined inside (which is more efficient compression-wise).
 Matroska supports both ways.
 
-For the single-track variant, there is the `StereoMode` element, which defines how planes are
-assembled in the track (mono or left-right combined). Odd values of `StereoMode` means the left
-plane comes first for more convenient reading. The pixel count of the track (`PixelWidth`/`PixelHeight`)
-is the raw number of pixels (for example, 3840x1080 for full HD side by side), and the
-`DisplayWidth`/`DisplayHeight`
-in pixels is the number of pixels for one plane (1920x1080 for that full HD stream).
-Old stereo 3D movies were displayed using anaglyph (cyan and red colors separated).
-For compatibility with such movies, there is a value of the `StereoMode` that corresponds to anaglyph.
+For the single-track variant, there is the `StereoMode` element,
+which defines how planes are assembled in the track (mono or left-right
+combined). Odd values of `StereoMode` means the left plane comes first
+for more convenient reading. The pixel count of the track
+(`PixelWidth`/`PixelHeight`) is the raw number of pixels (for
+example, 3840x1080 for full HD side by side), and the
+`DisplayWidth`/`DisplayHeight` in pixels is the number of pixels
+for one plane (1920x1080 for that full HD stream).  Old stereo 3D movies were
+displayed using anaglyph (cyan and red colors separated).  For compatibility
+with such movies, there is a value of the `StereoMode` that corresponds
+to anaglyph.
 
 There is also a "packed" mode (values 13 and 14) that consists of packing two frames together
 in a `Block` that uses lacing. The first frame is the left eye and the other frame is the right eye
@@ -1065,24 +1122,31 @@ For separate tracks, Matroska needs to define exactly which track does what.
 
 The 3D support is still in infancy and may evolve to support more features.
 
-The `StereoMode` used to be part of Matroska v2, but it didn't meet the requirement
-for multiple tracks. There was also a bug in [@?libmatroska] prior to 0.9.0 that would save/read
-it as `0x53B9` instead of `0x53B8`; see `OldStereoMode` ((#oldstereomode-element)). `Matroska Readers` **MAY** support these legacy files by checking
-Matroska v2 or `0x53B9`.
-The older values of `StereoMode` were 0 (mono), 1 (right eye), 2 (left eye), and 3 (both eyes); these are the only values that can be found in `OldStereoMode`.
-They are not compatible with the `StereoMode` values found in Matroska v3 and above.
+The `StereoMode` used to be part of Matroska v2, but it didn't meet the
+requirement for multiple tracks. There was also a bug in
+[@?libmatroska] prior to 0.9.0 that would save/read it as
+`0x53B9` instead of `0x53B8`; see `OldStereoMode` ((#oldstereomode-element)). `Matroska Readers`
+**MAY** support these legacy files by checking Matroska v2 or
+`0x53B9`.  The older values of `StereoMode` were 0 (mono), 1 (right eye),
+2 (left eye), and 3 (both eyes); these are the only values that can be found
+in `OldStereoMode`.  They are not compatible with the `StereoMode` values found in
+Matroska v3 and above.
 
 
 # Default Track Selection
 
-This section provides some example sets of `Tracks` and hypothetical user settings, along with
-indications of which ones a similarly configured `Matroska Player` **SHOULD** automatically
-select for playback by default in such a situation. A player **MAY** provide additional settings
-with more detailed controls for more nuanced scenarios. These examples are provided as guidelines
-to illustrate the intended usages of the various supported `Track` flags and their expected behaviors.
+This section provides some example sets of `Tracks` and hypothetical
+user settings, along with indications of which ones a similarly configured
+`Matroska Player` **SHOULD** automatically select for
+playback by default in such a situation. A player **MAY** provide
+additional settings with more detailed controls for more nuanced
+scenarios. These examples are provided as guidelines to illustrate the
+intended usages of the various supported `Track` flags and their
+expected behaviors.
 
-`Track` names are shown in English for illustrative purposes; actual files may have titles
-in the language of each track or provide titles in multiple languages.
+`Track` names are shown in English for illustrative purposes; actual
+files may have titles in the language of each track or provide titles in
+multiple languages.
 
 ## Audio Selection
 
@@ -1106,9 +1170,11 @@ The English tracks all have the Original flag, indicating that English is the or
 
 Generally, the player will first consider the track languages. If the player has an option to prefer
 original-language audio and the user has enabled it, then it should prefer one of the tracks with the Original flag.
-If the user has configured to specifically prefer audio tracks in English or Spanish, the player should select one of
-the tracks in the corresponding language. The player may also wish to prefer a track with the Original flag
-if no tracks matching any of the user's explicitly preferred languages are available.
+If the user has configured to specifically prefer audio tracks in English or
+Spanish, the player should select one of the tracks in the corresponding
+language. The player may also wish to prefer a track with the Original flag if
+no tracks matching any of the user's explicitly preferred languages are
+available.
 
 Two of the tracks have the Visual-Impaired flag. If the player has been configured to prefer such tracks,
 it should select one; otherwise, it should avoid them if possible.

--- a/ordering.md
+++ b/ordering.md
@@ -48,7 +48,7 @@ Additionally, the second `SeekHead` element **MUST** only reference `Cluster` el
 and not any other `Top-Level Element` already contained within the first `SeekHead` element.
 
 The second `SeekHead` element **MAY** be stored in any order relative to the other `Top-Level Elements`.
-Whether one or two `SeekHead` elements are used, the `SeekHead ` element(s) **MUST**
+Whether one or two `SeekHead` elements are used, the `SeekHead` element(s) **MUST**
 collectively reference the identity and position of all `Top-Level Elements` except
 for the first `SeekHead` element.
 
@@ -69,7 +69,7 @@ The first `Info` element **SHOULD** occur before the first `Tracks` element and 
 
 ## Chapters Element
 
-The `Chapters` element **SHOULD** be placed before the `Cluster ` element(s). The
+The `Chapters` element **SHOULD** be placed before the `Cluster` element(s). The
 `Chapters` element can be used during playback even if the user does not need to seek.
 It immediately gives the user information about what section is being read and what
 other sections are available.

--- a/ordering.md
+++ b/ordering.md
@@ -1,10 +1,12 @@
 # Matroska Element Ordering
 
-With the exceptions of the `EBML Header` and the `CRC-32` element, the EBML specification [@!RFC8794] does not
-require any particular storage order for elements. However, this specification
-defines mandates and recommendations for ordering certain elements to facilitate
-better playback, seeking, and editing efficiency. This section describes and offers
-rationale for ordering requirements and recommendations for Matroska.
+With the exceptions of the `EBML Header` and the `CRC-32`
+element, the EBML specification [@!RFC8794] does not require any
+particular storage order for elements. However, this specification defines
+mandates and recommendations for ordering certain elements to facilitate
+better playback, seeking, and editing efficiency. This section describes and
+offers rationale for ordering requirements and recommendations for
+Matroska.
 
 ## Top-Level Elements
 
@@ -18,16 +20,16 @@ All `Top-Level Elements` **MUST** use a 4-octet EBML Element ID.
 When using Medium Linking, chapters are used to reference other `Segments` to play in a given order (see (#medium-linking)).
 A `Segment` containing these `Linked Chapters` does not require a `Tracks` element or a `Cluster` element.
 
-It is possible to edit a Matroska file after it has been created. For example, chapters,
-tags, or attachments can be added. When new `Top-Level Elements` are added to a Matroska file,
-the `SeekHead` element(s) **MUST** be updated so that the `SeekHead` element(s) itemizes
-the identity and position of all `Top-Level Elements`.
+It is possible to edit a Matroska file after it has been created. For
+example, chapters, tags, or attachments can be added. When new `Top-Level Elements`
+are added to a Matroska file, the `SeekHead` element(s)
+**MUST** be updated so that the `SeekHead` element(s)
+itemizes the identity and position of all `Top-Level Elements`.
 
-Editing, removing, or adding
-elements to a Matroska file often requires that some existing elements be voided
-or extended.
-Transforming the existing elements into `Void` elements as padding can be used
-as a method to avoid moving large amounts of data around.
+Editing, removing, or adding elements to a Matroska file often requires
+that some existing elements be voided or extended.  Transforming the existing
+elements into `Void` elements as padding can be used as a method to
+avoid moving large amounts of data around.
 
 ## CRC-32
 

--- a/rfc_backmatter_matroska.md
+++ b/rfc_backmatter_matroska.md
@@ -25,7 +25,7 @@
   </front>
 </reference>
 
-<reference anchor="CIE-1931" target="https://en.wikipedia.org/wiki/CIE_1931_color_space">
+<reference anchor="CIE-1931" target="https://en.wikipedia.org/w/index.php?title=CIE_1931_color_space&amp;oldid=1242811504">
   <front>
     <title>CIE 1931 color space</title>
     <author>

--- a/streaming.md
+++ b/streaming.md
@@ -8,9 +8,11 @@ File access can simply be reading a file located on your computer, but it also i
 accessing a file from an HTTP (web) server or Common Internet File System (CIFS) (Windows share) server. These protocols
 are usually safe from reading errors, and seeking in the stream is possible. However,
 when a file is stored far away or on a slow server, seeking can be an expensive operation
-and should be avoided. When followed, the guidelines in (#implementation-recommendations) help reduce the number
-of seeking operations for regular playback and also have the playback start quickly without
-needing to read lot of data first (like a `Cues` element, `Attachments` element, or `SeekHead` element).
+and should be avoided.
+When followed, the guidelines in (#implementation-recommendations) help reduce the number of
+seeking operations for regular playback and also have the playback start
+quickly without needing to read lot of data first (like a `Cues` element,
+`Attachments` element, or `SeekHead` element).
 
 Matroska, having a small overhead, is well suited for storing music/videos on file
 servers without a big impact on the bandwidth used. Matroska does not require the index
@@ -26,19 +28,23 @@ in Matroska. Additionally, having the same information at the RTP and Matroska l
 be a source of confusion if they do not match.
 Livestreaming of Matroska over file-like protocols like HTTP, QUIC, etc., is possible.
 
-A live Matroska stream is different from a file because it usually has no known end
-(only ending when the client disconnects). For this, all bits of the "size" portion
-of the `Segment` element **MUST** be set to 1. Another option is to concatenate `Segment` elements
-with known sizes, one after the other. This solution allows a change of codec/resolution
-between each segment. For example, this allows for a switch between 4:3 and 16:9 in a television program.
+A live Matroska stream is different from a file because it usually has no
+known end (only ending when the client disconnects). For this, all bits of the
+"size" portion of the `Segment` element **MUST** be set to
+1. Another option is to concatenate `Segment` elements with known
+sizes, one after the other. This solution allows a change of codec/resolution
+between each segment. For example, this allows for a switch between 4:3 and
+16:9 in a television program.
 
-When `Segment` elements are continuous, certain elements (like `SeekHead`, `Cues`,
-`Chapters`, and `Attachments`) **MUST NOT** be used.
+When `Segment` elements are continuous, certain elements (like
+`SeekHead`, `Cues`, `Chapters`, and `Attachments`)
+**MUST NOT** be used.
 
-It is possible for a `Matroska Player` to detect that a stream is not seekable.
-If the stream has neither a `SeekHead` list nor a `Cues` list at the beginning of the stream,
-it **SHOULD** be considered non-seekable. Even though it is possible to seek forward
-in the stream, it is **NOT RECOMMENDED**.
+It is possible for a `Matroska Player` to detect that a stream is
+not seekable. If the stream has neither a `SeekHead` list nor a
+`Cues` list at the beginning of the stream, it **SHOULD** be
+considered non-seekable. Even though it is possible to seek forward in the
+stream, it is **NOT RECOMMENDED**.
 
 In the context of live radio or web TV, it is possible to "tag" the content while it is
 playing. The `Tags` element can be placed between `Clusters` each time it is necessary.

--- a/tags-precedence.md
+++ b/tags-precedence.md
@@ -23,7 +23,7 @@ and keep the tags matching these values if tags are also used.
 
 ## Tag Levels
 
-Tag elements allow tagging information on multiple levels, with each level having a `TargetTypeValue` (#targettypevalue-element).
+Tag elements allow tagging information on multiple levels, with each level having a `TargetTypeValue` ((#targettypevalue-element)).
 An element for a given `TargetTypeValue` also applies to the lower levels denoted by smaller `TargetTypeValue` values. If an upper value
 doesn't apply to a level but the actual value to use is not known,
 an empty `TagString` ((#tagstring-element)) or an empty `TagBinary` ((#tagbinary-element)) **MUST** be used as the tag value for this level.

--- a/tags-precedence.md
+++ b/tags-precedence.md
@@ -17,8 +17,10 @@ The following Matroska elements can also be defined with tags:
 When both values exist in the file, the value found in Tags takes precedence over the value found in the original location of the element.
 For example, if you have a `TrackEntry\Name` element and a tag value `TITLE` for that track in a Matroska `Segment`, the tag value string **SHOULD** be used instead of the `TrackEntry\Name` string to identify the track.
 
-As the Tag element is optional, a lot of `Matroska Readers` do not handle it and will not use the tags value when it's found.
-Thus, for maximum compatibility, it's usually better to put the strings in the `TrackEntry`, `ChapterAtom`, and `Attachments` elements
+As the Tag element is optional, a lot of `Matroska Readers` do not
+handle it and will not use the tags value when it's found.  Thus, for maximum
+compatibility, it's usually better to put the strings in the
+`TrackEntry`, `ChapterAtom`, and `Attachments` elements
 and keep the tags matching these values if tags are also used.
 
 ## Tag Levels

--- a/transforms/ebml_schema2markdown4iana_ids.xsl
+++ b/transforms/ebml_schema2markdown4iana_ids.xsl
@@ -86,7 +86,7 @@
   <xsl:template name="GenerateInvalid">
     <xsl:param name="id"/>
     <xsl:value-of select="$id"/>
-    <xsl:text> | Not valid for use as an Element ID | RFC 9559</xsl:text>
+    <xsl:text> | Not valid for use as an Element ID | RFC 9559, (#matroska-element-ids-registry)</xsl:text>
     <xsl:text>&#xa;</xsl:text>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
With a lot of (unnecessary) line changes.

There are still some tiny differences with the original XML:
- some XML tags are split on 2 lines (impossible with mmark)
- some extra lines endings
- some compact formatting of sections not possible with mmark