### PR TITLE
let mmark treat appendix as a section

### DIFF
--- a/cellar-tags/tagging.md
+++ b/cellar-tags/tagging.md
@@ -96,7 +96,7 @@ at all times. It is **RECOMMENDED** to use strict formatting when writing new ta
 #### Date Tags Formatting
 
 `TagString` fields defined in this document with dates **MUST** have the following format: "YYYY-MM-DD hh:mm:ss.mss" or a reduced version.
-The format is similar to the [@?ISO8601] date and time format defined in [@RFC3339, appendix A]
+The format is similar to the [@?ISO8601] date and time format defined in [@RFC3339, section A]
 without the "T" separator, without the time offset and with the addition of the milliseconds "mss".
 The date and times represented are in Coordinated Universal Time (UTC).
 


### PR DESCRIPTION
Sections with a letter are recognized by xml2rfc as appendices, using section instead of appendix let mmark turn the link into the proper section link.

Fixes #1007