### PR TITLE
tags: only allow latin capital letters in assigned tag names

### DIFF
--- a/cellar-tags/tagging.md
+++ b/cellar-tags/tagging.md
@@ -74,13 +74,26 @@ which tag has the desired meaning so that other apps could understand the same m
 
 ### TagName Formatting
 
-Assigned `TagName` values **MUST** consist of UTF-8 capital letters, numbers and the underscore character '_'.
+Assigned `TagName` values **MUST** consist of latin capital letters, numbers and the underscore character '_'.
 
 Assigned `TagName` values **MUST NOT** contain any space.
 
 Assigned `TagName` values **MUST NOT** start with the underscore character '_'; see (#why-assigned-tags-matter).
 
 It is **RECOMMENDED** that tag names start with the underscore character '_' for unassigned tags that are not meant to be added to the list of assigned tags.
+
+The syntax of assigned `TagName` values is defined using this Augmented Backus-Naur Form (ABNF) [@!RFC5234] notation:
+
+```abnf
+TagName                = FirstCharacter [Character]
+
+FirstCharacter         = CapitalLetter / DIGIT
+Character              = CapitalLetter / DIGIT / Underscore
+
+CapitalLetter          = %x41-5A  ; "A" to "Z"
+Underscore             = %x5F     ; "_"
+```
+
 
 ### TagString Formatting
 

--- a/cellar-tags/tags_iana.md
+++ b/cellar-tags/tags_iana.md
@@ -13,7 +13,7 @@ an optional Reference to a document describing the Element ID.
 The Name corresponds to the value stored in the `TagName` element.
 A Tag Name **MUST** only be found once in the IANA registry.
 Two Tag Names **MUST NOT** have the same semantic meaning.
-The Name is written in all UTF-8 capital letters, numbers and the underscore character '_'
+The Name is written in all latin capital letters, numbers and the underscore character '_'
 as defined in (#tag-formatting). The Name **MUST NOT** start with the underscore character '_'.
 
 The Type corresponds to which element will be stored the tag value.


### PR DESCRIPTION
The guidance for tag names has always been that it should be in capital letters [^1]. But that's a bit vague for non latin languages. Even for some latin based languages, accented letters could be in capital as well...

Given there is no proper technical way to describe this, and since all existing tags are in ASCII-US/latin capital letters (and incidentally all in English), we restrict the usable letters to the A-Z range.

Private tags can use whatever UTF-8 characters they want.

We also add an ABNF description to avoid any confusion that may be found in the text.

[^1]: https://web.archive.org/web/20071011065933/http://matroska.org/technical/specs/tagging/index.html