### PR TITLE
remove redundant audio codec mapping rule

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -497,8 +497,7 @@ Codec ID: A_AAC/MPEG2/LC
 
 Codec Name: Low Complexity
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -510,8 +509,7 @@ Codec ID: A_AAC/MPEG2/LC/SBR
 
 Codec Name: Low Complexity with Spectral Band Replication
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -523,8 +521,7 @@ Codec ID: A_AAC/MPEG2/MAIN
 
 Codec Name: MPEG2 Main Profile
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -536,8 +533,7 @@ Codec ID: A_AAC/MPEG2/SSR
 
 Codec Name: Scalable Sampling Rate
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -549,8 +545,7 @@ Codec ID: A_AAC/MPEG4/LC
 
 Codec Name: Low Complexity
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -562,8 +557,7 @@ Codec ID: A_AAC/MPEG4/LC/SBR
 
 Codec Name: Low Complexity with Spectral Band Replication
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -575,8 +569,7 @@ Codec ID: A_AAC/MPEG4/LTP
 
 Codec Name: Long Term Prediction
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -588,8 +581,7 @@ Codec ID: A_AAC/MPEG4/MAIN
 
 Codec Name: MPEG4 Main Profile
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 
@@ -601,8 +593,7 @@ Codec ID: A_AAC/MPEG4/SSR
 
 Codec Name: Scalable Sampling Rate
 
-Description: Channel number and sample rate have to be read from the corresponding audio element.
-The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
+Description: The audio stream is stripped from ADTS headers and normal Matroska frame based muxing scheme is applied.
 
 Initialization: none
 


### PR DESCRIPTION
It's already implied by the Audio Codec Mappings section text.