### PR TITLE
codec: make the VP8 reference informative

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -447,7 +447,7 @@ Codec ID: V_VP8
 
 Codec Name: VP8 Codec format
 
-Description: VP8 is an open and royalty free video compression format developed by Google and created by On2 Technologies as a successor to VP7. [@!RFC6386]
+Description: VP8 is an open and royalty free video compression format developed by Google and created by On2 Technologies as a successor to VP7. [@?RFC6386]
 
 Codec BlockAdditions: A single-channel encoding of an alpha channel **MAY** be stored in `BlockAdditions`. The `BlockAddID` of the `BlockMore` containing these data **MUST** be 1.
 


### PR DESCRIPTION
We don't use any special information from that document.