### PR TITLE
update the ISO 14496-15 reference to the latest version

### DIFF
--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -144,9 +144,9 @@
     <author>
       <organization>International Organization for Standardization</organization>
     </author>
-    <date month="" year="2014" />
+    <date month="October" year="2024" />
   </front>
-  <seriesInfo name="ISO" value="Standard 14496" />
+  <seriesInfo name="ISO" value="14496-15:2024" />
 </reference>
 
 <reference anchor="ITU-T.35" target="https://www.itu.int/rec/T-REC-T.35/en">


### PR DESCRIPTION
There's still not free version of this and we have 4 codecs that rely on it.