### PR TITLE
codec: replace ISO.13818-2 with ITU H.262

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -256,7 +256,7 @@ Codec ID: V_MPEG2
 
 Codec Name: MPEG 2
 
-Description: Frames correspond to a Video Sequence as defined in [@!ISO.13818-2].
+Description: Frames correspond to a Video Sequence as defined in [@!ITU-T.H.262].
 
 Initialization: none
 

--- a/cellar-codec/rfc_backmatter_codec.md
+++ b/cellar-codec/rfc_backmatter_codec.md
@@ -215,17 +215,6 @@
   <seriesInfo name="ISO" value="11172-2:1993" />
 </reference>
 
-<reference anchor="ISO.13818-2">
-  <front>
-    <title>Information technology - Generic coding of moving pictures and associated audio information - Part 2: Video</title>
-    <author>
-      <organization>International Organization for Standardization</organization>
-    </author>
-    <date month="October" year="2013"/>
-  </front>
-  <seriesInfo name="ISO" value="13818-2:2013" />
-</reference>
-
 <reference anchor="ISO.14496-2">
   <front>
     <title>Information technology - Coding of audio-visual objects - Part 2: Visual</title>
@@ -268,6 +257,17 @@
     <date month="February" year="2000"/>
   </front>
   <seriesInfo name="ITU-T Recommendation" value="T.35" />
+</reference>
+
+<reference anchor="ITU-T.H.262" target="https://www.itu.int/rec/T-REC-H.262/en">
+  <front>
+    <title>Procedure for the allocation of ITU-T defined codes for non-standard facilities</title>
+    <author>
+      <organization>ITU-T</organization>
+    </author>
+    <date month="July" year="1995"/>
+  </front>
+  <seriesInfo name="ITU-T Recommendation" value="H.262" />
 </reference>
 
 <reference anchor="JPEG" target="https://www.w3.org/Graphics/JPEG/itu-t81.pdf">


### PR DESCRIPTION
They are supposed to be the same:
". The text of ITU-T Recommendation H.262 was approved on 10th of July 1995. The identical text is also published as ISO/IEC International Standard 13818-2."

And the old 1995 version is available for free.