### PR TITLE
Details about signaling the source of the timecode

### DIFF
--- a/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
+++ b/cellar-codec/block_additional_mappings/smpte-st12-1-timecode.md
@@ -64,3 +64,34 @@ Or:
 - 12 minutes
 - 07 hours
 
+### Signaling the source of the timecode
+
+Source of the timecode SHOULD be signaled by the `TITLE` tag, with `TagLanguage` element set to `und`, associated to the Block Additional (using `TagTrackUID` and `TagBlockAddIDValue`).
+
+The following vocabulary is RECOMMENDED for known sources:
+
+- "9PIN" for data in the Sony 9-Pin RS-422 interface [@!Sony.9PIN], exact source unknown
+- "9PIN_TIMER1" for timer-1 data in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_TIMER2" for timer-2 data in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_LTC" for Linear Time Code in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_VITC" for Vertical Interval Time Code in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_VITCUSER" for Vertical Interval Time Code user bits in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_GENTIME" for time code generator in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "9PIN_GENUSER" for time code generator user bits in the Sony 9-Pin RS-422 interface [@!Sony.9PIN]
+- "ATC_LTC" for a Linear Time Code as defined in SMPTE ST 12-2 [@!SMPTE.ST12-2] (formerly SMPTE RP 188)
+- "ATC_VITC" for a Vertical Interval Time Code, progressive frame or first field of an interlaced content, as defined in SMPTE ST 12-2 [@!SMPTE.ST12-2] (formerly SMPTE RP 188)
+- "ATC_VITC2" for a Vertical Interval Time Code, second field of an interlaced content, as defined in SMPTE ST 12-2 [@!SMPTE.ST12-2] (formerly SMPTE RP 188)
+- "BITC" for a burnt-in timecode i.e. originally burnt into the video image so that humans can easily read the time code
+- "CTL" for a timecode originally embedded in the control track of a videotape, as found in JVC CTL [@!JVC.CTL]
+- "DAT_ABSOLUTE" for a timecode originally embedded in the metadata of a content which indicates the time code from the beginning of a tape, as found in Sony DAT [@!Sony.DAT]
+- "DAT_PROGRAM" for a timecode originally embedded in the metadata of a content which indicates the time code from the beginning of a program, as found in Sony DAT [@!Sony.DAT]
+- "DAT_RUNNING" for a timecode originally embedded in the metadata of a content which indicates the time code from an unspecified start, as found in Sony DAT [@!Sony.DAT]
+- "LTC" for a Linear Time Code as defined in SMPTE ST 12-1 [@!SMPTE.ST12-1]
+- "SDTI" for a time code originally embedded in a Serial Data Transport Interface, as defined in SMPTE ST 305 [@!SMPTE.ST305]
+- "SYSTEMSCHEME1" for a time code originally embedded in a System Scheme 1 application, as defined in SMPTE ST 405 [@!SMPTE.ST405]
+- "VITC" for a Vertical Interval Time Code, as defined in SMPTE ST 12-1 [@!SMPTE.ST12-1], progressive frame or first field of an interlaced content
+- "VITC2" for a Vertical Interval Time Code, as defined in SMPTE ST 12-1 [@!SMPTE.ST12-1], second field of an interlaced content
+
+Space character SHOULD NOT be used for the vocabulary of the source of time code.
+
+A Space character and any character after it SHOULD be considered as not part of the vocabulary of the source of the timecode.

--- a/cellar-codec/rfc_backmatter_codec.md
+++ b/cellar-codec/rfc_backmatter_codec.md
@@ -341,6 +341,66 @@
   <seriesInfo name="ST" value="12-1:2014, DOI 10.5594/SMPTE.ST12-1.2014" />
 </reference>
 
+<reference anchor="SMPTE.ST12-2" target="https://pub.smpte.org/doc/st12-2/20140220-pub/">
+  <front>
+    <title>Transmission of Time Code in the Ancillary Data Space</title>
+    <author>
+      <organization>SMPTE</organization>
+    </author>
+    <date day="20" month="February" year="2014" />
+  </front>
+  <seriesInfo name="ST" value="12-2:2014" />
+</reference>
+
+<reference anchor="SMPTE.ST305" target="https://www.normsplash.com/SMPTE/134363467/SMPTE-ST-305">
+  <front>
+    <title>Serial Data Transport Interface</title>
+    <author>
+      <organization>SMPTE</organization>
+    </author>
+    <date day="21" month="July" year="2005" />
+  </front>
+  <seriesInfo name="ST" value="305:2005" />
+</reference>
+
+<reference anchor="SMPTE.ST405" target="https://www.normsplash.com/SMPTE/142435617/SMPTE-ST-405">
+  <front>
+    <title>Material Exchange Format (MXF) - Elements and Individual Data Items for the MXF Generic Container System Scheme 1</title>
+    <author>
+      <organization>SMPTE</organization>
+    </author>
+    <date day="07" month="July" year="2006" />
+  </front>
+  <seriesInfo name="ST" value="405:2006" />
+</reference>
+
+<reference anchor="JVC.CTL" target="https://en.wikipedia.org/wiki/Control_track_longitudinal_timecode">
+  <front>
+    <title>Control track longitudinal timecode (CTL)</title>
+    <author>
+      <organization>JVC</organization>
+    </author>
+  </front>
+</reference>
+
+<reference anchor="Sony.9PIN" target="https://web.archive.org/web/20150601202908/http://www.belle-nuit.com/archives/9pin.html">
+  <front>
+    <title>9-pin protocol</title>
+    <author>
+      <organization>Sony</organization>
+    </author>
+  </front>
+</reference>
+
+<reference anchor="Sony.DAT" target="https://en.wikipedia.org/wiki/Digital_Audio_Tape">
+  <front>
+    <title>Digital Audio Tape (DAT)</title>
+    <author>
+      <organization>Sony</organization>
+    </author>
+  </front>
+</reference>
+
 <reference anchor="WAVEFORMATEX" target="https://docs.microsoft.com/en-us/windows/win32/api/mmeapi/ns-mmeapi-waveformatex">
   <front>
     <title>WAVEFORMATEX structure</title>


### PR DESCRIPTION
Add something similar to `\Segment\Tracks\TrackEntry\Name`.
While trying to change `\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName` definition, I remarked that this block is too much defined with a specific value in other parts of Matroska specs (it should also be utf-8 and not non utf-8 string), so I switched to a new block identifier. This would also avoid to have an errata for this update.