### PR TITLE
fix the AV1 CodecPrivate

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -152,7 +152,7 @@ A `Block` inside a `BlockGroup` **MUST** use `ReferenceBlock` elements if the fi
 A `Block` inside a `BlockGroup` **MUST** use `ReferenceBlock` elements if the `Block` doesn't contain a `Sequence Header OBU`.
 A `Block` with `frame_header_obu` where the `frame_type` is `INTRA_ONLY_FRAME` **MUST** use a `ReferenceBlock` with a value of 0 to reference itself.
 
-Initialization: The `CodecPrivate` consists of the `AV1CodecConfigurationRecord` described in section 2.3 of [@!AV1-ISOBMFF].
+Initialization: The `CodecPrivate` consists of the `AV1CodecConfigurationBox` described in section 2.3 of [@!AV1-ISOBMFF].
 
 PixelWidth:  **MUST** be `max_frame_width_minus_1`+1 of the `Sequence Header OBU`.
 


### PR DESCRIPTION
It's the `AV1CodecConfigurationBox`, not the whole `AV1CodecConfigurationRecord`. It was already defined that way in https://github.com/ietf-wg-cellar/matroska-specification/blob/master/codec/av1.md#codecprivate-1

The bug comes from 9c9b0c34a25b316109263ae6c79e93d03497aee5