### PR TITLE
enforce the distinction between SSA and ASS

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1023,6 +1023,8 @@ Codec Name: Advanced SubStation Alpha Format
 Description: The [Script Info] and [V4 Styles] sections are stored in the codecprivate. Each event is stored in its own `Block`.
 For more information see (#ssa-ass-subtitles) on SSA/ASS.
 
+This codec ID **MUST** be used when "ScriptType: v4.00+" or "[V4+ Styles]" sections are found in the original SSA script.
+
 The codec **MAY** also be found with the Codec ID `S_ASS`, but using that value is **NOT RECOMMENDED**.
 
 ### S_TEXT/ASCII
@@ -1041,6 +1043,8 @@ Codec Name: SubStation Alpha Format
 
 Description: The [Script Info] and [V4 Styles] sections are stored in the codecprivate. Each event is stored in its own `Block`.
 For more information see (#ssa-ass-subtitles) on SSA/ASS.
+
+This codec ID **MUST NOT** be used when "ScriptType: v4.00+" or "[V4+ Styles]" sections are found in the original SSA script.
 
 The codec **MAY** also be found with the Codec ID `S_SSA`, but using that value is **NOT RECOMMENDED**.
 


### PR DESCRIPTION
libavformat and VLC treat them the same.
mkvtoolnix checks if the v4+ elements are used or not. [1]

[1] https://gitlab.com/mbunkus/mkvtoolnix/-/blob/01a4e54818d2653d70b6d09cd8431f7fe1f8b7d9/src/input/subtitles.cpp#L381

If this was not always done properly we can turn it into a **SHOULD**. Using `S_TEXT/ASS` when the content is just SSA is fine. The other way around may cause issues. But in reality players just handle them the same way. 