### PR TITLE
[errata] define CueTime as the sum of Cluster + Block timestamps

### DIFF
--- a/cues.md
+++ b/cues.md
@@ -12,6 +12,10 @@ part of the `CuePoint` element, such as `CueDuration`,
 any `Matroska Reader` with additional information to use in the
 optimization of seeking performance.
 
+The absolute timestamp stored in `CueTime` corresponds to the sum of the
+`Cluster` Timestamp and the `Block` Timestamp.
+The `CodecDelay`, `DiscardPadding` and `SeekPreRoll` are not taken in account.
+
 ## Recommendations
 
 The following recommendations are provided to optimize Matroska performance.


### PR DESCRIPTION
No CodecDelay, DiscardPadding or SeekPreRoll.

Fixes #849

Once merged an errata should be sent to https://www.rfc-editor.org/errata.php#reportnew