### PR TITLE
Add HDR10+ mention in ITU T.35 metadata

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -1123,6 +1123,8 @@ Block type name: ITU T.35 metadata
 Description: the `BlockAdditional` data is interpreted as ITU T.35 metadata, as defined by [@?ITU-T.35]
 terminal codes. `BlockAddIDValue` **MUST** be 4.
 
+HDR10+ dynamic metadata can be stored as ITU T.35 terminal codes as defined in Table 8 of [@?CTA.861-4].
+
 ### avcE
 
 Block type identifier: 0x61766345

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -61,6 +61,17 @@
   </front>
 </reference>
 
+<reference anchor="CTA.861-4" target="https://shop.cta.tech/products/updates-to-dynamic-hdr-metadata-signaling">
+  <front>
+    <title>Updates to Dynamic HDR Metadata Signaling</title>
+    <author>
+      <organization>Consumer Technology Association</organization>
+    </author>
+    <date month="March" year="2019" />
+  </front>
+  <seriesInfo name="CTA" value="861-4" />
+</reference>
+
 <reference anchor="Dirac" target="https://web.archive.org/web/20150503015104/http://diracvideo.org/download/specification/dirac-spec-latest.pdf">
   <front>
     <title>Dirac Specification</title>


### PR DESCRIPTION
Since it's the official way.

Fixes #345