### PR TITLE
BlockAddIDValue 4 is not recommended

### DIFF
--- a/cellar-codec/block_additional_mappings_intro.md
+++ b/cellar-codec/block_additional_mappings_intro.md
@@ -31,6 +31,10 @@ The values of `BlockAddID` that are 2 or greater have no semantic meaning, but s
 associate the `BlockMore` element with a `BlockAdditionMapping` of the associated `Track`.
 See (#block-additional-mapping) on `Block Additional Mappings` for more information.
 
+It is **RECOMMENDED** to not use a value of 4 for `BlockAddID` and `BlockAddIDValue` when `BlockAddIDType` is not 4 -- i.e., ITU T.35 metadata (#itu-t-35-metadata),
+as some WebM-oriented demuxers consider a block with `BlockAddID` of 4 as ITU T.35 metadata
+without checking the `BlockAddIDType` element.
+
 The following XML depicts a use of a `Block Additional Mapping` to associate a timecode value with a `Block`:
 
 ```xml


### PR DESCRIPTION
Rebased version of #745 using the normative RECOMMENDED word as [suggested](https://github.com/ietf-wg-cellar/matroska-specification/pull/745#discussion_r1149215591) and some links to the T.35 block addition spec.

I'll merge this quickly but it can still be changed before we send it to the RFC editors (and also discussed in the upcoming meeting).