### PR TITLE
Add A_OPUS audio codec

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -757,6 +757,28 @@ AAC audio always uses wFormatTag 0xFF.
 
 Initialization: none
 
+### A_OPUS
+
+Codec ID: A_OPUS
+
+Codec Name: Opus interactive speech and audio codec
+
+Description: The OPUS audio codec defined by [@!RFC6716] using a similar encapsulation as the Ogg Encapsulation [@!RFC7845].
+
+Initialization: The track `CodecPrivate` **MUST** be present and contain the `Identification Header` defined in [@!RFC7845, section 5.1].
+
+Channels: The track `Channels` element value **MUST** be the "Output Channel Count" value of the `Identification Header`.
+
+SamplingFrequency: The track `SamplingFrequency` element value **MUST** be the "Input Sample Rate" value of the `Identification Header`.
+
+CodecDelay: The track `CodecDelay` element **MUST** be present and set to the "Pre-skip" value of the `Identification Header` translated to Matroska Ticks.
+The "Pre-skip" value is in samples at 48,000 Hz. The formula to get the `CodecDelay` is:
+
+    CodecDelay = pre-skip * 1,000,000,000 / 48,000.
+
+SeekPreRoll: The track `SeekPreRoll` element **SHOULD** be present and set to 80,000,000 -- 80 ms in Matroska Ticks --
+in order to ensure that the output audio is correct by the time it reaches the seek target.
+
 ### A_QUICKTIME
 
 Codec ID: A_QUICKTIME


### PR DESCRIPTION
Replaces #106 

The formatting may evolve later on how we need to map existing values in a format into the Matroska fields. For example using the EBML Path of each field we need to set would be nice.

The 80 ms SeekPreRoll comes from https://wiki.xiph.org/MatroskaOpus and that's also the value set in [mkvmerge](https://gitlab.com/mbunkus/mkvtoolnix/-/blob/7a32d31e7029b1ca4f323eb0f7fb975ec979b089/src/output/p_opus.cpp#L41) and [set](https://github.com/FFmpeg/FFmpeg/blob/3565903c638fb77d600d2983701b12300e695a5d/libavformat/matroskaenc.c#L2039) in [libavformat](https://github.com/FFmpeg/FFmpeg/blob/3565903c638fb77d600d2983701b12300e695a5d/libavformat/matroskaenc.c#L281).