### PR TITLE
refer to the Matroska specification as RFC9559

### DIFF
--- a/cellar-codec/index_codec.md
+++ b/cellar-codec/index_codec.md
@@ -45,7 +45,7 @@ in a `Block` element and in an optional `CodecPrivate` element.
 
 # Introduction
 
-Matroska is a multimedia container format.
+Matroska is a multimedia container format defined in [@!RFC9559].
 It stores interleaved and timestamped audiovisual data using various codecs.
 To interpret the codec data, a mapping between the way the data is stored in Matroska and
 how it is understood by such a codec is necessary.


### PR DESCRIPTION
As done in 30f45f736d5ea4df66232429b3f2cfed1c9cfaa5.