### PR TITLE
Remove normative text from IANA considerations

### DIFF
--- a/cellar-tags/rfc_backmatter_tags.md
+++ b/cellar-tags/rfc_backmatter_tags.md
@@ -7,9 +7,10 @@ description is clear and fits the purpose of this registry.
 
 Moreover, criteria for `binary` tags include ensuring the data in the `TagBinary` element
 are defined in a specification.
-When possible, i.e., the binary format is not already in use elsewhere, the
-data should not start with the size of the data to follow, as this size is already
+When possible, i.e., the binary format is not already in use elsewhere, it is **RECOMMENDED** that the
+data not start with the size of the data to follow, as this size is already
 part of the `TagBinary` element.
+The content of the binary data **MUST NOT** be a single UTF-8 string, in which case the tag should be `TagString`.
 
 Criteria for `nested` tags include ensuring that the tag consists of one or more
 child `SimpleTag` elements to describe the metadata corresponding to that tag.

--- a/cellar-tags/tags_iana.md
+++ b/cellar-tags/tags_iana.md
@@ -24,8 +24,6 @@ Matroska Tag Names for UTF-8 data are to be allocated according to the "First Co
 * `binary`: the value of the Tag is stored in `TagBinary`,
 
 Matroska Tag Names for binary data are to be allocated according to the "Specification Required" policy [@!RFC8126].
-The content of the binary data **MUST NOT** be a single UTF-8 string, in which case the type should be `UTF-8`.
-It is **RECOMMENDED** to not include the size of the binary data at the start of the data as the size is already handled by the element itself.
 
 * `nested`: the tag doesn't contain a value, i.e., neither a `TagBinary` nor a `TagString` child element, only `SimpleTag` child elements inside.
 


### PR DESCRIPTION
There's one left with the underscore but it's already part of the rules defined in 3.2.1.

cc @boucadair @SpencerDawkins 