### PR TITLE
Use "Matroska multimedia container" in the abstracts

### DIFF
--- a/index_chapter_codecs.md
+++ b/index_chapter_codecs.md
@@ -38,7 +38,7 @@ email="dave@dericed.com"
 
 .# Abstract
 
-This document defines common Matroska Chapter Codecs, the basic Matroska Script and the DVD inspired DVD menu [@?DVD-Video].
+This document defines common Matroska multimedia container Chapter Codecs, the basic Matroska Script and the DVD inspired DVD menu [@?DVD-Video].
 
 {mainmatter}
 

--- a/index_codec.md
+++ b/index_codec.md
@@ -38,7 +38,7 @@ fullname="Dave Rice"
 
 .# Abstract
 
-This document defines the Matroska codec mappings, including the codec ID, layout of data
+This document defines the Matroska multimedia container codec mappings, including the codec ID, layout of data
 in a `Block` element and in an optional `CodecPrivate` element.
 
 {mainmatter}

--- a/index_control.md
+++ b/index_control.md
@@ -38,7 +38,7 @@ email="dave@dericed.com"
 
 .# Abstract
 
-This document defines the Control Track usage found in the Matroska container.
+This document defines the Matroska multimedia container Control Track usage found in the Matroska container.
 
 {mainmatter}
 

--- a/index_matroska5.md
+++ b/index_matroska5.md
@@ -38,7 +38,7 @@ fullname="Dave Rice"
 
 .# Abstract
 
-This document defines the Matroska version 5 additions.
+This document defines the Matroska multimedia container version 5 additions.
 
 {mainmatter}
 

--- a/index_tags.md
+++ b/index_tags.md
@@ -38,7 +38,7 @@ fullname="Dave Rice"
 
 .# Abstract
 
-This document defines the Matroska tags, namely the tag names and their respective semantic meaning.
+This document defines the Matroska multimedia container tags, namely the tag names and their respective semantic meaning.
 
 {mainmatter}
 


### PR DESCRIPTION
This is the generic term used in other places.