### PR TITLE
fix the link to IMDb documentation

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -353,7 +353,7 @@ This holds the same information as the "MCDI" in [@!ID3v2.3].</description>
       <description lang="en">Library of Congress Control Number [@!LCCN].</description>
     </tag>
     <tag name="IMDB" class="Identifiers" type="UTF-8">
-      <description lang="en">Internet Movie Database [@!IMDb] identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>
+      <description lang="en">Internet Movie Database [@!IMDb] title identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>
     </tag>
     <tag name="TMDB" class="Identifiers" type="UTF-8">
       <description lang="en">The Movie DB "movie_id" or "tv_id" identifier for movies/TV shows [@!MovieDB]. The variable length digits string **MUST** be prefixed with either "movie/" or "tv/".</description>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -28,9 +28,9 @@
   </front>
 </reference>
 
-<reference anchor="IMDb" target="https://imdb-api.com/api">
+<reference anchor="IMDb" target="https://developer.imdb.com/documentation/key-concepts/">
   <front>
-    <title>IMDb API Documentation</title>
+    <title>IMDb data key concepts</title>
     <author>
       <organization>Internet Movie Database</organization>
     </author>


### PR DESCRIPTION
And only use the title identifier since we restrict to the "tt" prefix.