### PR TITLE
add EBU R128 loudness/peak value tags

### DIFF
--- a/cellar-tags/rfc_backmatter_tags.md
+++ b/cellar-tags/rfc_backmatter_tags.md
@@ -10,6 +10,30 @@
   </front>
 </reference>
 
+<reference anchor="EBU-R.128" target="https://tech.ebu.ch/publications/r128/">
+  <front>
+    <title>LOUDNESS NORMALISATION AND PERMITTED MAXIMUM LEVEL OF AUDIO SIGNALS</title>
+    <author/>
+     <date month="November" year="2023" />
+  </front>
+</reference>
+
+<reference anchor="EBU-TECH.3341" target="https://tech.ebu.ch/publications/tech3341">
+  <front>
+    <title>LOUDNESS METERING: ‘EBU MODE’ METERING TO SUPPLEMENT EBU R 128 LOUDNESS NORMALIZATION</title>
+    <author/>
+     <date month="November" year="2023" />
+  </front>
+</reference>
+
+<reference anchor="EBU-TECH.3342" target="https://tech.ebu.ch/publications/tech3342">
+  <front>
+    <title>LOUDNESS RANGE: A MEASURE TO SUPPLEMENT EBU R 128 LOUDNESS NORMALIZATION</title>
+    <author/>
+     <date month="November" year="2023" />
+  </front>
+</reference>
+
 <reference anchor="GS1" target="https://www.gs1.org/standards/barcodes-epcrfid-id-keys/gs1-general-specifications">
   <front>
     <title>GS1 General Specifications</title>
@@ -26,6 +50,16 @@
      <author fullname='Dirk Mahoney' role='editor'><organization/></author>
      <author fullname='Johan Sundstrom' role='editor'><organization/></author>
      <date day="3" month="February" year="1999" />
+  </front>
+</reference>
+
+<reference anchor="IEEE.754" target="https://standards.ieee.org/standard/754-2019.html">
+  <front>
+    <title>IEEE Standard for Binary Floating-Point Arithmetic</title>
+    <author>
+      <organization>IEEE</organization>
+    </author>
+    <date year="2019" month="June" day="13"/>
   </front>
 </reference>
 

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -340,6 +340,28 @@ the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stor
       The value is a normalized absolute sample value of the target audio, using the Float number defined in (#number-tags-formatting) (e.g., "1.0129").
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
+    <tag name="EBU_R128_LOUDNESS" class="Technical Information" type="binary">
+      <description lang="en">EBU R 128 Loudness.
+      The value is the Loudness relative to nominal full scale in LUFS (Loudness Units Full Scale) normalized to a Target Level of -23.0 LUFS as defined in [@!EBU-R.128].
+      This value is stored as a floating-point number in the 32-bit and 64-bit binary interchange format, as defined in [@!IEEE.754]. It is similar to a EBML floating number value [@?RFC8794, section 7.3].</description>
+    </tag>
+    <tag name="EBU_R128_MAX_TRUE_PEAK" class="Technical Information" type="binary">
+      <description lang="en">EBU R 128 Maximum True Peak Level.
+      This corresponds to the maximum value of the audio signal waveform of a programme in the continuous time domain, measured in dB True Peak (dBTP), as defined in [@!EBU-R.128].
+      This value is stored as a floating-point number in the 32-bit and 64-bit binary interchange format, as defined in [@!IEEE.754]. It is similar to a EBML floating number value [@?RFC8794, section 7.3].</description>
+    </tag>
+    <tag name="EBU_R128_LOUDNESS_RANGE" class="Technical Information" type="binary">
+      <description lang="en">EBU R 128 Loudness Range, measures the variation in a time-varying loudness measurement, in LU (Loudness Units) as defined in [@!EBU-TECH.3342].
+      This value is stored as a floating-point number in the 32-bit and 64-bit binary interchange format, as defined in [@!IEEE.754]. It is similar to a EBML floating number value [@?RFC8794, section 7.3].</description>
+    </tag>
+    <tag name="EBU_R128_MAX_MOMENTARY_LOUDNESS" class="Technical Information" type="binary">
+      <description lang="en">EBU R 128 Maximum Momentary Loudness, measures the variation of loudness on a 0.4 s sliding rectangular window, in LUFS (Loudness Units Full Scale) as defined in [@!EBU-TECH.3341].
+      This value is stored as a floating-point number in the 32-bit and 64-bit binary interchange format, as defined in [@!IEEE.754]. It is similar to a EBML floating number value [@?RFC8794, section 7.3].</description>
+    </tag>
+    <tag name="EBU_R128_MAX_SHORT_LOUDNESS" class="Technical Information" type="binary">
+      <description lang="en">EBU R 128 Maximum Short-Term Loudness, measures the variation of loudness on a 3 s sliding rectangular window, in LUFS (Loudness Units Full Scale) as defined in [@!EBU-TECH.3341].
+      This value is stored as a floating-point number in the 32-bit and 64-bit binary interchange format, as defined in [@!IEEE.754]. It is similar to a EBML floating number value [@?RFC8794, section 7.3].</description>
+    </tag>
 
     <tag name="ISRC" class="External Identifiers" type="UTF-8">
       <description lang="en">The International Standard Recording Code [@!ISRC],


### PR DESCRIPTION
It seems for the ITU_BS_1770_LUFS we can just tell to normalize to -23, and for other sources the values should be shifted ? cc @bb010g 