### PR TITLE
Add zstd compression

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1202,6 +1202,9 @@ Each block **MUST** be decompressable, even if no previous block is available in
       <enum value="3" label="Header Stripping">
         <documentation lang="en" purpose="definition">Octets in `ContentCompSettings` ((#contentcompsettings-element)) have been stripped from each frame.</documentation>
       </enum>
+      <enum value="4" label="Zstandard" minver="5">
+        <documentation lang="en" purpose="definition">Zstandard (zstd) compression [@!RFC8878].</documentation>
+      </enum>
     </restriction>
     <extension type="stream copy" keep="1"/>
   </element>

--- a/matroska5_body.md
+++ b/matroska5_body.md
@@ -129,3 +129,11 @@ definition:
 : One language corresponding to the EditionString,
 in the form defined in [@!RFC5646]; see [@!RFC9559, section 12] on language codes.
 
+# Zstandard Compression
+
+This document adds value "4" to the `ContentCompAlgo` element ([@RFC9559, section 5.1.4.1.31.6]).
+It corresponds to the Zstandard (zstd) compression algorithm [@!RFC8878].
+
+When the Zstandard compression algorithm is used, the `ContentCompSettings` element ([@RFC9559, section 5.1.4.1.31.7])
+**MAY** optionally contain a dictionary to improve compression efficiency.
+

--- a/matroska5_iana.md
+++ b/matroska5_iana.md
@@ -2,3 +2,7 @@
 
 ## Matroska Element IDs Registry Additions
 
+## Matroska Compression Algorithms Registry Additions
+
+This document adds value "4" to the "Matroska Compression Algorithms" registry.
+It corresponds to the Zstandard compression algorithm described in section (#zstandard-compression).


### PR DESCRIPTION
Based on #423 but for the v5 document.

Keeping as draft because the use of a [dictionary may not be usable](https://www.rfc-editor.org/rfc/rfc8878.html#name-use-of-dictionaries) in the wild (it requires a state ? which makes seeking inmpossible).

Also, as said in https://github.com/ietf-wg-cellar/matroska-specification/pull/423#issuecomment-1037982014, there is a header to the Zstandard stream that we should strip. In that case we should explain what needs to be stripped.