### PR TITLE
remove BlockAddIDValue value for opaque data

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1128,7 +1128,7 @@ Block type identifier: 1
 Block type name: Opaque data
 
 Description: the `BlockAdditional` data is interpreted as opaque additional data passed to the codec
-with the Block data. `BlockAddIDValue` **MUST** be 1.
+with the Block data.
 
 ### ITU T.35 Metadata
 


### PR DESCRIPTION
It was added in #390 but that value is not allowed since #287.

The Opaque data (used by WavPack) don't make use of that value since it's for data unknown to the codec.