### PR TITLE
codec: always express Block Type identifiers in hexadecimal

### DIFF
--- a/cellar-codec/block_additional_mappings_intro.md
+++ b/cellar-codec/block_additional_mappings_intro.md
@@ -49,7 +49,7 @@ The following XML depicts a use of a `Block Additional Mapping` to associate a t
         <BlockAddIDValue>2</BlockAddIDValue><!--arbitrary value
           used in BlockAddID-->
         <BlockAddIDName>timecode</BlockAddIDName>
-        <BlockAddIDType>121</BlockAddIDType>
+        <BlockAddIDType>0x79</BlockAddIDType>
       </BlockAdditionMapping>
       <CodecID>V_FFV1</CodecID>
       <Video>

--- a/cellar-codec/codec_iana.md
+++ b/cellar-codec/codec_iana.md
@@ -123,10 +123,10 @@ The Change Controller for the initial entries is the IETF.
 
 BlockAddIDType | BlockAddIDName            | Reference
 --------:|:--------------------------|:------------------------------
-0 | BlockAddIDValue | This document, (#use-blockaddidvalue)
-1 | Opaque data | This document, (#opaque-data)
-4 | ITU T.35 metadata | This document, (#itu-t-35-metadata)
-121 | SMPTE ST 12-1 timecode | This document, (#smpte-st-12-1-timecode)
+0x00 | BlockAddIDValue | This document, (#use-blockaddidvalue)
+0x01 | Opaque data | This document, (#opaque-data)
+0x04 | ITU T.35 metadata | This document, (#itu-t-35-metadata)
+0x79 | SMPTE ST 12-1 timecode | This document, (#smpte-st-12-1-timecode)
 0x61766345 | Dolby Vision enhancement-layer AVC configuration | This document, (#avce)
 0x68766345 | Dolby Vision enhancement-layer HEVC configuration | This document, (#hvce)
 0x64766343 | Dolby Vision configuration dvcC | This document, (#dvcc)

--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -1184,6 +1184,7 @@ Support for a Block Addition mapping is defined in Matroska with the following v
 
 Each `BlockAdditionMapping` supported in Matroska **MUST** have a unique `BlockAddIDType`.
 It **MUST** be defined for each Block Addition Mapping.
+The unsigned integers are expressed in hexadecimal as large values can be used.
 
 ### Block Type Name
 
@@ -1198,7 +1199,7 @@ An optional description for the encoding. This value is only intended for human 
 
 ### Use BlockAddIDValue
 
-Block type identifier: 0
+Block type identifier: 0x00
 
 Block type name: "BlockAddIDValue"
 
@@ -1209,7 +1210,7 @@ with an unknown `BlockAddIDValue`, and **SHOULD NOT** be used if it is possible 
 
 ### Opaque Data
 
-Block type identifier: 1
+Block type identifier: 0x01
 
 Block type name: "Opaque data"
 
@@ -1219,7 +1220,7 @@ The usage of these `BlockAdditional` data is defined in the "Codec BlockAddition
 
 ### ITU T.35 Metadata
 
-Block type identifier: 4
+Block type identifier: 0x04
 
 Block type name: "ITU T.35 metadata"
 
@@ -1230,7 +1231,7 @@ HDR10+ dynamic metadata can be stored as ITU T.35 terminal codes as defined in T
 
 ### SMPTE ST 12-1 Timecode
 
-Block type identifier: 121
+Block type identifier: 0x79
 
 Block type name: "SMPTE ST 12-1 timecode"
 


### PR DESCRIPTION
So we don't mix decimals and hexadecimals. (from IANA review).