### PR TITLE
add WebVTT reference and WebM CodecIDs

### DIFF
--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -365,3 +365,13 @@
     <date year="2023" month="October" day="16"/>
   </front>
 </reference>
+
+<reference anchor="WebM-WebVTT" target="https://wiki.webmproject.org/webm-metadata/temporal-metadata/webvtt-in-webm">
+  <front>
+    <title>WebVTT in WebM</title>
+    <author fullname='Matthew Heaney'><organization>Google</organization></author>
+    <author fullname='Frank Galligan'><organization>Google</organization></author>
+    <date year="2012" month="February" day="01"/>
+  </front>
+</reference>
+

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -375,3 +375,15 @@
   </front>
 </reference>
 
+<reference anchor="WebVTT" target="https://www.w3.org/TR/2019/CR-webvtt1-20190404/">
+  <front>
+    <title>WebVTT: The Web Video Text Tracks Format</title>
+    <author fullname='Simon Pieters'><organization>Opera Software AS</organization></author>
+    <author fullname='Silvia Pfeiffer' role='editor'><organization>NICTA</organization></author>
+    <author fullname='Philip Jaegenstedt'><organization>Opera Software ASA</organization></author>
+    <author fullname='Ian Hickson'><organization>Google</organization></author>
+    <date month="April" year="2019" />
+  </front>
+  <refcontent>W3C Candidate Recommendation</refcontent>
+</reference>
+

--- a/subtitles.md
+++ b/subtitles.md
@@ -373,8 +373,8 @@ BlockDuration: 00:00:01.730
 
 ## WebVTT
 
-The "Web Video Text Tracks Format" (short: WebVTT) is developed by the [World Wide Web Consortium (W3C)](https://www.w3.org/).
-Its specifications are [freely available](https://w3c.github.io/webvtt/).
+The "Web Video Text Tracks Format" (short: WebVTT) is developed by the World Wide Web Consortium (W3C).
+Its specifications are freely available at [@!WebVTT].
 
 The guiding principles for the storage of WebVTT in Matroska are:
 

--- a/subtitles.md
+++ b/subtitles.md
@@ -586,7 +586,7 @@ nor a Settings List, and it wasn't preceded by Comment blocks.
 ### Storage of WebVTT in Matroska vs. WebM
 
 Note: the storage of WebVTT in Matroska is not the same as the design document for storage
-of WebVTT in WebM. There are several reasons for this including but not limited to:
+of WebVTT in WebM [@?WebM-WebVTT]. There are several reasons for this including but not limited to:
 the WebM document is old (from February 2012) and was based on an earlier draft of WebVTT
 and ignores several parts that were added to WebVTT later; WebM does still [not support subtitles at all](http://www.webmproject.org/docs/container/);
 the proposal suggests splitting the information across multiple tracks making

--- a/subtitles.md
+++ b/subtitles.md
@@ -588,7 +588,7 @@ nor a Settings List, and it wasn't preceded by Comment blocks.
 Note: the storage of WebVTT in Matroska is not the same as the design document for storage
 of WebVTT in WebM [@?WebM-WebVTT]. There are several reasons for this including but not limited to:
 the WebM document is old (from February 2012) and was based on an earlier draft of WebVTT
-and ignores several parts that were added to WebVTT later; WebM does still [not support subtitles at all](http://www.webmproject.org/docs/container/);
+and ignores several parts that were added to WebVTT later; WebM does still not support subtitles at all [@?WebMContainer];
 the proposal suggests splitting the information across multiple tracks making
 demuxer's and remuxer's life very difficult.
 

--- a/subtitles.md
+++ b/subtitles.md
@@ -592,6 +592,9 @@ and ignores several parts that were added to WebVTT later; WebM does still not s
 the proposal suggests splitting the information across multiple tracks making
 demuxer's and remuxer's life very difficult.
 
+WebM uses the "D_WEBVTT/SUBTITLES", "D_WEBVTT/CAPTIONS", "D_WEBVTT/DESCRIPTIONS", and "D_WEBVTT/METADATA" `CodecID`
+with different tracks depending on the data type and without a `CodecPrivate`.
+
 
 ## HDMV presentation graphics subtitles
 


### PR DESCRIPTION
The WebM codecs are not official IDs because they are bogus and don't contain the proper extradata.

Fixes #204