### PR TITLE
Clarification about when CodecPrivate is mandatory

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -74,6 +74,7 @@ within a track, then that updated Initialization data **MUST** be written into t
 of the first `Cluster` to require it. If the encoding does not require any form of Initialization,
 then `none` **MUST** be used to define the Initialization and the `CodecPrivate` element
 **SHOULD NOT** be written and **MUST** be ignored.
+If the `TrackEntry` contains a `CodecPrivate` element, its data **MUST** be provided to the decoder.
 
 ### Codec BlockAdditions
 


### PR DESCRIPTION
Rebased version #446 where a lot of the added Initialization where already added earlier.
This one line is the only actual addition that is left.

I'll merge this quickly but it can still be changed before we send it to the RFC editors (and also discussed in the upcoming meeting).