### PR TITLE
codec: add a reference to RFC9559 for xiph lacing

### DIFF
--- a/cellar-codec/codec_specs.md
+++ b/cellar-codec/codec_specs.md
@@ -425,7 +425,8 @@ Initialization: The `CodecPrivate` contains the first three Theora packets in or
 
 * Byte 1: number of distinct packets `#p` minus one inside the `CodecPrivate` block. This **MUST** be "2" for current (as of 2016-07-08) Theora headers.
 
-* Bytes 2..n: lengths of the first `#p` packets, coded in Xiph-style lacing. The length of the last packet is the length of the `CodecPrivate` block minus the lengths coded in these bytes minus one.
+* Bytes 2..n: lengths of the first `#p` packets, coded in Xiph-style lacing as defined in [@!RFC9559, section 10.3.2].
+  The length of the last packet is the length of the `CodecPrivate` block minus the lengths coded in these bytes minus one.
 
 * Bytes n+1..: The Theora identification header, followed by the commend header followed by the codec setup header. Those are described in the [@!Theora].
 
@@ -944,13 +945,13 @@ Codec Name: Vorbis
 
 Initialization: The `CodecPrivate` contains the first three Vorbis packet in order. The lengths of the packets precedes them. The actual layout is:
 
-- Byte 1: number of distinct packets `#p` minus one inside the `CodecPrivate` block.
+* Byte 1: number of distinct packets `#p` minus one inside the `CodecPrivate` block.
   This **MUST** be "2" for current (as of 2016-07-08) Vorbis headers.
 
-- Bytes 2..n: lengths of the first `#p` packets, coded in Xiph-style lacing.
+* Bytes 2..n: lengths of the first `#p` packets, coded in Xiph-style lacing as defined in [@!RFC9559, section 10.3.2].
   The length of the last packet is the length of the `CodecPrivate` block minus the lengths coded in these bytes minus one.
 
-- Bytes n+1..: The "Identification Header" as defined in Section 4.2.2 of [@!VORBIS],
+* Bytes n+1..: The "Identification Header" as defined in Section 4.2.2 of [@!VORBIS],
   followed by the "Comment Header" as defined in Section 5 of [@!VORBIS],
   followed by the "Setup Header" as defined in Section 4.2.4 of [@!VORBIS].
 


### PR DESCRIPTION
This is the same reference used for Xiph lacing in RFC9559.