### PR TITLE
Add `SampleAspectRatioNum`/`SampleAspectRatioDen` elements

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -648,6 +648,12 @@ The format depends on the `ChapProcessCodecID` used; see (#chapprocesscodecid-el
     <extension type="stream copy" keep="1"/>
     <extension type="webmproject.org" webm="1"/>
   </element>
+  <element name="SampleAspectRatioNum" path="\Segment\Tracks\TrackEntry\Video\SampleAspectRationNum" id="0x54AC" type="uinteger" minver="5" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Numerator of the video's sample aspect ratio. If `SampleAspectRatioNum` and `SampleAspectRatioDen` are present in a `TrackEntry`, the `DisplayWidth`, `DisplayHeight`, and `DisplayUnit` (if present) of the same `TrackEntry` are purely informative. Setting `SampleAspectRatioNum` and `SampleAspectRatioDen` is equivalent to a legacy `DisplayWidth` computed as `DisplayHeight` * (`PixelWidth` - `PixelCropLeft` - `PixelCropRight`) / (`PixelHeight` - `PixelCropTop` - `PixelCropBottom`) * `SampleAspectRatioNum` / `SampleAspectRatioDen`.</documentation>
+  </element>
+  <element name="SampleAspectRatioDen" path="\Segment\Tracks\TrackEntry\Video\SampleAspectRationDen" id="0x54AD" type="uinteger" minver="5" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Denominator of the video's sample aspect ratio. If `SampleAspectRatioNum` and `SampleAspectRatioDen` are present in a `TrackEntry`, the `DisplayWidth`, `DisplayHeight`, and `DisplayUnit` (if present) of the same `TrackEntry` are purely informative. Setting `SampleAspectRatioNum` and `SampleAspectRatioDen` is equivalent to a legacy `DisplayWidth` computed as `DisplayHeight` * (`PixelWidth` - `PixelCropLeft` - `PixelCropRight`) / (`PixelHeight` - `PixelCropTop` - `PixelCropBottom`) * `SampleAspectRatioNum` / `SampleAspectRatioDen`.</documentation>
+  </element>
   <element name="DisplayWidth" path="\Segment\Tracks\TrackEntry\Video\DisplayWidth" id="0x54B0" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
     <implementation_note note_attribute="default">If the DisplayUnit of the same `TrackEntry` is 0, then the default value for `DisplayWidth` is equal to `PixelWidth` - `PixelCropLeft` - `PixelCropRight`; else, there is no default value.</implementation_note>


### PR DESCRIPTION
Currently, Matroska allows a video's sample aspect ratio to be set via the display aspect ratio through the `DisplayWidth`/`DisplayHeight` elements.

However, these elements are currently specified to encode the display aspect ratio *after* applying cropping. This creates inconsistencies with players that do not read the `PixelCrop` elements and, in theory, makes it impossible for Matroska writers to create files that display with the correct aspect ratio both in players that respect cropping and in players that do not.

Moreover, many existing files do not actually follow this convention that the display aspect ratio apply to the cropped video, and instead store the display aspect ratio of the uncropped video. In particular, MKVToolNix stores the `DisplayWidth`/`DisplayHeight` in this format.

In order to be able to resolve these discrepancies in the future without changing existing behavior, this commit adds explicit `SampleAspectRatio{Num,Den}` elements, which specify the sample aspect ratio rather than the display aspect ratio. This has the advantage of being independent of any cropping and is also consistent with the way the sample/display aspect ratios are stored in video coding formats like H.264 (see: ITU-T H.273, section 8.6 "Sample aspect ratio indicator"). In cases where the `DisplayWidth`/`DisplayHeight` and the `SampleAspectRatioNum`/`SampleAspectRatioDen` elements are both present and might conflict, it is clearly specified in what way the sample aspect ratio elements take precedence. Matroska writers can write both kinds of elements without risking conflicts.

Refer to the following links for previous discussion about these issues.

See: https://codeberg.org/mbunkus/mkvtoolnix/issues/2389
See: mpv-player/mpv#13446

---

This change is a second, different approach to solving the problem brought up in #947. I am, among other reasons, opening it to hopefully create more discussion on this issue: I'm not overly attached to this *specific* solution and would be equally happy if #947 was applied instead of this.

The advantages of this solution over #947 are:
- It adds new elements and thus does not change any existing behavior, hence not breaking backwards compatibility
   - However: As argued in #947 it's not clear how much backwards compatibility #947 would *actually* break since most files in the wild do not follow the current spec and follow what #947 proposes instead. 
- It moves to storing the sample aspect ratio as a sample aspect ratio, which is more consistent with video coding formats like H.264 and is independent of any cropping.

The disadvantages of this solution over #947 are:
- Due to adding a new element, it requires Matroska v5
- It does not fix any of the *existing* spec-noncompliant files in the wild and could instead only be applied to new files.

---

Making `SampleAspectRatio{Num,Den}` completely "disable" (i.e. render informative) the `Display{Width,Height}` was chosen because even with added `SampleAspectRatio{Num,Den}` elements there would still be no way to determine whether an existing file's `Display{Width,Height}` are meant in the spec-compliant sense or in the spec-noncompliant-but-established sense.
An alternative would be *enforcing* that `DisplayWidth` be automatically derived as `DisplayHeight` * (`PixelWidth` - `PixelCropLeft` - `PixelCropRight`) / (`PixelHeight` - `PixelCropTop` - `PixelCropBottom`) * `SampleAspectRatioNum` / `SampleAspectRatioDen` (and not be purely informative), overriding an existing `DisplayWidth`  in the file if present. This would work for spec-compliant files, but would still display spec-noncompliant files with (the correct display aspect ratio but) incorrect display dimensions in spec-compliant players (Though players that currently ignore the spec and follow #947's proposal instead could opt to also adopt equivalent behavior here).
Hence, completely disabling `Display{Width,Height}` when `SampleAspectRatio{Num,Den}` are present seems like the simpler choice, but I'm happy to change it if there are disagreements.