### PR TITLE
codec: allow more than one BlockAdditionMapping with T.35 data

### DIFF
--- a/cellar-codec/block_additional_mappings_intro.md
+++ b/cellar-codec/block_additional_mappings_intro.md
@@ -138,12 +138,13 @@ When multiple T.35 `BlockAdditionMapping` are used, they **MUST** include a `Blo
 containing the first bytes of the [@?ITU-T.35] header: the country code, the optional country code extension,
 the terminal provider code, and the terminal provider oriented code.
 
-`BlockAddIDValue` **SHOULD** be 4 when only one T.35 `BlockAdditionMapping` is used.
-When multiple T.35 `BlockAdditionMapping` are used, one of them **SHOULD** use a `BlockAddIDValue` 4,
-preferably if it contains HDR10+ metadata, for compatibility with older systems which assume a `BlockAddIDValue`
-of 4 means the data are HDR10+ metadata and ignore the `BlockAddIDType`.
+HDR10+ dynamic metadata [@?SMPTE.ST2094-40] can be stored with ITU T.35 terminal codes as defined in defined in [@?CTA.861-4].
+The country code is 0xB5, the terminal provider code is 0x00 0x3C and the terminal provider oriented code is 0x00 0x01.
 
-HDR10+ dynamic metadata can be stored as ITU T.35 terminal codes as defined in Table 8 of [@?CTA.861-4].
+When multiple T.35 `BlockAdditionMapping` are used, one of them **SHOULD** use a `BlockAddIDValue` value of 4,
+preferably if it contains HDR10+ dynamic metadata, for compatibility with older systems
+which assume a `BlockAddIDValue` value of 4 means the data are HDR10+ dynamic metadata and ignore the `BlockAddIDType`.
+It is also **RECOMMENDED** to use a value of 4 for `BlockAddIDValue` when only one T.35 `BlockAdditionMapping` is used.
 
 ### SMPTE ST 12-1 Timecode
 

--- a/cellar-codec/block_additional_mappings_intro.md
+++ b/cellar-codec/block_additional_mappings_intro.md
@@ -132,7 +132,16 @@ Block type identifier: 0x04
 Block type name: "ITU T.35 metadata"
 
 Description: the `BlockAdditional` data is interpreted as ITU T.35 metadata, as defined by [@?ITU-T.35]
-terminal codes. `BlockAddIDValue` **MUST** be 4.
+terminal codes.
+
+When multiple T.35 `BlockAdditionMapping` are used, they **MUST** include a `BlockAddIDExtraData` element
+containing the first bytes of the [@?ITU-T.35] header: the country code, the optional country code extension,
+the terminal provider code, and the terminal provider oriented code.
+
+`BlockAddIDValue` **SHOULD** be 4 when only one T.35 `BlockAdditionMapping` is used.
+When multiple T.35 `BlockAdditionMapping` are used, one of them **SHOULD** use a `BlockAddIDValue` 4,
+preferably if it contains HDR10+ metadata, for compatibility with older systems which assume a `BlockAddIDValue`
+of 4 means the data are HDR10+ metadata and ignore the `BlockAddIDType`.
 
 HDR10+ dynamic metadata can be stored as ITU T.35 terminal codes as defined in Table 8 of [@?CTA.861-4].
 

--- a/cellar-codec/rfc_backmatter_codec.md
+++ b/cellar-codec/rfc_backmatter_codec.md
@@ -351,6 +351,16 @@
   <seriesInfo name="ST" value="12-1:2014, DOI 10.5594/SMPTE.ST12-1.2014" />
 </reference>
 
+<reference anchor="SMPTE.ST2094-40" target="https://pub.smpte.org/doc/st2094-40/20200409-pub/">
+  <front>
+    <title>Dynamic Metadata for Color Volume Transform</title>
+    <author>
+      <organization>SMPTE</organization>
+    </author>
+    <date day="9" month="April" year="2020" />
+  </front>
+</reference>
+
 <reference anchor="WAVEFORMATEX" target="https://docs.microsoft.com/en-us/windows/win32/api/mmeapi/ns-mmeapi-waveformatex">
   <front>
     <title>WAVEFORMATEX structure</title>


### PR DESCRIPTION
T.35 can contain a lot of different types of data. At the container level we only know it's T.35 data. But given the format of the data, multiple T.35
can't be grouped inside of a single BlockAdditional element.

There is a rule saying that the BlockAddIDValue MUST be 4, which forbids the use of multiple  BlockAdditionMapping for different types of T.35 data.

We now allow more T.35 mapping by relaxing this rule for when only one T.35 BlockAdditionMapping is used.
And when multiple ones, one of them should use a BlockAddIDValue of 4, especially if it contains HDR10+ metadata, to maximize backward compatibility.