### PR TITLE
Add more tag formatting constraints

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -364,10 +364,10 @@ This holds the same information as the "MCDI" in [@!ID3v2.3].</description>
       <description lang="en">The TV Database [@!TheTVDB] tag which can include movies. The variable length digits string representing a "Series ID", "Episode ID" or "Movie ID" identifier **MUST** be prefixed with "series/", "episodes/", or "movies/", respectively.</description>
     </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
-      <description lang="en">URL to purchase this file. This is akin to the "WPAY" tag in [@!ID3v2.3].</description>
+      <description lang="en">URL to purchase this file using the URL format defined in [@!RFC3986]. This is akin to the "WPAY" tag in [@!ID3v2.3].</description>
     </tag>
     <tag name="PURCHASE_INFO" class="Commercial" type="UTF-8">
-      <description lang="en">Information on where to purchase this album. This is akin to the "WCOM" tag in [@!ID3v2.3].</description>
+      <description lang="en">Information on where to purchase this album using the URL format defined in [@!RFC3986]. This is akin to the "WCOM" tag in [@!ID3v2.3].</description>
     </tag>
     <tag name="PURCHASE_OWNER" class="Commercial" type="UTF-8">
       <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2.3].</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -32,7 +32,7 @@ All tags can be used "under" the "SAMPLE" tag like "TITLE", "ARTIST", "DATE_RELE
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
       <description lang="en">The name of the country
 that is meant to have other tags inside (using nested tags) to country specific information about the item,
-in the Matroska countries form, i.e. [@!RFC5646] two-letter region subtags, without the UK exception.
+using the Country Code format defined in (#tag-formatting).
 All tags can be used "under" the "COUNTRY" tag like "LABEL", "RATING", etc.
 </description>
     </tag>
@@ -71,7 +71,7 @@ It **SHOULD** be a child of the following tags: "ARTIST", "LEAD_PERFORMER", or "
       <description lang="en">Email corresponding to the tag it's included in, using the "Addr-Spec" format defined in [@!RFC5322, section 3.4.1].</description>
     </tag>
     <tag name="ADDRESS" class="Nested Information" type="UTF-8">
-      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code.
+      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code using the Country Code format defined in (#tag-formatting).
 It can be useful for a recording label.</description>
     </tag>
     <tag name="FAX" class="Nested Information" type="UTF-8">
@@ -262,7 +262,7 @@ an age in other countries or a URI defining a logo).</description>
     </tag>
     <tag name="RECORDING_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">The location where the item was recorded,
-in the Matroska countries form, i.e. [@!RFC5646] two-letter region subtags, without the UK exception.
+using the Country Code format defined in (#tag-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example,
 "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state
@@ -270,7 +270,7 @@ is unknown, but you want to store the city, simply leave a space between the two
     </tag>
     <tag name="COMPOSITION_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">Location that the item was originally designed/written,
-in the Matroska countries form, i.e. [@!RFC5646] two-letter region subtags, without the UK exception.
+using the Country Code format defined in (#tag-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city.
 For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown,
@@ -278,7 +278,7 @@ but you want to store the city, simply leave a space between the two commas. For
     </tag>
     <tag name="COMPOSER_NATIONALITY" class="Spatial Information" type="UTF-8">
       <description lang="en">Nationality of the main composer of the item, mostly for classical music,
-in the Matroska countries form, i.e. [@!RFC5646] two-letter region subtags, without the UK exception.</description>
+using the Country Code format defined in (#tag-formatting).</description>
     </tag>
     <tag name="COMMENT" class="Personal" type="UTF-8">
       <description lang="en">Any comment related to the content.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -69,7 +69,7 @@ Or "Marley Bob" and "Marley Robert Nesta" (no comma needed).</description>
 It **SHOULD** be a child of the following tags: "ARTIST", "LEAD_PERFORMER", or "ACCOMPANIMENT".</description>
     </tag>
     <tag name="EMAIL" class="Nested Information" type="UTF-8">
-      <description lang="en">Email corresponding to the tag it's included in.</description>
+      <description lang="en">Email corresponding to the tag it's included in, using the "Addr-Spec" format defined in [@!RFC5322, section 3.4.1].</description>
     </tag>
     <tag name="ADDRESS" class="Nested Information" type="UTF-8">
       <description lang="en">The physical address of the entity. The address **SHOULD** include a country code.

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -288,7 +288,7 @@ using the Country Code format defined in (#tag-formatting).</description>
     </tag>
     <tag name="RATING" class="Personal" type="UTF-8">
       <description lang="en">A numeric value defining how much a person likes the song/movie. The number is between
-0 and 5 with decimal values possible (e.g., 2.7), 5(.0) being the highest possible rating.
+0 and 5 with stored using the Float number defined in (#tag-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
 Other rating systems with different ranges will have to be scaled.</description>
     </tag>
     <tag name="ENCODER" class="Technical Information" type="UTF-8">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -315,7 +315,7 @@ The majority of the contemporary rock and pop music you hear on the radio these 
     </tag>
     <tag name="TUNING" class="Technical Information" type="UTF-8">
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
-the same tone as the musical piece (e.g., "441.34" in Hertz).</description>
+the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#tag-formatting).</description>
     </tag>
     <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8">
       <description lang="en">The gain to apply to reach 89dB SPL on playback. The value is computed according to the [@!ReplayGain] standard.

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -32,7 +32,7 @@ All tags can be used "under" the "SAMPLE" tag like "TITLE", "ARTIST", "DATE_RELE
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
       <description lang="en">The name of the country
 that is meant to have other tags inside (using nested tags) to country specific information about the item,
-using the Country Code format defined in (#tag-formatting).
+using the Country Code format defined in (#tagstring-formatting).
 All tags can be used "under" the "COUNTRY" tag like "LABEL", "RATING", etc.
 </description>
     </tag>
@@ -71,7 +71,7 @@ It **SHOULD** be a child of the following tags: "ARTIST", "LEAD_PERFORMER", or "
       <description lang="en">Email corresponding to the tag it's included in, using the "Addr-Spec" format defined in [@!RFC5322, section 3.4.1].</description>
     </tag>
     <tag name="ADDRESS" class="Nested Information" type="UTF-8">
-      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code using the Country Code format defined in (#tag-formatting).
+      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code using the Country Code format defined in (#tagstring-formatting).
 It can be useful for a recording label.</description>
     </tag>
     <tag name="FAX" class="Nested Information" type="UTF-8">
@@ -262,7 +262,7 @@ an age in other countries or a URI defining a logo).</description>
     </tag>
     <tag name="RECORDING_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">The location where the item was recorded,
-using the Country Code format defined in (#tag-formatting).
+using the Country Code format defined in (#tagstring-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example,
 "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state
@@ -270,7 +270,7 @@ is unknown, but you want to store the city, simply leave a space between the two
     </tag>
     <tag name="COMPOSITION_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">Location that the item was originally designed/written,
-using the Country Code format defined in (#tag-formatting).
+using the Country Code format defined in (#tagstring-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city.
 For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown,
@@ -278,7 +278,7 @@ but you want to store the city, simply leave a space between the two commas. For
     </tag>
     <tag name="COMPOSER_NATIONALITY" class="Spatial Information" type="UTF-8">
       <description lang="en">Nationality of the main composer of the item, mostly for classical music,
-using the Country Code format defined in (#tag-formatting).</description>
+using the Country Code format defined in (#tagstring-formatting).</description>
     </tag>
     <tag name="COMMENT" class="Personal" type="UTF-8">
       <description lang="en">Any comment related to the content.</description>
@@ -288,7 +288,7 @@ using the Country Code format defined in (#tag-formatting).</description>
     </tag>
     <tag name="RATING" class="Personal" type="UTF-8">
       <description lang="en">A numeric value defining how much a person likes the song/movie. The number is between
-0 and 5 with stored using the Float number defined in (#tag-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
+0 and 5 with stored using the Float number defined in (#tagstring-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
 Other rating systems with different ranges will have to be scaled.</description>
     </tag>
     <tag name="ENCODER" class="Technical Information" type="UTF-8">
@@ -298,15 +298,15 @@ Other rating systems with different ranges will have to be scaled.</description>
       <description lang="en">A list of the settings used for encoding this item. No specific format.</description>
     </tag>
     <tag name="BPS" class="Technical Information" type="UTF-8">
-      <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#tag-formatting).
+      <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#tagstring-formatting).
       This is only the data in the `Block(s)`, and excludes headers and any container overhead.</description>
     </tag>
     <tag name="FPS" class="Technical Information" type="UTF-8">
       <description lang="en">The average frames per second of the specified item. This is typically the average
-number of Blocks per second stored using the Float number defined in (#tag-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
+number of Blocks per second stored using the Float number defined in (#tagstring-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
     </tag>
     <tag name="BPM" class="Technical Information" type="UTF-8">
-      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#tag-formatting).</description>
+      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#tagstring-formatting).</description>
     </tag>
     <tag name="MEASURE" class="Technical Information" type="UTF-8">
       <description lang="en">In music, a measure is a unit of time in Western music like "4/4". It represents
@@ -315,7 +315,7 @@ The majority of the contemporary rock and pop music you hear on the radio these 
     </tag>
     <tag name="TUNING" class="Technical Information" type="UTF-8">
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
-the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#tag-formatting).</description>
+the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#tagstring-formatting).</description>
     </tag>
     <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8">
       <description lang="en">The gain to apply to reach 89dB SPL on playback. The value is computed according to the [@!ReplayGain] standard.
@@ -324,7 +324,7 @@ the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stor
     </tag>
     <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8">
       <description lang="en">The maximum absolute peak amplitude of the item. The value is computed according to the [@!ReplayGain] standard.
-      The value is a normalized absolute sample value of the target audio, using the Float number defined in (#tag-formatting) (e.g., "1.0129").
+      The value is a normalized absolute sample value of the target audio, using the Float number defined in (#tagstring-formatting) (e.g., "1.0129").
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">
@@ -373,7 +373,7 @@ This holds the same information as the "MCDI" in [@!ID3v2.3].</description>
       <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2.3].</description>
     </tag>
     <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8">
-      <description lang="en">The amount paid for entity, using the Float number defined in (#tag-formatting).
+      <description lang="en">The amount paid for entity, using the Float number defined in (#tagstring-formatting).
       The currency is not included. For instance, you would store "15.59" instead of "$15.59USD".</description>
     </tag>
     <tag name="PURCHASE_CURRENCY" class="Commercial" type="UTF-8">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -26,9 +26,8 @@ to describe the original work of art that this item is based on.
 All tags can be used "under" the "ORIGINAL" tag like "LYRICIST", "LEAD_PERFORMER", etc.</description>
     </tag>
     <tag name="SAMPLE" class="Nesting Information" type="nested">
-      <description lang="en">A tag that contains other tags to describe a sample used in the
-targeted item taken from another work of art. All tags in this list can be used
-"under" the "SAMPLE" tag like "TITLE", "ARTIST", "DATE_RELEASED", etc.</description>
+      <description lang="en">A tag that contains other tags to describe a sample used in the targeted item originally found in another work of art.
+All tags can be used "under" the "SAMPLE" tag like "TITLE", "ARTIST", "DATE_RELEASED", etc.</description>
     </tag>
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
       <description lang="en">The name of the country

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -57,7 +57,7 @@ or for video's audio track you might use "English 5.1" This is akin to the "TIT2
       <description lang="en">Sub Title of the entity.</description>
     </tag>
     <tag name="URL" class="Nested Information" type="UTF-8">
-      <description lang="en">URL corresponding to the tag it's included in.</description>
+      <description lang="en">URL corresponding to the tag it's included in, using the format defined in [@!RFC3986].</description>
     </tag>
     <tag name="SORT_WITH" class="Nested Information" type="UTF-8">
       <description lang="en">A child `SimpleTag` element to indicate what alternative value the parent `SimpleTag` element can have

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -324,7 +324,7 @@ the same tone as the musical piece (e.g., "441.34" in Hertz).</description>
     </tag>
     <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8">
       <description lang="en">The maximum absolute peak amplitude of the item. The value is computed according to the [@!ReplayGain] standard.
-      The value is a normalized absolute sample value of the target audio stored as a string without spaces (e.g., "1.0129").
+      The value is a normalized absolute sample value of the target audio, using the Float number defined in (#tag-formatting) (e.g., "1.0129").
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -32,7 +32,7 @@ All tags can be used "under" the "SAMPLE" tag like "TITLE", "ARTIST", "DATE_RELE
     <tag name="COUNTRY" class="Nesting Information" type="UTF-8">
       <description lang="en">The name of the country
 that is meant to have other tags inside (using nested tags) to country specific information about the item,
-using the Country Code format defined in (#tagstring-formatting).
+using the Country Code format defined in (#country-code-tags-formatting).
 All tags can be used "under" the "COUNTRY" tag like "LABEL", "RATING", etc.
 </description>
     </tag>
@@ -71,7 +71,7 @@ It **SHOULD** be a child of the following tags: "ARTIST", "LEAD_PERFORMER", or "
       <description lang="en">Email corresponding to the tag it's included in, using the "Addr-Spec" format defined in [@!RFC5322, section 3.4.1].</description>
     </tag>
     <tag name="ADDRESS" class="Nested Information" type="UTF-8">
-      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code using the Country Code format defined in (#tagstring-formatting).
+      <description lang="en">The physical address of the entity. The address **SHOULD** include a country code using the Country Code format defined in (#country-code-tags-formatting).
 It can be useful for a recording label.</description>
     </tag>
     <tag name="FAX" class="Nested Information" type="UTF-8">
@@ -262,7 +262,7 @@ an age in other countries or a URI defining a logo).</description>
     </tag>
     <tag name="RECORDING_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">The location where the item was recorded,
-using the Country Code format defined in (#tagstring-formatting).
+using the Country Code format defined in (#country-code-tags-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example,
 "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state
@@ -270,7 +270,7 @@ is unknown, but you want to store the city, simply leave a space between the two
     </tag>
     <tag name="COMPOSITION_LOCATION" class="Spatial Information" type="UTF-8">
       <description lang="en">Location that the item was originally designed/written,
-using the Country Code format defined in (#tagstring-formatting).
+using the Country Code format defined in (#country-code-tags-formatting).
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city.
 For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown,
@@ -278,7 +278,7 @@ but you want to store the city, simply leave a space between the two commas. For
     </tag>
     <tag name="COMPOSER_NATIONALITY" class="Spatial Information" type="UTF-8">
       <description lang="en">Nationality of the main composer of the item, mostly for classical music,
-using the Country Code format defined in (#tagstring-formatting).</description>
+using the Country Code format defined in (#country-code-tags-formatting).</description>
     </tag>
     <tag name="COMMENT" class="Personal" type="UTF-8">
       <description lang="en">Any comment related to the content.</description>
@@ -288,7 +288,7 @@ using the Country Code format defined in (#tagstring-formatting).</description>
     </tag>
     <tag name="RATING" class="Personal" type="UTF-8">
       <description lang="en">A numeric value defining how much a person likes the song/movie. The number is between
-0 and 5 with stored using the Float number defined in (#tagstring-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
+0 and 5 with stored using the Float number defined in (#number-tags-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
 Other rating systems with different ranges will have to be scaled.</description>
     </tag>
     <tag name="ENCODER" class="Technical Information" type="UTF-8">
@@ -298,15 +298,15 @@ Other rating systems with different ranges will have to be scaled.</description>
       <description lang="en">A list of the settings used for encoding this item. No specific format.</description>
     </tag>
     <tag name="BPS" class="Technical Information" type="UTF-8">
-      <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#tagstring-formatting).
+      <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#number-tags-formatting).
       This is only the data in the `Block(s)`, and excludes headers and any container overhead.</description>
     </tag>
     <tag name="FPS" class="Technical Information" type="UTF-8">
       <description lang="en">The average frames per second of the specified item. This is typically the average
-number of Blocks per second stored using the Float number defined in (#tagstring-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
+number of Blocks per second stored using the Float number defined in (#number-tags-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
     </tag>
     <tag name="BPM" class="Technical Information" type="UTF-8">
-      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#tagstring-formatting).</description>
+      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#number-tags-formatting).</description>
     </tag>
     <tag name="MEASURE" class="Technical Information" type="UTF-8">
       <description lang="en">In music, a measure is a unit of time in Western music like "4/4". It represents
@@ -315,7 +315,7 @@ The majority of the contemporary rock and pop music you hear on the radio these 
     </tag>
     <tag name="TUNING" class="Technical Information" type="UTF-8">
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
-the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#tagstring-formatting).</description>
+the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#number-tags-formatting).</description>
     </tag>
     <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8">
       <description lang="en">The gain to apply to reach 89dB SPL on playback. The value is computed according to the [@!ReplayGain] standard.
@@ -324,7 +324,7 @@ the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stor
     </tag>
     <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8">
       <description lang="en">The maximum absolute peak amplitude of the item. The value is computed according to the [@!ReplayGain] standard.
-      The value is a normalized absolute sample value of the target audio, using the Float number defined in (#tagstring-formatting) (e.g., "1.0129").
+      The value is a normalized absolute sample value of the target audio, using the Float number defined in (#number-tags-formatting) (e.g., "1.0129").
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">
@@ -373,7 +373,7 @@ This holds the same information as the "MCDI" in [@!ID3v2.3].</description>
       <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2.3].</description>
     </tag>
     <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8">
-      <description lang="en">The amount paid for entity, using the Float number defined in (#tagstring-formatting).
+      <description lang="en">The amount paid for entity, using the Float number defined in (#number-tags-formatting).
       The currency is not included. For instance, you would store "15.59" instead of "$15.59USD".</description>
     </tag>
     <tag name="PURCHASE_CURRENCY" class="Commercial" type="UTF-8">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -303,7 +303,7 @@ and excludes headers and any container overhead.</description>
     </tag>
     <tag name="FPS" class="Technical Information" type="UTF-8">
       <description lang="en">The average frames per second of the specified item. This is typically the average
-number of Blocks per second. In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
+number of Blocks per second stored using the Float number defined in (#tag-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
     </tag>
     <tag name="BPM" class="Technical Information" type="UTF-8">
       <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#tag-formatting).</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -373,8 +373,8 @@ This holds the same information as the "MCDI" in [@!ID3v2.3].</description>
       <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2.3].</description>
     </tag>
     <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8">
-      <description lang="en">The amount paid for entity. There **SHOULD** only be a numeric value in here. Only numbers,
-no letters or symbols other than ".". For instance, you would store "15.59" instead of "$15.59USD".</description>
+      <description lang="en">The amount paid for entity, using the Float number defined in (#tag-formatting).
+      The currency is not included. For instance, you would store "15.59" instead of "$15.59USD".</description>
     </tag>
     <tag name="PURCHASE_CURRENCY" class="Commercial" type="UTF-8">
       <description lang="en">The currency type used to pay for the entity. Use [@!ISO4217] for the 3 letter alphabetic code.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -306,7 +306,7 @@ and excludes headers and any container overhead.</description>
 number of Blocks per second. In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
     </tag>
     <tag name="BPM" class="Technical Information" type="UTF-8">
-      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter). Usually a decimal number.</description>
+      <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#tag-formatting).</description>
     </tag>
     <tag name="MEASURE" class="Technical Information" type="UTF-8">
       <description lang="en">In music, a measure is a unit of time in Western music like "4/4". It represents

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -298,8 +298,8 @@ Other rating systems with different ranges will have to be scaled.</description>
       <description lang="en">A list of the settings used for encoding this item. No specific format.</description>
     </tag>
     <tag name="BPS" class="Technical Information" type="UTF-8">
-      <description lang="en">The average bits per second of the specified item. This is only the data in the `Block(s)`,
-and excludes headers and any container overhead.</description>
+      <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#tag-formatting).
+      This is only the data in the `Block(s)`, and excludes headers and any container overhead.</description>
     </tag>
     <tag name="FPS" class="Technical Information" type="UTF-8">
       <description lang="en">The average frames per second of the specified item. This is typically the average

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -38,16 +38,16 @@ All tags can be used "under" the "COUNTRY" tag like "LABEL", "RATING", etc.
 </description>
     </tag>
     <tag name="TOTAL_PARTS" class="Organization Information" type="UTF-8">
-      <description lang="en">Total number of parts defined at the first lower level. (e.g., if `TargetType` is "ALBUM",
+      <description lang="en">Total number of parts defined at the first lower level. (e.g., if `TargetTypeValue` is "50" (`TargetType` = "ALBUM"),
 the total number of tracks of an audio CD).</description>
     </tag>
     <tag name="PART_NUMBER" class="Organization Information" type="UTF-8">
-      <description lang="en">Number of the current part of the current level. (e.g., if `TargetType` is "TRACK",
+      <description lang="en">Number of the current part of the current level. (e.g., if `TargetTypeValue` is "30" (`TargetType` = "TRACK"),
 the track number of an audio CD).</description>
     </tag>
     <tag name="PART_OFFSET" class="Organization Information" type="UTF-8">
       <description lang="en">A number to add to "PART_NUMBER", when the parts at that level don't start at 1
-(e.g., if `TargetType` is "TRACK", the track number of the second audio CD).</description>
+(e.g., if `TargetTypeValue` is "30" (`TargetType` = "TRACK"), the track number of the second audio CD).</description>
     </tag>
     <tag name="TITLE" class="Titles" type="UTF-8">
       <description lang="en">The title of this item. For example, for music you might label this "Canon in D",

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -64,7 +64,7 @@
     <author>
       <organization>International ISRC Registration Authority</organization>
     </author>
-    <date year="2001"/>
+    <date year="2021"/>
   </front>
   <seriesInfo name="IFPI" value="4th Edition" />
 </reference>

--- a/tagging.md
+++ b/tagging.md
@@ -139,9 +139,9 @@ TargetTypeValue | Audio strings                   | Video strings             | 
 Table: TargetTypeValue Values Semantic Description
 
 An upper level value tag applies to the lower level. This means that if a CD has the same
-artist for all tracks, you just need to set the ARTIST tag at level 50 (ALBUM) and not
-to each TRACK (but you can). That also means that, if some parts of the CD have no known
-ARTIST, the value **MUST** be set to nothing (a void string "").
+artist for all tracks, you just need to set the "ARTIST" `TagName` at `TargetTypeValue` 50 (ALBUM) and not
+to each TRACK (`TargetTypeValue` 30), but you can. That also means that, if some parts of the CD have no known
+"ARTIST", the value **MUST** be set to nothing (a void string "").
 
 When a level doesn't exist it **MUST NOT** be specified in the files, so that the "TOTAL_PARTS"
 and "PART_NUMBER" elements match the same levels.

--- a/tagging.md
+++ b/tagging.md
@@ -118,13 +118,13 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 ## Target Types
 
-The `TargetType` element allows tagging of different parts that are inside or outside a
+The `TargetTypeValue` element allows tagging of different parts that are inside or outside a
 given file. For example, in an audio file with one song you could have information about
 the album it comes from and even the CD set even if it's not found in the file.
 
-For application to know the kind of information (like "TITLE") relates to a certain level
-(CD title or track title), we also need a set of official `TargetType` names. For now audio
-and video will have different values and names. That also means the same tag name can
+For applications to know the kind of information (like "TITLE") relates to a certain level
+(CD title or track title), we also need a set of official `TargetTypeValue` values and `TargetType` names.
+For now audio and video will have different values and names. That also means the same tag name can
 have different meanings depending on where it is (otherwise, we would end up with 15 TITLE_ tags).
 
 TargetTypeValue | Audio strings                   | Video strings             | Comment

--- a/tagging.md
+++ b/tagging.md
@@ -114,9 +114,11 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 * Fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
   Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
+  The "." separator represent the boundary between the integer value and the decimal parts.
   If the string doesn't contain the "." separator, the value is an integer value.
+  Thousandths separators **SHOULD NOT** be used.
   To display it differently for another local, applications **SHOULD** support auto
-  replacement on display. Also, a thousandths separator **SHOULD NOT** be used.
+  replacement on display.
 
 * Fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
   i.e. [@!RFC5646] two-letter region subtags, without the UK exception

--- a/tagging.md
+++ b/tagging.md
@@ -115,6 +115,7 @@ The `TagName` **SHOULD NOT** contain any space.
 `TagString` fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
 This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
 without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
+The date and times represented are in Coordinated Universal Time (UTC).
 
 Date and times are usually not precise to a particular millisecond.
 To store less accurate dates, parts of the date string are removed starting from the right.

--- a/tagging.md
+++ b/tagging.md
@@ -79,7 +79,7 @@ than one tag value with the same name to be stored, then more than one `SimpleTa
 ## Why Official Tags Matter
 
 There is a debate between people who think all tags **SHOULD** be free and those who think
-all tags **SHOULD** be strict. If you look at this page you will realize we are in between.
+all tags **SHOULD** be strict. Our recommendations are in between.
 
 Advanced-users application might let you put any tag in your file. But for the rest of
 the applications, they usually give you a basic list of tags you can use. Both have their

--- a/tagging.md
+++ b/tagging.md
@@ -113,6 +113,8 @@ which tag has the wanted meaning so that other apps could understand the same me
   you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
 
 * Fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
+  Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
+  If the string doesn't contain the "." separator, the value is an integer value.
   To display it differently for another local, applications **SHOULD** support auto
   replacement on display. Also, a thousandths separator **SHOULD NOT** be used.
 

--- a/tagging.md
+++ b/tagging.md
@@ -100,19 +100,23 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 ## Tag Formatting
 
+### TagName Formatting
+
 * The `TagName` **SHOULD** consists of UTF-8 capital letters, numbers and the underscore character '_'.
 
 * The `TagName` **SHOULD NOT** contain any space.
 
 * `TagNames` starting with the underscore character '_' are not official tags; see (#why-official-tags-matter).
 
-* The fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
+### TagString Formatting
+
+* `TagString` fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
   This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
   without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
   To store less accuracy, you remove items starting from the right. For instance, to store only the year,
   you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
 
-* Fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
+* `TagString` fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
   Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
   The "." separator represent the boundary between the integer value and the decimal parts.
   If the string doesn't contain the "." separator, the value is an integer value.
@@ -120,7 +124,7 @@ which tag has the wanted meaning so that other apps could understand the same me
   To display it differently for another local, applications **SHOULD** support auto
   replacement on display.
 
-* Fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
+* `TagString` fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
   i.e. [@!RFC5646] two-letter region subtags, without the UK exception
 
 ## Target Types

--- a/tagging.md
+++ b/tagging.md
@@ -122,7 +122,7 @@ The `TargetType` element allows tagging of different parts that are inside or ou
 given file. For example, in an audio file with one song you could have information about
 the album it comes from and even the CD set even if it's not found in the file.
 
-For application to know the kind of information (like TITLE) relates to a certain level
+For application to know the kind of information (like "TITLE") relates to a certain level
 (CD title or track title), we also need a set of official `TargetType` names. For now audio
 and video will have different values and names. That also means the same tag name can
 have different meanings depending on where it is (otherwise, we would end up with 15 TITLE_ tags).

--- a/tagging.md
+++ b/tagging.md
@@ -102,7 +102,7 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 ### TagName Formatting
 
-The `TagName` **SHOULD** consists of UTF-8 capital letters, numbers and the underscore character '_'.
+The `TagName` **SHOULD** consist of UTF-8 capital letters, numbers and the underscore character '_'.
 
 The `TagName` **SHOULD NOT** contain any space.
 

--- a/tagging.md
+++ b/tagging.md
@@ -87,10 +87,12 @@ needs. But it's usually a bad idea to use custom/exotic tags because you will pr
 be the only person to use this information even though everyone else could benefit from it.
 So hopefully, when someone wants to put information in one's file, they will find an
 official one that fit them and hopefully use it ! If it's not in the list, this person
-can contact us any time for addition of such a missing tag. But it doesn't mean it will
-be accepted... Matroska files are not meant the become a whole database of people who made
-costumes for a film. A website would be better for that... It's hard to define what **SHOULD**
-be in and what doesn't make sense in a file; thus, we'll treat each request carefully.
+can try get a new tag in the Matroska Tags Names registry ((#matroska-tags-names-registry)).
+This registry is not meant to have every possible information in a file.
+Matroska files are not meant the become a whole database of people who made
+costumes for a film. A website would be better for that. It's hard to define what should
+be in and what doesn't make sense in a file; thus, each demand needs to balance if it
+makes sense to be carried over in a file for storage and/or sharing or if it doesn't belong there.
 
 We also need an official list simply for developers to be able to display relevant information
 in their own design (if they choose to support a list of meta-information they **SHOULD** know

--- a/tagging.md
+++ b/tagging.md
@@ -95,8 +95,8 @@ be in and what doesn't make sense in a file; thus, each demand needs to balance 
 makes sense to be carried over in a file for storage and/or sharing or if it doesn't belong there.
 
 We also need an official list simply for developers to be able to display relevant information
-in their own design (if they choose to support a list of meta-information they **SHOULD** know
-which tag has the wanted meaning so that other apps could understand the same meaning).
+in their own design, if they choose to support a list of meta-information they should know
+which tag has the wanted meaning so that other apps could understand the same meaning.
 
 ## Tag Formatting
 

--- a/tagging.md
+++ b/tagging.md
@@ -115,9 +115,6 @@ which tag has the wanted meaning so that other apps could understand the same me
   To display it differently for another local, applications **SHOULD** support auto
   replacement on display. Also, a thousandths separator **SHOULD NOT** be used.
 
-* For currency amounts, there **SHOULD** only be a numeric value in the Tag.
-  Only numbers, no letters or symbols other than ".". For instance, you would store "15.59" instead of "$15.59USD".
-
 ## Target Types
 
 The `TargetTypeValue` element allows tagging of different parts that are inside or outside a

--- a/tagging.md
+++ b/tagging.md
@@ -125,7 +125,7 @@ the album it comes from and even the CD set even if it's not found in the file.
 For applications to know the kind of information (like "TITLE") relates to a certain level
 (CD title or track title), we also need a set of official `TargetTypeValue` values and `TargetType` names.
 For now audio and video will have different values and names. That also means the same tag name can
-have different meanings depending on where it is (otherwise, we would end up with 15 TITLE_ tags).
+have different meanings depending on where it is, otherwise we would end up with 7 "TITLE_" tag names.
 
 TargetTypeValue | Audio strings                   | Video strings             | Comment
 ----------------|:--------------------------------|:--------------------------|:-------

--- a/tagging.md
+++ b/tagging.md
@@ -102,30 +102,38 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 ### TagName Formatting
 
-* The `TagName` **SHOULD** consists of UTF-8 capital letters, numbers and the underscore character '_'.
+The `TagName` **SHOULD** consists of UTF-8 capital letters, numbers and the underscore character '_'.
 
-* The `TagName` **SHOULD NOT** contain any space.
+The `TagName` **SHOULD NOT** contain any space.
 
-* `TagNames` starting with the underscore character '_' are not official tags; see (#why-official-tags-matter).
+`TagNames` starting with the underscore character '_' are not official tags; see (#why-official-tags-matter).
 
 ### TagString Formatting
 
-* `TagString` fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
-  This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
-  without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
-  To store less accuracy, you remove items starting from the right. For instance, to store only the year,
-  you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
+#### Date Tags Formatting
 
-* `TagString` fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
-  Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
-  The "." separator represent the boundary between the integer value and the decimal parts.
-  If the string doesn't contain the "." separator, the value is an integer value.
-  Thousandths separators **SHOULD NOT** be used.
-  To display it differently for another local, applications **SHOULD** support auto
-  replacement on display.
+`TagString` fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
+This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
+without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
 
-* `TagString` fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
-  i.e. [@!RFC5646] two-letter region subtags, without the UK exception
+To store less accuracy, you remove items starting from the right. For instance, to store only the year,
+you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
+
+#### Number Tags Formatting
+
+`TagString` fields that require a Float **SHOULD** use the "." mark instead of the "," mark.
+Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
+The "." separator represent the boundary between the integer value and the decimal parts.
+If the string doesn't contain the "." separator, the value is an integer value.
+Thousandths separators **SHOULD NOT** be used.
+
+To display it differently for another local, applications **SHOULD** support auto
+replacement on display.
+
+#### Country Code Tags Formatting
+
+`TagString` fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
+i.e. [@!RFC5646] two-letter region subtags, without the UK exception
 
 ## Target Types
 

--- a/tagging.md
+++ b/tagging.md
@@ -74,7 +74,7 @@ This corresponds to this layout of EBML elements:
 In this way, it becomes possible to store any `SimpleTag` as attributes of another `SimpleTag`.
 
 Multiple items **SHOULD** never be stored as a list in a single `TagString`. If there is more
-than one tag of a certain type to be stored, then more than one `SimpleTag` **SHOULD** be used.
+than one tag value with the same name to be stored, then more than one `SimpleTag` **SHOULD** be used.
 
 ## Why Official Tags Matter
 

--- a/tagging.md
+++ b/tagging.md
@@ -116,8 +116,10 @@ The `TagName` **SHOULD NOT** contain any space.
 This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
 without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
 
-To store less accuracy, you remove items starting from the right. For instance, to store only the year,
-you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
+Date and times are usually not precise to a particular millisecond.
+To store less accurate dates, parts of the date string are removed starting from the right.
+For instance, to store only the year, one would use "2004".
+To store a specific day such as May 1st, 2003, one would use "2003-05-01".
 
 #### Number Tags Formatting
 

--- a/tagging.md
+++ b/tagging.md
@@ -115,6 +115,9 @@ which tag has the wanted meaning so that other apps could understand the same me
   To display it differently for another local, applications **SHOULD** support auto
   replacement on display. Also, a thousandths separator **SHOULD NOT** be used.
 
+* Fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
+  i.e. [@!RFC5646] two-letter region subtags, without the UK exception
+
 ## Target Types
 
 The `TargetTypeValue` element allows tagging of different parts that are inside or outside a

--- a/tagging.md
+++ b/tagging.md
@@ -148,10 +148,11 @@ to each TRACK (`TargetTypeValue` 30), but you can. That also means that, if some
 When a level doesn't exist it **MUST NOT** be specified in the files, so that the "TOTAL_PARTS"
 and "PART_NUMBER" elements match the same levels.
 
-Here is an example of how these `organizational` tags work: If you set 10 "TOTAL_PARTS" to
-the ALBUM level (40) it means the album contains 10 lower parts. The lower part in question
-is the first lower level that is specified in the file. So, if it's TRACK (30), then that
-means it contains 10 tracks. If it's MOVEMENT (20), that means it's 10 movements, etc.
+Here is an example of how these organizational tags from (#organization-information) work:
+If you set 10 "TOTAL_PARTS" to the ALBUM level (`TargetTypeValue` = 50) it means the album contains 10 lower parts.
+The lower part in question is the first lower level that is specified in the file.
+So, if it's TRACK (`TargetTypeValue` = 30), then that means it contains 10 tracks.
+If it's MOVEMENT (`TargetTypeValue` = 20), that means it's 10 movements, etc.
 
 # Official Tags
 

--- a/tagging.md
+++ b/tagging.md
@@ -185,7 +185,7 @@ If it's MOVEMENT (`TargetTypeValue` = 20), that means it's 10 movements, etc.
 # Official Tags
 
 The following is a complete list of the supported Matroska Tags. While it is possible
-to use Tag names that are not listed below, this is not recommended as compatibility will
+to use Tag names that are not listed below, this is **NOT RECOMMENDED** as compatibility will
 be compromised. If you find that there is a Tag missing that you would like to use,
 then please contact the persons mentioned in the IANA Matroska Tags Registry for its inclusion; see (#matroska-tags-names-registry).
 

--- a/tagging.md
+++ b/tagging.md
@@ -1,6 +1,6 @@
 # Tagging
 
-When a `SimpleTag` is nested within another `SimpleTag`, the nested `SimpleTag` becomes an attribute of the base `SimpleTag`.
+When a `SimpleTag` is nested within another `SimpleTag`, the nested `SimpleTag` becomes an attribute of its parent `SimpleTag`.
 For instance, if you wanted to store the dates that a singer used certain addresses for,
 that singer being the lead singer for a track that included multiple bands simultaneously,
 then your `SimpleTag` tree would look something like this:

--- a/tagging.md
+++ b/tagging.md
@@ -98,7 +98,7 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 ## Tag Formatting
 
-* The `TagName` **SHOULD** consists of capital letters, numbers and the underscore character '_'.
+* The `TagName` **SHOULD** consists of UTF-8 capital letters, numbers and the underscore character '_'.
 
 * The `TagName` **SHOULD NOT** contain any space.
 

--- a/tagging.md
+++ b/tagging.md
@@ -110,6 +110,14 @@ The `TagName` **SHOULD NOT** contain any space.
 
 ### TagString Formatting
 
+Although tags are metadata mostly used for reading, there are cases where the string value could
+be used for sorting, categorization, etc. For this reason, when possible, strict formatting
+of the value should be used so everyone can agree on how to use the value.
+
+Due to preexisting files where these formatting rules were not explicit, they are usually
+presented as rules that **SHOULD** be applied when possible, rather than **MUST** be applied
+at all times. It is **RECOMMENDED** to use strict formatting when writing new tag values.
+
 #### Date Tags Formatting
 
 `TagString` fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".

--- a/tagging.md
+++ b/tagging.md
@@ -106,9 +106,10 @@ which tag has the wanted meaning so that other apps could understand the same me
 
 * `TagNames` starting with the underscore character '_' are not official tags; see (#why-official-tags-matter).
 
-* The fields with dates **SHOULD** have the following format: YYYY-MM-DD hh:mm:ss.mss YYYY = Year,
-  MM = Month, DD = Days, HH = Hours, mm = Minutes, ss = Seconds, mss = Milliseconds.
-  To store less accuracy, you remove items starting from the right. To store only the year,
+* The fields with dates **SHOULD** have the following format: "YYYY-MM-DD hh:mm:ss.mss".
+  This is similar to the ISO8601 date and time format defined in [@RFC3339, appendix A] of [@RFC9559]
+  without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
+  To store less accuracy, you remove items starting from the right. For instance, to store only the year,
   you would use, "2004". To store a specific day such as May 1st, 2003, you would use "2003-05-01".
 
 * Fields that require a Float **SHOULD** use the "." mark instead of the "," mark.

--- a/tags_security.md
+++ b/tags_security.md
@@ -6,7 +6,9 @@ Tag values can be either `TagString` or `TagBinary` blobs. In both cases issues 
 
 Most of the time strings are kept as-is and don't pose a security issue, apart from invalid UTF-8 values.
 
-String tags that are parsed like "REPLAYGAIN_GAIN" or "REPLAYGAIN_PEAK" defined in (#technical-information) may cause issues when the string is bogus or in an unexpected format.
+String tags that are parsed like "REPLAYGAIN_GAIN" or "REPLAYGAIN_PEAK" defined in (#technical-information)
+or string tags following the rules from (#tagstring-formatting) or string tags following other strict formats like URLs
+may cause issues when the string is bogus or in an unexpected format.
 
 Binary tags that need to be parsed like "MCDI" defined in (#identifiers) may cause issues when the data is bogus or incomplete.
 


### PR DESCRIPTION
And define some generic types that should be parsed the same (numbers, dates, country codes).

Refer to tag targets with the `TargetTypeValue` which is mandatory, unlike the `TargetType` string.

And fix some odd wording here and there.