### PR TITLE
reword the LYRICS text

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -105,7 +105,7 @@ This is akin to the "TPE1" tag in [@!ID3v2.3] when the `TargetTypeValue` is 30 (
     <tag name="LYRICS" class="Entities" type="UTF-8">
       <description lang="en">The lyrics corresponding to a song, in case audio synchronization is not known
 or as a duplicate of a subtitle track. Editing this value, when it is a duplicate of a subtitle track, **SHOULD** also result
-in editing the subtitle track for more consistency.</description>
+in editing the subtitle track for more consistency, and vice versa.</description>
     </tag>
     <tag name="LYRICIST" class="Entities" type="UTF-8">
       <description lang="en">The name of a person who wrote the lyrics for a musical item. This is akin to the "TEXT" tag in [@!ID3v2.3] when the `TargetTypeValue` is 30 (TRACK).</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -103,8 +103,8 @@ This is akin to the "TPE1" tag in [@!ID3v2.3] when the `TargetTypeValue` is 30 (
       <description lang="en">The name of a person who arranged the piece (e.g., Ravel).</description>
     </tag>
     <tag name="LYRICS" class="Entities" type="UTF-8">
-      <description lang="en">The lyrics corresponding to a song (in case audio synchronization is not known
-or as a doublon to a subtitle track). Editing this value, when subtitles are found, **SHOULD** also result
+      <description lang="en">The lyrics corresponding to a song, in case audio synchronization is not known
+or as a duplicate of a subtitle track. Editing this value, when it is a duplicate of a subtitle track, **SHOULD** also result
 in editing the subtitle track for more consistency.</description>
     </tag>
     <tag name="LYRICIST" class="Entities" type="UTF-8">


### PR DESCRIPTION
doublon is not used in English. And it's clearer to explain the double edition.