### PR TITLE
Store the ReplayGain tag values as strings

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -308,12 +308,15 @@ The majority of the contemporary rock and pop music you hear on the radio these 
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
 the same tone as the musical piece (e.g., "441.34" in Hertz). The default value is 440.0 Hz.</description>
     </tag>
-    <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="binary">
-      <description lang="en">The gain to apply to reach 89dB SPL on playback. This is based on the [@!ReplayGain] standard.
-Note that ReplayGain information can be found at all TargetType levels (track, album, etc).</description>
+    <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8">
+      <description lang="en">The gain to apply to reach 89dB SPL on playback. The value is computed according to the [@!ReplayGain] standard.
+      The value in decibels (dB) is stored as a string (e.g., "-0.42 dB"). The decibel unit is **OPTIONAL**.
+      Note that ReplayGain information can be found at all TargetType levels (track, album, etc).</description>
     </tag>
-    <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="binary">
-      <description lang="en">The maximum absolute peak value of the item. This is based on the [@!ReplayGain] standard.</description>
+    <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8">
+      <description lang="en">The maximum absolute peak amplitude of the item. The value is computed according to the [@!ReplayGain] standard.
+      The value is a normalized absolute sample value of the target audio stored as a string without spaces (e.g., "1.0129").
+      Note that ReplayGain information can be found at all TargetType levels (track, album, etc).</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">
       <description lang="en">The International Standard Recording Code [@!ISRC],


### PR DESCRIPTION
This is how it's stored in Vorbis [1][2] and how
mkvmerge passes the value from one to the other [3]. There doesn't seem to be any player reading it from Matroska.

[1] https://code.videolan.org/videolan/vlc/-/blob/f1a90394435471e75fee6f13383079a3d0272ec4/modules/demux/xiph_metadata.c#L472
[2] https://github.com/FFmpeg/FFmpeg/blob/153a6dc8faafc4de263a493484ffc1dc2b5b26b2/libavformat/replaygain.c
[3] https://gitlab.com/mbunkus/mkvtoolnix/-/blob/7a32d31e7029b1ca4f323eb0f7fb975ec979b089/src/common/tags/vorbis.cpp#L78

I would have preferred a binary version of a float value to avoid parsing errors. But for backward compatibility it's probably better to keep it like this. Unless mkvmerge ends up turning Vorbis replay gain into a binary format ? I don't know the code enough to tell for sure, cc @mbunkus.