### PR TITLE
codec: simplify BlockAddIDName for BlockAddIDType 0

### DIFF
--- a/cellar-codec/codec_iana.md
+++ b/cellar-codec/codec_iana.md
@@ -122,7 +122,7 @@ The Change Controller for the initial entries is the IETF.
 
 BlockAddIDType | BlockAddIDName            | Reference
 --------:|:--------------------------|:------------------------------
-0 | Use BlockAddIDValue | This document, (#use-blockaddidvalue)
+0 | BlockAddIDValue | This document, (#use-blockaddidvalue)
 1 | Opaque data | This document, (#opaque-data)
 4 | ITU T.35 metadata | This document, (#itu-t-35-metadata)
 121 | SMPTE ST 12-1 timecode | This document, (#smpte-st-12-1-timecode)

--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -1189,7 +1189,7 @@ An optional description for the encoding. This value is only intended for human 
 
 Block type identifier: 0
 
-Block type name: "Use BlockAddIDValue"
+Block type name: "BlockAddIDValue"
 
 Description: This value indicates that the actual type is stored in `BlockAddIDValue` instead.
 This value is used when it is important to have a strong compatibility


### PR DESCRIPTION
It's a user readable text and doesn't seem to be used in the wild.