### PR TITLE
mention V_UNCOMPRESSED defines the packing in UncompressedFourCC

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -418,7 +418,8 @@ Codec ID: V_UNCOMPRESSED
 
 Codec Name: Video, raw uncompressed video frames
 
-Description: All details about the used color specs and bit depth are to be put/read from the `TrackEntry\Video\UncompressedFourCC` elements.
+Description: The codec doesn't use any form of compression. All the relevant fields of the `TrackEntry\Video` element **MUST** be filled to play this content correctly.
+In addition the packing of RGB, YUV, etc. pixels **MUST** be declared with a `TrackEntry\Video\UncompressedFourCC` element with values defined in [@!RFC9559, section 5.1.4.1.28.15].
 
 Initialization: none
 


### PR DESCRIPTION
And that it needs a lot of TrackEntry\Video elements to be usable. Although the list is not exhaustive.

Unfortunately the list of FourCC is not "well defined" as it has many uncertain sources and there might be incompatible collisions between them.

We could add our own registry of known FourCC's, but that means we would need to collect a lot of the existing ones and hope people will use our list...

Ref. #337