### PR TITLE
Add missing Codec ID prefix for unused track types

### DIFF
--- a/codec_iana.md
+++ b/codec_iana.md
@@ -3,9 +3,8 @@
 ## Matroska Codec IDs Registry
 
 This document defines registries for Codec IDs stored in the `CodecID` element.
-A `CodecID` is a case-sensitive ASCII string with a `V_`, `A_`, `S_` and `B_` prefix for
-video, audio, subtitle and button tracks respectively. The details of the string format
-are found in (#codec-id).
+A `CodecID` is a case-sensitive ASCII string with a prefix defined in (#CodecPrefix).
+The details of the string format are found in (#codec-id).
 
 To register a new Codec ID in this registry, one needs a Codec ID string, a TrackType value,
 a description, a Change Controller, and an optional Reference to a document describing the Codec ID.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -28,11 +28,11 @@ capital letters (A-Z) except for the last character of a `Codec ID Prefix` which
 an underscore ("_").
 
 Track Type      | Codec ID Prefix
------------|----------------
-Video      | "V_"
-Audio      | "A_"
-Subtitle   | "S_"
-Button     | "B_"
+----------------|----------------
+Video (1)       | "V_"
+Audio (2)       | "A_"
+Subtitle (17)   | "S_"
+Button (18)     | "B_"
 Table: Codec ID Prefix by Track Type{#CodecPrefix}
 
 Each `CodecID` **MUST** include a `Major Codec ID` immediately following the `Codec ID Prefix`.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -23,17 +23,17 @@ Support for a codec is defined in Matroska with the following values.
 
 Each codec supported for storage in Matroska **MUST** have a unique `CodecID`.
 Each `CodecID` **MUST** be prefixed with the string from the following table according to
-the associated type of the codec. All characters of a `Codec ID Prefix` **MUST** be
+the associated Track Type of the codec. All characters of a `Codec ID Prefix` **MUST** be
 capital letters (A-Z) except for the last character of a `Codec ID Prefix` which **MUST** be
 an underscore ("_").
 
-Codec Type | Codec ID Prefix
+Track Type      | Codec ID Prefix
 -----------|----------------
 Video      | "V_"
 Audio      | "A_"
 Subtitle   | "S_"
 Button     | "B_"
-Table: Codec ID Prefix by Codec Type{#CodecPrefix}
+Table: Codec ID Prefix by Track Type{#CodecPrefix}
 
 Each `CodecID` **MUST** include a `Major Codec ID` immediately following the `Codec ID Prefix`.
 A `Major Codec ID` **MAY** be followed by an **OPTIONAL** `Codec ID Suffix` to communicate a refinement

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -31,8 +31,12 @@ Track Type      | Codec ID Prefix
 ----------------|----------------
 Video (1)       | "V_"
 Audio (2)       | "A_"
+Complex (3)     | "O_"
+Logo (16)       | "L_"
 Subtitle (17)   | "S_"
 Button (18)     | "B_"
+Control (32)    | "C_"
+Metadata (33)   | "M_"
 Table: Codec ID Prefix by Track Type{#CodecPrefix}
 
 Each `CodecID` **MUST** include a `Major Codec ID` immediately following the `Codec ID Prefix`.


### PR DESCRIPTION
And reference the table in the Codec ID IANA registry. 

Fixes #125 