### PR TITLE
fix SMPTE ST12-1 bits interpretation

### DIFF
--- a/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
+++ b/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
@@ -6,34 +6,20 @@ If the Block uses Lacing, the timecode value is associated with the first frame 
 
 The `Block Additional Mapping` contains a full binary representation of a 64-bit SMPTE timecode
 value stored in big-endian format and expressed exactly as defined in Section 8 and 9
-of SMPTE 12M [@!SMPTE.ST12-1]. For convenience, here are the bit assignments for a
-SMPTE ST 12-1 binary representation as described in [@?RFC5484, section 6.2]:
+of SMPTE 12M [@!SMPTE.ST12-1].
+For convenience, here are the time address bit assignments as described in [@?RFC5484, section 6.2]:
 
 | Bit Positions | Label                  |
 |:-------------:|:-----------------------|
 | 0--3          | Units of frames        |
-| 4--7          | First binary group     |
 | 8--9          | Tens of frames         |
-| 10            | Drop frame flag        |
-| 11            | Color frame flag       |
-| 12--15        | Second binary group    |
 | 16--19        | Units of seconds       |
-| 20--23        | Third binary group     |
 | 24--26        | Tens of seconds        |
-| 27            | Polarity correction    |
-| 28--31        | Fourth binary group    |
 | 32--35        | Units of minutes       |
-| 36--39        | Fifth binary group     |
 | 40--42        | Tens of minutes        |
-| 43            | Binary group flag BGF0 |
-| 44--47        | Sixth binary group     |
 | 48--51        | Units of hours         |
-| 52--55        | Seventh binary group   |
 | 56--57        | Tens of hours          |
-| 58            | Binary group flag BGF1 |
-| 59            | Binary group flag BGF2 |
-| 60--63        | Eighth binary group    |
-Table: SMPTE ST 12-1 Bits Assignment{#ST12Bits}
+Table: SMPTE ST 12-1 Time Address Bit Positions{#ST12Bits}
 
 For example, a timecode value of "07:32:54;18" can be expressed as a 64-bit SMPTE 12M value as:
 

--- a/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
+++ b/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
@@ -21,9 +21,46 @@ For convenience, here are the time address bit assignments as described in [@?RF
 | 56--57        | Tens of hours          |
 Table: SMPTE ST 12-1 Time Address Bit Positions{#ST12Bits}
 
-For example, a timecode value of "07:32:54;18" can be expressed as a 64-bit SMPTE 12M value as:
+For example, a timecode value of "07:12:26;18" can be expressed as a 64-bit SMPTE 12M value as:
 
 ```
 10000000 01100000 01100000 01010000
 00100000 00110000 01110000 00000000
 ```
+
+Or with the irrelevant bits marked with an "x" which gives 26 usable bits:
+
+```
+1000xxxx 01xxxxxx 0110xxxx 010xxxxx
+0010xxxx 001xxxxx 0111xxxx 00xxxxxx
+```
+
+This is interpreted in hexadecimal:
+
+- 0x8 units of frames
+- 0x1 tens of frames
+- 0x6 units of seconds
+- 0x2 tens of seconds
+- 0x2 units of minutes
+- 0x1 tens of minutes
+- 0x7 units of hours
+- 0x0 tens of hours
+
+Given no value is above 9, the BCD coding correspond to the actual values:
+
+- 8 units of frames
+- 1 tens of frames
+- 6 units of seconds
+- 2 tens of seconds
+- 2 units of minutes
+- 1 tens of minutes
+- 7 units of hours
+- 0 tens of hours
+
+Or:
+
+- 18 frames
+- 26 seconds
+- 12 minutes
+- 07 hours
+

--- a/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
+++ b/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
@@ -6,7 +6,7 @@ If the Block uses Lacing, the timecode value is associated with the first frame 
 
 The `Block Additional Mapping` contains a full binary representation of a 64-bit SMPTE timecode
 value stored in big-endian format and expressed exactly as defined in Section 8 and 9
-of SMPTE 12M [@!SMPTE.ST12-1].
+of SMPTE 12M [@!SMPTE.ST12-1], without the 16-bit synchronization word.
 For convenience, here are the time address bit assignments as described in [@?RFC5484, section 6.2]:
 
 | Bit Positions | Label                  |


### PR DESCRIPTION
I don't get the same results as @JeromeMartinez in #682

Looking at the use of `AV_FRAME_DATA_S12M_TIMECODE` in FFmpeg it seems broken all over the place (using 32-bit values).

~~On top of #936 which has some text cleanup (to avoid rebase issues).~~