### PR TITLE
Add a rule for tag replacement

### DIFF
--- a/tagging.md
+++ b/tagging.md
@@ -150,6 +150,10 @@ If some tracks of that CD have no known
 "ARTIST", the value **MUST** be set to nothing, a void string "" as detailed in [@!RFC9559, section 24.2],
 so that the album "ARTIST" doesn't apply.
 
+If a tag with a given `TagName` is found at a `TargetTypeValue`,
+only values of that `TagName` are valid at that `TargetTypeValue` level.
+In other words, the `TagName` values from upper `TargetTypeValue` levels don't apply at that level.
+
 Multiple `SimpleTag` with the same `TagName` can be used at a given `TargetTypeValue` level when each `SimpleTag` contain a `TagString`.
 For example this can be useful to find a single "ARTIST" even when they are found in a collaboration.
 The concatenation of each `TagString` represents the value for the `TagName` at this level.


### PR DESCRIPTION
~~Draft on top of #884 as I'm not sure it's a rule that makes sense.~~ However it's implied by the fact lower levels should void tags that are set by the parent.

A better rule would be to RECOMMEND not to use an upper value if it doesn't apply to all children.