### PR TITLE
move Musepack Codec Mapping in Matroska v5

### DIFF
--- a/codec_iana.md
+++ b/codec_iana.md
@@ -65,7 +65,6 @@ A_DTS/LOSSLESS | 2 | Digital Theatre System Lossless | This document, (#a-dts-lo
 A_EAC3 | 2 | Dolby Digital Plus / E-AC-3 | This document, (#a-eac3)
 A_FLAC | 2 |  FLAC | This document, (#a-flac)
 A_MLP | 2 | Meridian Lossless Packing / MLP | This document, (#a-mlp)
-A_MPC | 2 | MPC (musepack) SV8 | This document, (#a-mpc)
 A_MPEG/L1 | 2 | MPEG Audio 1, 2 Layer I | This document, (#a-mpeg-l1)
 A_MPEG/L2 | 2 | MPEG Audio 1, 2 Layer II | This document, (#a-mpeg-l2)
 A_MPEG/L3 | 2 | MPEG Audio 1, 2, 2.5 Layer III | This document, (#a-mpeg-l3)

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -668,15 +668,6 @@ Codec Name: Meridian Lossless Packing / MLP
 
 Description: A lossless audio codec used in DVD-Audio discs. The format is similar to Dolby TrueHD ((#a-truehd)) but with less channels.
 
-### A_MPC
-
-Codec ID: A_MPC
-
-Codec Name: MPC (musepack) SV8
-
-Description: The main developer for musepack has requested that we wait until the SV8 framing has been fully defined
-for musepack before defining how to store it in Matroska.
-
 ### A_MPEG/L1
 
 Codec ID: A_MPEG/L1

--- a/matroska5_body.md
+++ b/matroska5_body.md
@@ -129,3 +129,16 @@ definition:
 : One language corresponding to the EditionString,
 in the form defined in [@!RFC5646]; see [@!RFC9559, section 12] on language codes.
 
+# New Codec Mapping
+
+This documents adds the following codec mappings, with the same definition format as in [@!I-D.ietf-cellar-codec].
+
+## A_MPC
+
+Codec ID: A_MPC
+
+Codec Name: MPC (musepack) SV8
+
+Description: The main developer for musepack has requested that we wait until the SV8 framing has been fully defined
+for musepack before defining how to store it in Matroska. See [@!Musepack].
+

--- a/matroska5_iana.md
+++ b/matroska5_iana.md
@@ -2,3 +2,12 @@
 
 ## Matroska Element IDs Registry Additions
 
+## Matroska Codec IDs Registry Additions
+
+This document adds the following Codec IDs to the "Matroska Codec IDs" Registry.
+The Change Controller for the these new entries is the IETF.
+
+Codec ID | Track Type | Description            | Reference
+--------:|:----------:|:-----------------------|:------------------------------
+A_MPC | 2 | MPC (musepack) SV8 | This document, (#a-mpc)
+Table: Additional "Matroska Codec IDs" Registry Values{#codec-id-registry-table}

--- a/rfc_backmatter_matroska5.md
+++ b/rfc_backmatter_matroska5.md
@@ -13,6 +13,16 @@
   <seriesInfo name="ITU-T Recommendation" value="J.17" />
 </reference>
 
+<reference anchor="Musepack" target="http://trac.musepack.net/musepack/wiki/SV8Specification">
+  <front>
+    <title>SV8 specification</title>
+    <author>
+      <organization>Musepack</organization>
+    </author>
+    <date day="24" month="February" year="2009"/>
+  </front>
+</reference>
+
 <reference anchor="NAB1964" target="https://www.richardhess.com/tape/history/NAB/NAB_Disc_Standard_1964_searchable.pdf">
   <front>
     <title>NAB Audio Recording And Reproducing Standards For Disc Recording And Reproducing</title>


### PR DESCRIPTION
The mapping is not defined yet and no files (should) exist with A_MPC.

We can create the proper mapping for Matroska v5.

Ref. #89