### PR TITLE
Reorder child nodes of element to comply with EBMLSchema.xsd sequence

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1174,7 +1174,7 @@ This value **MUST** be unique for each `ContentEncoding` found in the `ContentEn
       <enum value="0" label="Compression"/>
       <enum value="1" label="Encryption"/>
     </restriction>
-    <extension type="enum source" registry="Content Encoding Type" policy="Specification Required"/>      
+    <extension type="enum source" registry="Content Encoding Type" policy="Specification Required"/>
     <extension type="webmproject.org" webm="1"/>
     <extension type="stream copy" keep="1"/>
   </element>


### PR DESCRIPTION
The [EBMLSchema.xsd schema](https://github.com/ietf-wg-cellar/ebml-specification/blob/1b979df551709813c5f9e7163b886a09436fbfff/EBMLSchema.xsd#L26) defines elementType with an xs:sequence requiring children in this order:
1. documentation,
2. implementation_note,
3. restriction,
4. extension.

Several elements in the Matroska schema had extension elements positioned before restriction elements, violating this constraint.

Reordered `extension` children of `element` to come after `restriction`.

This ensures the schema validates against EBMLSchema.xsd by mitigating the following validation errors:
```
% xmllint --noout --schema EBMLSchema.xsd ebml_matroska.xml
ebml_matroska.xml:295: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:565: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:592: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:668: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:773: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:785: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:797: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:947: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1100: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1157: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1175: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1192: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1223: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1264: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1482: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1564: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml:1618: element restriction: Schemas validity error : Element '{urn:ietf:rfc:8794}restriction': This element is not expected. Expected is ( {urn:ietf:rfc:8794}extension ).
ebml_matroska.xml fails to validate
```