### PR TITLE
add a proper V_MS/VFW/FOURCC description

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -328,13 +328,13 @@ Codec ID: `V_MS/VFW/FOURCC`
 
 Codec Name: Microsoft Video Codec Manager (VCM)
 
-Description: The `CodecPrivate` contains the VCM structure BITMAPINFOHEADER including
+Description: Video frames originating from Video For Windows, using the Microsoft Video Codec Manager codecs.
+This is a codec designed to be transmuxed back and forth from AVI sources.
+
+Initialization: The `CodecPrivate` contains the VCM structure BITMAPINFOHEADER including
 the extra private bytes, as defined in [@!BITMAPINFOHEADER].
 The data are stored in little-endian format (like on IA32 machines). Where is the Huffman table stored
 in HuffYUV, not AVISTREAMINFO ??? And the FourCC, not in AVISTREAMINFO.fccHandler ???
-
-Initialization: `CodecPrivate` contains the VCM structure BITMAPINFOHEADER including the extra private bytes,
-as defined by Microsoft in [@!BITMAPINFOHEADER].
 
 ### V_QUICKTIME
 

--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -333,8 +333,7 @@ This is a codec designed to be transmuxed back and forth from AVI sources.
 
 Initialization: The `CodecPrivate` contains the VCM structure BITMAPINFOHEADER including
 the extra private bytes, as defined in [@!BITMAPINFOHEADER].
-The data are stored in little-endian format (like on IA32 machines). Where is the Huffman table stored
-in HuffYUV, not AVISTREAMINFO ??? And the FourCC, not in AVISTREAMINFO.fccHandler ???
+The data are stored in little-endian format (like on IA32 machines).
 
 ### V_QUICKTIME
 


### PR DESCRIPTION
And remove duplicate Initialization definition.

And remove bogus HuffYUV reference

From the libavformat+libavcodec spec there is no special
handling of HuffYUV needed in AVI. This is the regular extradata.

Fixes #982