### PR TITLE
make floating point string formatting a MUST

### DIFF
--- a/cellar-tags/tagging.md
+++ b/cellar-tags/tagging.md
@@ -111,12 +111,12 @@ To store a specific day such as May 1st, 2003, one would use "2003-05-01".
 Only ASCII numbers "0" to "9" and the "." character **MUST** be used.
 The "." separator represents the boundary between the integer value and the decimal parts.
 If the string doesn't contain the "." separator, the value is an integer value.
-Thousandths separators **MUST NOT** be used.
+Digit grouping delimiters **MUST NOT** be used.
 
 To display it differently for another locale, applications **MUST** support auto
 replacement on display.
 
-In legacy media containers, it is possible that the "," separator or the thousandths separators might have been used.
+In legacy media containers, it is possible that the "," separator or the digit grouping delimiters might have been used.
 
 #### Country Code Tags Formatting
 

--- a/cellar-tags/tagging.md
+++ b/cellar-tags/tagging.md
@@ -116,7 +116,14 @@ Digit grouping delimiters **MUST NOT** be used.
 To display it differently for another locale, applications **MUST** support auto
 replacement on display.
 
-In legacy media containers, it is possible that the "," separator or the digit grouping delimiters might have been used.
+In legacy media containers, it is possible that the "," character might have been used as a separator
+or that digit grouping delimiters might have been used. A `Matroska Reader` **SHOULD** consider the following
+character handling to parse such legacy formats:
+
+* if multiple instances of the same non-number character are found, they are be ignored,
+* if only one "." character is found and no other non-number character is found, the "." is the integer-decimal separator,
+* if only one "," character is found and no other non-number character is found, the "," is a digit grouping delimiter,
+* any other non-number character is ignored.
 
 #### Country Code Tags Formatting
 

--- a/cellar-tags/tagging.md
+++ b/cellar-tags/tagging.md
@@ -107,14 +107,16 @@ To store a specific day such as May 1st, 2003, one would use "2003-05-01".
 
 #### Number Tags Formatting
 
-`TagString` fields that require a floating-point number **SHOULD** use the "." mark instead of the "," mark.
-Only ASCII numbers "0" to "9" and the "." character **SHOULD** be used.
+`TagString` fields that require a floating-point number **MUST** use the "." mark instead of the "," mark.
+Only ASCII numbers "0" to "9" and the "." character **MUST** be used.
 The "." separator represents the boundary between the integer value and the decimal parts.
 If the string doesn't contain the "." separator, the value is an integer value.
-Thousandths separators **SHOULD NOT** be used.
+Thousandths separators **MUST NOT** be used.
 
-To display it differently for another locale, applications **SHOULD** support auto
+To display it differently for another locale, applications **MUST** support auto
 replacement on display.
+
+In legacy media containers, it is possible that the "," separator or the thousandths separators might have been used.
 
 #### Country Code Tags Formatting
 

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -321,9 +321,9 @@ The majority of the contemporary rock and pop music you hear on the radio these 
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
 the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#number-tags-formatting).</description>
     </tag>
-    <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8">
+    <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="UTF-8" parser="number-with-unit">
       <description lang="en">The gain to apply to reach 89 dB SPL (Sound Pressure Level in decibels) on playback. The value is computed according to the [@!ReplayGain] standard.
-      The value in decibels (dB) is stored as a string (e.g., "-0.42 dB"). The decibel unit is **OPTIONAL**.
+      The value in decibels (dB) is stored as a string (e.g., "-0.42 dB"), using the Float number defined in (#number-tags-formatting). The decibel unit is **OPTIONAL**. There **MAY** be a space between the number and the decibel unit.
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
     <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8" parser="number">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -290,7 +290,7 @@ using the Country Code format defined in (#country-code-tags-formatting).</descr
     <tag name="PLAY_COUNTER" class="User Information" type="UTF-8">
       <description lang="en">The number of time the item has been played.</description>
     </tag>
-    <tag name="RATING" class="User Information" type="UTF-8">
+    <tag name="RATING" class="User Information" type="UTF-8" parser="number">
       <description lang="en">A numeric value defining how much a person likes the song/movie. The number is between
 0 and 5 with stored using the Float number defined in (#number-tags-formatting) (e.g., 2.7), 5(.0) being the highest possible rating.
 Other rating systems with different ranges will have to be scaled.</description>
@@ -301,15 +301,15 @@ Other rating systems with different ranges will have to be scaled.</description>
     <tag name="ENCODER_SETTINGS" class="Technical Information" type="UTF-8">
       <description lang="en">A list of the settings used for encoding this item. No specific format.</description>
     </tag>
-    <tag name="BPS" class="Technical Information" type="UTF-8">
+    <tag name="BPS" class="Technical Information" type="UTF-8" parser="number">
       <description lang="en">The average bits per second of the specified item stored using the Float number defined in (#number-tags-formatting).
       This is only the data in the `Block(s)`, and excludes headers and any container overhead.</description>
     </tag>
-    <tag name="FPS" class="Technical Information" type="UTF-8">
+    <tag name="FPS" class="Technical Information" type="UTF-8" parser="number">
       <description lang="en">The average frames per second of the specified item. This is typically the average
 number of Blocks per second stored using the Float number defined in (#number-tags-formatting). In the event that lacing is used, each laced chunk is to be counted as a separate frame.</description>
     </tag>
-    <tag name="BPM" class="Technical Information" type="UTF-8">
+    <tag name="BPM" class="Technical Information" type="UTF-8" parser="number">
       <description lang="en">Average number of beats per minute in the complete target (e.g., a chapter) stored using the Float number defined in (#number-tags-formatting).</description>
     </tag>
     <tag name="MEASURE" class="Technical Information" type="UTF-8">
@@ -317,7 +317,7 @@ number of Blocks per second stored using the Float number defined in (#number-ta
 a regular grouping of beats, a meter, as indicated in musical notation by the time signature.
 The majority of the contemporary rock and pop music you hear on the radio these days is written in the 4/4 time signature.</description>
     </tag>
-    <tag name="TUNING" class="Technical Information" type="UTF-8">
+    <tag name="TUNING" class="Technical Information" type="UTF-8" parser="number">
       <description lang="en">It is saved as a frequency in hertz to allow near-perfect tuning of instruments to
 the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stored using the Float number defined in (#number-tags-formatting).</description>
     </tag>
@@ -326,7 +326,7 @@ the same tone as the musical piece (e.g., "441.34" in Hertz). The values is stor
       The value in decibels (dB) is stored as a string (e.g., "-0.42 dB"). The decibel unit is **OPTIONAL**.
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
     </tag>
-    <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8">
+    <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="UTF-8" parser="number">
       <description lang="en">The maximum absolute peak amplitude of the item. The value is computed according to the [@!ReplayGain] standard.
       The value is a normalized absolute sample value of the target audio, using the Float number defined in (#number-tags-formatting) (e.g., "1.0129").
       Note that ReplayGain information can be found at all `TargetType` levels (track, album, etc).</description>
@@ -376,7 +376,7 @@ This holds the same information as the "MCDI" in [@!ID3v2.3] when the `TargetTyp
     <tag name="PURCHASE_OWNER" class="Commercial" type="UTF-8">
       <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2.3] when the `TargetTypeValue` is 30 (TRACK).</description>
     </tag>
-    <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8">
+    <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8" parser="number">
       <description lang="en">The amount paid for entity, using the Float number defined in (#number-tags-formatting).
       The currency is not included. For instance, you would store "15.59" instead of "$15.59USD".</description>
     </tag>


### PR DESCRIPTION
Although readers may be ready to handle other formats.

I haven't checked existing code to see if some format check/parsing/fixing is done. cc @mbunkus 