### PR TITLE
rework the BlockAdditional sections

### DIFF
--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -4,6 +4,22 @@ Extra data or metadata can be added to each `Block` using `BlockAdditional` data
 Each `BlockAdditional` contains a `BlockAddID` that identifies the kind of data it contains.
 When the `BlockAddID` is set to "1" the contents of the `BlockAdditional` element
 are defined by the Codec Mappings defines; see (#codec-blockadditions).
+The following XML depicts the nested elements of a `BlockGroup` element with an example of `BlockAdditions` with a `BlockAddID` of "1":
+
+```xml
+<BlockGroup>
+  <Block>{Binary data of a VP9 video frame in YUV}</Block>
+  <BlockAdditions>
+    <BlockMore>
+      <BlockAddID>1</BlockAddID>
+      <BlockAdditional>
+        {alpha channel encoding to supplement the VP9 frame}
+      </BlockAdditional>
+    </BlockMore>
+  </BlockAdditions>
+</BlockGroup>
+```
+
 When the `BlockAddID` is set a value greater than "1", then the contents of the
 `BlockAdditional` element are defined by the `BlockAdditionalMapping` element, within
 the associated `Track` element, where the `BlockAddID` element of `BlockAdditional` element

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -23,8 +23,8 @@ The following XML depicts the nested elements of a `BlockGroup` element with an 
 
 When the `BlockAddID` is set a value greater than "1", then the contents of the
 `BlockAdditional` element are defined by the `BlockAdditionalMapping` element, within
-the associated `Track` element, where the `BlockAddID` element of `BlockAdditional` element
-equals the `BlockAddIDValue` of the associated `Track`'s `BlockAdditionalMapping` element.
+the associated `TrackEntry` element, where the `BlockAddID` element of `BlockAdditional` element
+equals the `BlockAddIDValue` of the associated `TrackEntry`'s `BlockAdditionalMapping` element.
 That `BlockAdditionalMapping` element identifies a particular `Block Additional Mapping` by the `BlockAddIDType`.
 
 The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -26,6 +26,10 @@ the associated `Track` element, where the `BlockAddID` element of `BlockAddition
 equals the `BlockAddIDValue` of the associated `Track`'s `BlockAdditionalMapping` element.
 That `BlockAdditionalMapping` element identifies a particular `Block Additional Mapping` by the `BlockAddIDType`.
 
+The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply
+associate the `BlockMore` element with a `BlockAdditionMapping` of the associated `Track`.
+See (#block-additional-mapping) on `Block Additional Mappings` for more information.
+
 The following XML depicts a use of a `Block Additional Mapping` to associate a timecode value with a `Block`:
 
 ```xml

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -3,7 +3,8 @@
 Extra data or metadata can be added to each `Block` using `BlockAdditional` data.
 Each `BlockAdditional` contains a `BlockAddID` that identifies the kind of data it contains.
 When the `BlockAddID` is set to "1" the contents of the `BlockAdditional` element
-are defined by the Codec Mappings defines; see (#codec-blockadditions).
+are defined by the "Codec BlockAdditions" section of the codec; see (#codec-blockadditions).
+
 The following XML depicts the nested elements of a `BlockGroup` element with an example of `BlockAdditions` with a `BlockAddID` of "1":
 
 ```xml

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1112,6 +1112,7 @@ Block type name: Opaque data
 
 Description: the `BlockAdditional` data is interpreted as opaque additional data passed to the codec
 with the Block data.
+The usage of these `BlockAdditional` data is defined in the "Codec BlockAdditions" section of the codec; see (#codec-blockadditions).
 
 ### ITU T.35 Metadata
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -95,22 +95,6 @@ The values of `BlockAddID` that are 2 of greater have no semantic meaning, but s
 associate the `BlockMore` element with a `BlockAdditionMapping` of the associated `Track`.
 See (#block-additional-mapping) on `Block Additional Mappings` for more information.
 
-The following XML depicts the nested elements of a `BlockGroup` element with an example of `BlockAdditions`:
-
-```xml
-<BlockGroup>
-  <Block>{Binary data of a VP9 video frame in YUV}</Block>
-  <BlockAdditions>
-    <BlockMore>
-      <BlockAddID>1</BlockAddID>
-      <BlockAdditional>
-        {alpha channel encoding to supplement the VP9 frame}
-      </BlockAdditional>
-    </BlockMore>
-  </BlockAdditions>
-</BlockGroup>
-```
-
 ### Citation
 
 Documentation of the associated normative and informative references for the codec is **RECOMMENDED**.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -82,14 +82,7 @@ This `BlockAdditional` data with a `BlockAddID` of 1 **MAY** be passed to the as
 
 A codec definition **MUST** contain a "Codec BlockAdditions" section if the codec can use `BlockAdditional` data with a `BlockAddID` of 1.
 
-The following table defines the meanings of `BlockAddID` values.
-
-BlockAddID       | Definition
------------------|:---------------
-0                | Invalid.
-1                | The meaning of the `BlockAdditional` data is defined by the Codec Mapping.
-2 or greater     | The `BlockAdditional` data correspond to `BlockAdditionMapping` with the same `BlockAddIDValue` as the `BlockAddID`.
-Table: BlockAddID Values{#BlockAddIDValues}
+The `BlockAddID` values are defined in (#block-addition-mappings).
 
 ### Citation
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -77,9 +77,11 @@ Additional data that contextualizes or supplements a `Block` can be stored withi
 the `BlockAdditional` element of a `BlockMore` element [@!RFC9559, section 5.1.3.5.2.1].
 Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data it contains.
 
+A `BlockAddID` of 1 means the data in the `BlockAdditional` element are tied to the codec.
+This `BlockAdditional` data with a `BlockAddID` of 1 **MAY** be passed to the associated decoder alongside the `Block` content .
+
 A codec definition **MUST** contain a "Codec BlockAdditions" section if the codec can use `BlockAdditional` data with a `BlockAddID` of 1.
 
-This `BlockAdditional` data **MAY** be passed to the associated decoder along with the content of the `Block` element.
 The following table defines the meanings of `BlockAddID` values.
 
 BlockAddID       | Definition

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -75,12 +75,12 @@ then `none` **MUST** be used to define the Initialization and the `CodecPrivate`
 
 Additional data that contextualizes or supplements a `Block` can be stored within
 the `BlockAdditional` element of a `BlockMore` element [@!RFC9559, section 5.1.3.5.2.1].
+Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data it contains.
 
 A codec definition **MUST** contain a "Codec BlockAdditions" section if the codec can use `BlockAdditional` data with a `BlockAddID` of 1.
 
 This `BlockAdditional` data **MAY** be passed to the associated decoder along with the content of the `Block` element.
-Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data
-it contains. The following table defines the meanings of `BlockAddID` values.
+The following table defines the meanings of `BlockAddID` values.
 
 BlockAddID       | Definition
 -----------------|:---------------

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -79,11 +79,11 @@ be passed to the associated decoder along with the content of the `Block` elemen
 Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data
 it contains. The following table defines the meanings of `BlockAddID` values.
 
-BlockAddID Value | Definition
+BlockAddID       | Definition
 -----------------|:---------------
 0                | Invalid.
-1                | Indicates that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`.
-2 or greater     | `BlockAddID` values of 2 and greater are mapped to the `BlockAddIDValue` of the `BlockAdditionMapping` of the associated `Track`.
+1                | The meaning of the `BlockAdditional` data is defined by the Codec Mapping.
+2 or greater     | The `BlockAdditional` data correspond to `BlockAdditionMapping` with the same `BlockAddIDValue` as the `BlockAddID`.
 Table: BlockAddID Values{#BlockAddIDValues}
 
 The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -91,10 +91,6 @@ BlockAddID       | Definition
 2 or greater     | The `BlockAdditional` data correspond to `BlockAdditionMapping` with the same `BlockAddIDValue` as the `BlockAddID`.
 Table: BlockAddID Values{#BlockAddIDValues}
 
-The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply
-associate the `BlockMore` element with a `BlockAdditionMapping` of the associated `Track`.
-See (#block-additional-mapping) on `Block Additional Mappings` for more information.
-
 ### Citation
 
 Documentation of the associated normative and informative references for the codec is **RECOMMENDED**.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -74,8 +74,8 @@ then `none` **MUST** be used to define the Initialization and the `CodecPrivate`
 ### Codec BlockAdditions
 
 Additional data that contextualizes or supplements a `Block` can be stored within
-the `BlockAdditional` element of a `BlockMore` element. This `BlockAdditional` data **MAY**
-be passed to the associated decoder along with the content of the `Block` element.
+the `BlockAdditional` element of a `BlockMore` element [@!RFC9559, section 5.1.3.5.2.1].
+This `BlockAdditional` data **MAY** be passed to the associated decoder along with the content of the `Block` element.
 Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data
 it contains. The following table defines the meanings of `BlockAddID` values.
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -75,6 +75,9 @@ then `none` **MUST** be used to define the Initialization and the `CodecPrivate`
 
 Additional data that contextualizes or supplements a `Block` can be stored within
 the `BlockAdditional` element of a `BlockMore` element [@!RFC9559, section 5.1.3.5.2.1].
+
+A codec definition **MUST** contain a "Codec BlockAdditions" section if the codec can use `BlockAdditional` data with a `BlockAddID` of 1.
+
 This `BlockAdditional` data **MAY** be passed to the associated decoder along with the content of the `Block` element.
 Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data
 it contains. The following table defines the meanings of `BlockAddID` values.


### PR DESCRIPTION
In the Codec section only BlockAddID=1 is defined. The more generic parts are defined in the "Block Additional Mapping" section (which should have been in RFC 9559).