### PR TITLE
make country code string formatting a MUST

### DIFF
--- a/tagging.md
+++ b/tagging.md
@@ -118,7 +118,7 @@ replacement on display.
 
 #### Country Code Tags Formatting
 
-`TagString` fields that use a Country Code **SHOULD** use the Matroska countries form defined in [@!RFC9559, section 13],
+`TagString` fields that use a Country Code **MUST** use the Matroska countries form defined in [@!RFC9559, section 13],
 i.e. [@!RFC5646] two-letter region subtags, without the UK exception.
 
 ## Target Types


### PR DESCRIPTION
The SHOULD was added in 2734e4053ff6ba12d59bf78906ecb89e7b905fa8. But it was not present in the original spec which just defined the Matroska country code format.