### PR TITLE
add a general rule about mapping codec metadata to Matroska ones

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -138,6 +138,11 @@ These recommendations are based on [@!RFC6648, section 3].
 All codecs described in this section **MUST** have a `TrackType` ([@!RFC9559, section 5.1.4.1.3]) value of "1" for video.
 The track using these codecs **MUST** contain a `Video` element -- EBML Path `\Segment\Tracks\TrackEntry\Video`.
 
+Most video codec contain meta information about the data they contain, like encoded width and height, chroma subsampling, etc.
+Whenever possible these information inside the codec **SHOULD** be extracted and repeated at the Matroska level with
+the appropriate element(s) inside the `\Segment\Tracks\TrackEntry\Video` and `\Segment\Tracks\TrackEntry` elements.
+These values **MUST** be valid for the whole Segment.
+
 ### V_AV1
 
 Codec ID: `V_AV1`
@@ -471,6 +476,11 @@ Note that the format differs from the `VPCodecConfigurationRecord` structure, as
 
 All codecs described in this section **MUST** have a `TrackType` ([@!RFC9559, section 5.1.4.1.3]) value of "2" for audio.
 The track using these codecs **MUST** contain an `Audio` element -- EBML Path `\Segment\Tracks\TrackEntry\Audio`.
+
+Most audio codec contain meta information about the data they contain, like encoded sampling frequency, channel count, etc.
+Whenever possible these information inside the codec **SHOULD** be extracted and repeated at the Matroska level with
+the appropriate element(s) inside the `\Segment\Tracks\TrackEntry\Audio` and `\Segment\Tracks\TrackEntry` elements.
+These values **MUST** be valid for the whole Segment.
 
 ### A_AAC/MPEG2/LC
 
@@ -946,6 +956,11 @@ Initialization: none
 ## Subtitle Codec Mappings
 
 All codecs described in this section **MUST** have a `TrackType` ([@!RFC9559, section 5.1.4.1.3]) value of "17" for subtitles.
+
+Subtitle codec often contain meta information about the data they contain, like expected output dimension, language, etc.
+Whenever possible these information inside the codec **SHOULD** be extracted and repeated at the Matroska level with
+the appropriate element(s) inside the `\Segment\Tracks\TrackEntry\Video` and `\Segment\Tracks\TrackEntry` elements.
+These values **MUST** be valid for the whole Segment.
 
 ### S_ARIBSUB
 


### PR DESCRIPTION
It's easier than having to dig into each format to tell how each value maps to what part of Matroska...

A full codec mapping specification (like av1.md) should go deep into this mapping. But with most codec the mapping is common and straightforward. It only gets trickier for codecs like Opus or AV1 that may need specific Matroska features.

It is also important to mention that the values MUST not change in the Segment. Some codec may hide changing parameters (encoded resolution, sampling frequency, etc) but as long as it's hidden inside the codec, we don't need to know about it.