### PR TITLE
add subtitles codecs found in Haali's list

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -869,6 +869,21 @@ Codec Name: Advanced Subtitles Format
 Description: The [Script Info] and [V4 Styles] sections are stored in the codecprivate. Each event is stored in its own `Block`.
 For more information see (#ssa-ass-subtitles) on SSA/ASS.
 
+### S_TEXT/USF
+
+Codec ID: S_TEXT/USF
+
+Codec Name: Universal Subtitle Format
+
+Description: An XML based subtitle format.
+Each `BlockGroup` contains XML data from a "subtitle" XML element as defined in section 3.4 of [@!USF],
+without the "subtitle" element itself and with the start, stop duration mapped to the `BlockGroup` timestamp and `BlockDuration` element.
+The "image" XML elements are turned into Matroska attachements and replaced in the stream with their attachment filename.
+
+Initialization: The `CodecPrivate` element **MAY** be present.
+If present it **MAY** contains "metadata", "styles" and "effects" XML elements usable in the whole stream inside a parent "USFSubtitles" XML parent element,
+similar to the "USFSubtitles" element of a standalone USF file but without the "subtitles" XML element.
+
 ### S_TEXT/WEBVTT
 
 Codec ID: S_TEXT/WEBVTT

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -835,6 +835,14 @@ Initialization: None
 
 ## Subtitle Codec Mappings
 
+### S_TEXT/ASCII
+
+Codec ID: S_TEXT/ASCII
+
+Codec Name: ASCII Plain Text
+
+Description: Basic text subtitles with only ASCII characters allowed.
+
 ### S_TEXT/UTF8
 
 Codec ID: S_TEXT/UTF8

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -130,3 +130,14 @@
     <date year="2022" month="October" day="6"/>
   </front>
 </reference>
+
+<reference anchor="USF" target="https://subtitld.org/en/development/usf">
+  <front>
+    <title>Universal Subtitle Format</title>
+    <author fullname='Christophe PARIS'/>
+    <author fullname='Ludovic Vialle'><organization>CoreCodec</organization></author>
+    <author fullname='Uffe Hammer'/>
+    <date year="2010" month="November" day="28"/>
+  </front>
+</reference>
+


### PR DESCRIPTION
As found in https://haali.net/mkv/codecs.pdf and VLC and libavformat.

`V_SNOW` has been left out because it's quite exotic.

Fixes #420 and #78