### PR TITLE
Add ``application/x-font-otf`` as a legacy MIME type

### DIFF
--- a/attachments.md
+++ b/attachments.md
@@ -91,6 +91,8 @@ Therefore, it is **RECOMMENDED** for a `Matroska Player` to support the followin
 
 * application/x-font-ttf: TrueType fonts, equivalent to `font/ttf`
 
+* application/x-font-otf: OpenType Layout fonts, equivalent to `font/otf`
+
 * application/vnd.ms-opentype: OpenType Layout fonts, equivalent to `font/otf`
 
 * application/font-sfnt: Generic SFNT Font Type, equivalent to `font/sfnt`


### PR DESCRIPTION
In a recent MKVToolNix [commit](https://gitlab.com/mbunkus/mkvtoolnix/-/commit/d858c2bf138009b8316b32c4554397ecb609d938), ``application/x-font-otf`` was defined as a legacy MIME type. It might be a good idea to include a mention of this in the documentation