### PR TITLE
fix AttachmentLink occurence

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -454,7 +454,7 @@ see [@?I-D.ietf-cellar-codec] for more info.</documentation>
     <documentation lang="en" purpose="definition">A human-readable string specifying the codec.</documentation>
     <extension type="webmproject.org" webm="1"/>
   </element>
-  <element name="AttachmentLink" path="\Segment\Tracks\TrackEntry\AttachmentLink" id="0x7446" type="uinteger" maxver="3" range="not 0" maxOccurs="1">
+  <element name="AttachmentLink" path="\Segment\Tracks\TrackEntry\AttachmentLink" id="0x7446" type="uinteger" maxver="3" range="not 0">
     <documentation lang="en" purpose="definition">The UID of an attachment that is used by this codec.</documentation>
     <documentation lang="en" purpose="usage notes">The value **MUST** match the `FileUID` value of an attachment found in this `Segment`.</documentation>
     <extension type="libmatroska" cppname="TrackAttachmentLink"/>


### PR DESCRIPTION
A track can reference multiple attachments.

The max value to 1 was introduced in 2c0a14d3e0117175c1bf224c7be6496eedb28541 and then turned into a `maxOccurs` value in  6210296013de0e3f95ca15fde43595bfcd6ee774.

Fixes #930